### PR TITLE
Add Wikipedia links to real Player/Coach/GM/Arena cards

### DIFF
--- a/src/components/ExternalLinksMenu.vue
+++ b/src/components/ExternalLinksMenu.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ExternalLink } from "lucide-vue-next";
+
+defineProps<{
+    links: { label: string; url: string }[];
+}>();
+</script>
+
+<template>
+    <span v-if="links.length" class="external-links-menu" @click.stop>
+        <a
+            v-for="link in links"
+            :key="link.url"
+            :href="link.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            :title="link.label"
+            class="external-link-icon"
+        >
+            <ExternalLink class="h-3.5 w-3.5" />
+        </a>
+    </span>
+</template>
+
+<style scoped>
+.external-links-menu {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.external-link-icon {
+    display: inline-flex;
+    color: hsl(var(--muted-foreground));
+    transition: color 0.15s ease;
+}
+
+.external-link-icon:hover {
+    color: hsl(var(--primary));
+}
+</style>

--- a/src/components/TeamBuilder/ArenaSection.vue
+++ b/src/components/TeamBuilder/ArenaSection.vue
@@ -3,7 +3,8 @@ import { ref, computed } from "vue";
 import { WESTERN_TEAMS, EASTERN_TEAMS } from "@/constants/constants";
 import type { Arena, SortDirection, DrawerSide } from "@/models/types";
 import arenaData from "@/assets/data/arenas.json";
-import { getRandomIndex } from "@/constants/utilities";
+import { getRandomIndex, getWikipediaUrl } from "@/constants/utilities";
+import ExternalLinksMenu from "@/components/ExternalLinksMenu.vue";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -169,7 +170,10 @@ const toggleFilter = (filter: string) => {
                     </Button>
                     <template v-else>
                         <img :src="teamArena.imgLink" height="100" width="150" class="rounded shadow-md" />
-                        <div class="arena-name">{{ teamArena.name }}</div>
+                        <div class="flex items-center gap-2 mt-3">
+                            <div class="arena-name !mt-0">{{ teamArena.name }}</div>
+                            <ExternalLinksMenu :links="[{ label: 'Wikipedia', url: getWikipediaUrl(teamArena.name) }]" />
+                        </div>
                     </template>
                 </div>
                 <Separator class="my-4" />

--- a/src/components/TeamBuilder/CoachSection.vue
+++ b/src/components/TeamBuilder/CoachSection.vue
@@ -332,7 +332,7 @@ const getCleanName = (coachName: string) => coachName.replace(/\*$/, '').trim();
                                 />
                                 <ExternalLinksMenu
                                     v-if="!teamCoach.isCustom"
-                                    :links="[{ label: 'Wikipedia', url: getWikipediaUrl(teamCoach.name ?? '') }]"
+                                    :links="[{ label: 'Wikipedia', url: getWikipediaUrl(getCleanName(teamCoach.name ?? '')) }]"
                                 />
                             </div>
                         </template>

--- a/src/components/TeamBuilder/CoachSection.vue
+++ b/src/components/TeamBuilder/CoachSection.vue
@@ -2,7 +2,8 @@
 import { ref, computed } from 'vue';
 import type { Coach, SortDirection, DrawerSide } from '@/models/types';
 import coachesData from '@/assets/data/coaches.json';
-import { getRandomIndex, roundValueToNPlaces } from '@/constants/utilities';
+import { getRandomIndex, roundValueToNPlaces, getWikipediaUrl } from '@/constants/utilities';
+import ExternalLinksMenu from '@/components/ExternalLinksMenu.vue';
 import { useCustomCoaches } from '@/composables/useCustomCoaches';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -328,6 +329,10 @@ const getCleanName = (coachName: string) => coachName.replace(/\*$/, '').trim();
                                     v-if="isHallOfFamer(teamCoach.name ?? '')"
                                     class="h-4 w-4 text-yellow-500 fill-yellow-500 self-center"
                                     title="Hall of Fame"
+                                />
+                                <ExternalLinksMenu
+                                    v-if="!teamCoach.isCustom"
+                                    :links="[{ label: 'Wikipedia', url: getWikipediaUrl(teamCoach.name ?? '') }]"
                                 />
                             </div>
                         </template>

--- a/src/components/TeamBuilder/GMSection.vue
+++ b/src/components/TeamBuilder/GMSection.vue
@@ -2,7 +2,8 @@
 import { ref, computed } from "vue";
 import type { GM, SortDirection, DrawerSide } from "@/models/types";
 import gmData from "@/assets/data/execs.json";
-import { getRandomIndex } from "@/constants/utilities";
+import { getRandomIndex, getWikipediaUrl } from "@/constants/utilities";
+import ExternalLinksMenu from "@/components/ExternalLinksMenu.vue";
 import { useCustomGMs } from "@/composables/useCustomGMs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -233,7 +234,13 @@ const handleDeleteGM = async () => {
                     </Button>
                     <template v-else>
                         <UserCircle2 class="h-16 w-16 text-muted-foreground" />
-                        <div class="gm-name">{{ teamGM.name }}</div>
+                        <div class="flex items-center gap-2 mt-3">
+                            <div class="gm-name !mt-0">{{ teamGM.name }}</div>
+                            <ExternalLinksMenu
+                                v-if="!teamGM.isCustom"
+                                :links="[{ label: 'Wikipedia', url: getWikipediaUrl(teamGM.name) }]"
+                            />
+                        </div>
                     </template>
                 </div>
                 <Separator class="my-4" />

--- a/src/components/TeamBuilder/PlayerSlot.vue
+++ b/src/components/TeamBuilder/PlayerSlot.vue
@@ -111,7 +111,7 @@ const averageStats = computed(() => {
                 {{ playerInitials }}
               </AvatarFallback>
             </Avatar>
-            <div class="flex items-center gap-1.5">
+            <div class="flex items-center justify-center gap-1.5 w-full">
               <h4 class="player-name">
                 {{ player?.fullName }}
               </h4>
@@ -284,6 +284,7 @@ const averageStats = computed(() => {
   text-align: center;
   line-height: 1.3;
   margin: 0.25rem 0 0;
+  min-width: 0;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/TeamBuilder/PlayerSlot.vue
+++ b/src/components/TeamBuilder/PlayerSlot.vue
@@ -6,6 +6,8 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
 import { X, UserPlus, Plus, BarChart3, ArrowLeftRight, GitCompareArrows } from 'lucide-vue-next';
+import { getWikipediaUrl } from '@/constants/utilities';
+import ExternalLinksMenu from '@/components/ExternalLinksMenu.vue';
 
 interface Player {
   id: number;
@@ -18,6 +20,7 @@ interface Player {
     abbreviation: string;
   };
   playerStats?: any[];
+  isCustom?: boolean;
 }
 
 interface Props {
@@ -108,9 +111,15 @@ const averageStats = computed(() => {
                 {{ playerInitials }}
               </AvatarFallback>
             </Avatar>
-            <h4 class="player-name">
-              {{ player?.fullName }}
-            </h4>
+            <div class="flex items-center gap-1.5">
+              <h4 class="player-name">
+                {{ player?.fullName }}
+              </h4>
+              <ExternalLinksMenu
+                v-if="player && !player.isCustom"
+                :links="[{ label: 'Wikipedia', url: getWikipediaUrl(player.fullName) }]"
+              />
+            </div>
             <div class="player-meta">
               <span v-if="player?.team?.abbreviation" class="meta-item">{{ player.team.abbreviation }}</span>
               <span v-if="player?.team?.abbreviation" class="meta-divider">•</span>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -147,6 +147,7 @@ export const ESPN_TEAM_URL =
 */
 
 const BBALL_REF_PREFIX = "https://www.basketball-reference.com";
+export const WIKIPEDIA_PREFIX = "https://en.wikipedia.org/wiki/";
 
 const COACH_COLUMNS = ["Coach", "From", "To", "Birth Date", "College"];
 

--- a/src/constants/utilities.ts
+++ b/src/constants/utilities.ts
@@ -1,3 +1,5 @@
+import { WIKIPEDIA_PREFIX } from "./constants";
+
 export const range = (start: number, stop: number, step: number = 1) => {
     return Array.from(
         { length: (stop - start) / step + 1 },
@@ -11,4 +13,10 @@ export const roundValueToNPlaces = (value: any, n: number = 1) => {
 
 export const getRandomIndex = (data: any[]): number => {
     return Math.floor(Math.random() * data.length);
+};
+
+export const getWikipediaUrl = (name: string): string => {
+    const cleanName = name.replace(/\*$/, "").trim();
+    const slug = encodeURIComponent(cleanName.replace(/\s+/g, "_"));
+    return `${WIKIPEDIA_PREFIX}${slug}`;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,26 @@
 {
     // https://github.com/vuejs/tsconfig/blob/main/tsconfig.json
-    "extends": "@vue/tsconfig/tsconfig.web.json",
+    // Not extending @vue/tsconfig/tsconfig.web.json: that package is pinned to
+    // the 0.1.x line (package.json "@vue/tsconfig": "^0.1.3"), whose base
+    // tsconfig sets `importsNotUsedAsValues`/`preserveValueImports`. TypeScript
+    // extends-merges compilerOptions per key with no way to unset an inherited
+    // key, and TS 5.6+ removed those two options outright (TS5102), so any
+    // fresh `npm install` (typescript resolves to 5.9.3 per package-lock.json)
+    // fails type-check before this project's own code is even considered. The
+    // handful of settings actually needed from that base are inlined below,
+    // with `verbatimModuleSyntax` replacing the two removed options as
+    // TypeScript's own error message recommends.
     "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
     "compilerOptions": {
-        // @vue/tsconfig@0.1.3 sets `importsNotUsedAsValues`/`preserveValueImports`,
-        // which TS 5.5 deprecated. They are no-ops here; silence until the base
-        // config is upgraded (which would enable stricter verbatimModuleSyntax).
-        "ignoreDeprecations": "5.0",
         "module": "ESNext",
+        "moduleResolution": "Node",
+        "resolveJsonModule": true,
+        "useDefineForClassFields": true,
+        "isolatedModules": true,
+        "verbatimModuleSyntax": true,
         "target": "ESNext",
         "lib": ["ESNext", "DOM", "DOM.Iterable"],
+        "types": [],
         // `"noImplicitThis": true` is part of `strict`
         // Added again here in case some users decide to disable `strict`.
         // This enables stricter inference for data properties on `this`.


### PR DESCRIPTION
## Summary
- Adds a Wikipedia link icon to real (non-custom) Player, Coach, GM, and Arena cards in Team Builder — `getWikipediaUrl` helper + shared `ExternalLinksMenu.vue` component, wired into the 4 existing card components.
- Scope deliberately excludes Basketball-Reference and Team links (no browsable team list exists yet to attach them to) and any new routes/entity detail pages — see follow-up roadmap notes below.
- Includes a prerequisite fix: `tsconfig.json` extended a stale `@vue/tsconfig` base that set two TypeScript options removed in TS 5.6+, which broke `type-check` on any clean `npm install` (unrelated to this feature, but blocked verifying it).

## Test plan
- [x] `npm run type-check` passes cleanly
- [x] `npm run lint` — no new issues (61 pre-existing issues in untouched files)
- [x] Each of the 6 implementation tasks independently reviewed (spec compliance + code quality), 2 review-driven fixes applied and re-verified
- [x] Final whole-branch review passed after fixing a long-player-name overflow regression
- [ ] Manual click-through in a running browser (Team Builder: Arena/Coach/GM/Player, both real and custom) — not performed by me, no Chrome/Chromium available to my browser-automation tooling in this environment. Please verify before merging: icon renders only on real entities, links open the correct Wikipedia page in a new tab, and clicking the icon doesn't trigger the parent card's own click behavior (drawer open / card flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)