### PR TITLE
feat(team-builder): add drag and drop roster reordering

### DIFF
--- a/src/components/TeamBuilder/PlayerSlot.vue
+++ b/src/components/TeamBuilder/PlayerSlot.vue
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
-import { X, UserPlus, Plus, BarChart3, ArrowLeftRight, GitCompareArrows } from 'lucide-vue-next';
+import { X, UserPlus, Plus, BarChart3, ArrowLeftRight, GitCompareArrows, GripVertical } from 'lucide-vue-next';
 import { getWikipediaUrl } from '@/constants/utilities';
 import ExternalLinksMenu from '@/components/ExternalLinksMenu.vue';
 import { ratingTier, ratingSourceLabel } from '@/constants/ratings';
@@ -33,12 +33,21 @@ interface Props {
   player?: Player | null;
   position?: string;
   isFlipped?: boolean;
+  isDragging?: boolean;
+  isDropTarget?: boolean;
+  isPickedUp?: boolean;
+  /** True while some card - anywhere in the roster - is held by the keyboard flow. */
+  isPickupActive?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   player: null,
   position: undefined,
   isFlipped: false,
+  isDragging: false,
+  isDropTarget: false,
+  isPickedUp: false,
+  isPickupActive: false,
 });
 
 const emit = defineEmits<{
@@ -47,9 +56,21 @@ const emit = defineEmits<{
   'flip': [index: number];
   'viewStats': [index: number];
   'compare': [index: number];
+  'dragStart': [index: number, event: DragEvent];
+  'dragEnd': [];
+  'dragOver': [index: number, event: DragEvent];
+  'dragLeave': [index: number];
+  'drop': [index: number, event: DragEvent];
+  'pickup': [index: number];
 }>();
 
 const hasPlayer = computed(() => !!props.player);
+const slotLabel = computed(() => props.position || `Slot ${props.slotIndex}`);
+const moveLabel = computed(() => {
+  if (props.isPickedUp) return `Put ${props.player?.fullName} back in ${slotLabel.value}`;
+  if (props.isPickupActive) return `Swap into ${slotLabel.value}`;
+  return `Move ${props.player?.fullName} from ${slotLabel.value}`;
+});
 const playerInitials = computed(() => {
   if (!props.player) return '?';
   return `${props.player.first_name[0]}${props.player.last_name[0]}`;
@@ -77,13 +98,38 @@ const averageStats = computed(() => {
 </script>
 
 <template>
-  <div class="player-card-wrapper">
+  <div
+    class="player-card-wrapper"
+    :class="{
+      'is-draggable': hasPlayer,
+      'is-dragging': isDragging,
+      'is-drop-target': isDropTarget,
+      'is-picked-up': isPickedUp,
+    }"
+    :draggable="hasPlayer"
+    @dragstart="emit('dragStart', slotIndex, $event)"
+    @dragend="emit('dragEnd')"
+    @dragover="emit('dragOver', slotIndex, $event)"
+    @dragleave="emit('dragLeave', slotIndex)"
+    @drop="emit('drop', slotIndex, $event)"
+  >
     <Card class="player-card">
       <CardHeader class="card-header">
         <div class="flex items-center justify-between w-full">
           <div class="flex items-center gap-2 min-w-0">
+            <Button
+              v-if="hasPlayer"
+              @click.stop="emit('pickup', slotIndex)"
+              variant="ghost"
+              size="icon"
+              class="drag-handle h-7 w-7 text-muted-foreground hover:text-foreground"
+              :aria-label="moveLabel"
+              :aria-pressed="isPickedUp"
+            >
+              <GripVertical class="w-4 h-4" />
+            </Button>
             <Badge variant="secondary" class="position-badge">
-              {{ position || `Slot ${slotIndex}` }}
+              {{ slotLabel }}
             </Badge>
             <span
               v-if="hasPlayer && displayRating !== null"
@@ -124,6 +170,19 @@ const averageStats = computed(() => {
             >
               <Plus class="w-4 h-4 mr-1" />
               Add Player
+            </Button>
+            <!-- Only reachable while a card is held by the keyboard flow -
+                 pointer users drop straight onto the card. -->
+            <Button
+              v-if="isPickupActive"
+              @click.stop="emit('pickup', slotIndex)"
+              variant="outline"
+              size="sm"
+              class="add-button"
+              :aria-label="`Move held player into ${slotLabel}`"
+            >
+              <GripVertical class="w-4 h-4 mr-1" />
+              Move here
             </Button>
           </div>
         </template>
@@ -215,6 +274,51 @@ const averageStats = computed(() => {
 .player-card-wrapper:hover {
   border-color: hsl(var(--primary));
   box-shadow: 0 0 0.5rem hsla(var(--primary), 0.3);
+}
+
+/* Drag & Drop states */
+.player-card-wrapper.is-draggable {
+  cursor: grab;
+}
+
+.player-card-wrapper.is-dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+/* The card the pointer is currently over - reads as "release here". */
+.player-card-wrapper.is-drop-target {
+  border-color: hsl(var(--primary));
+  border-style: dashed;
+  box-shadow: 0 0 0.75rem hsla(var(--primary), 0.5);
+  transform: scale(1.02);
+}
+
+/* The card held by the keyboard flow, which persists between keypresses. */
+.player-card-wrapper.is-picked-up {
+  border-style: dashed;
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0.75rem hsla(var(--primary), 0.5);
+}
+
+.drag-handle {
+  cursor: grab;
+  flex-shrink: 0;
+}
+
+.player-card-wrapper.is-dragging .drag-handle {
+  cursor: grabbing;
+}
+
+/* Drag feedback is a transform; honour reduced-motion by dropping it. */
+@media (prefers-reduced-motion: reduce) {
+  .player-card-wrapper {
+    transition: none;
+  }
+
+  .player-card-wrapper.is-drop-target {
+    transform: none;
+  }
 }
 
 .player-card {

--- a/src/components/TeamBuilder/RosterSection.vue
+++ b/src/components/TeamBuilder/RosterSection.vue
@@ -23,9 +23,18 @@ interface Player {
 interface Props {
   selectedPlayers: Map<number, Player>;
   cardsFlipped: Map<number, boolean>;
+  draggingSlot?: number | null;
+  dropTargetSlot?: number | null;
+  pickedUpSlot?: number | null;
+  liveMessage?: string;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  draggingSlot: null,
+  dropTargetSlot: null,
+  pickedUpSlot: null,
+  liveMessage: '',
+});
 
 const emit = defineEmits<{
   'addPlayer': [index: number];
@@ -33,6 +42,13 @@ const emit = defineEmits<{
   'flipCard': [index: number];
   'viewStats': [index: number];
   'compare': [index: number];
+  'dragStart': [index: number, event: DragEvent];
+  'dragEnd': [];
+  'dragOver': [index: number, event: DragEvent];
+  'dragLeave': [index: number];
+  'dropSlot': [index: number, event: DragEvent];
+  'pickup': [index: number];
+  'cancelPickup': [];
 }>();
 
 const POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C'];
@@ -62,10 +78,24 @@ const starterRating = computed(() =>
 const ratedStarterCount = computed(
   () => STARTER_INDICES.filter(i => ratingOf(i) !== undefined).length,
 );
+
+const isPickupActive = computed(() => props.pickedUpSlot !== null);
+
+// Escape cancels a keyboard pickup from anywhere in the roster, so it's bound
+// once here rather than on every slot.
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && isPickupActive.value) {
+    event.stopPropagation();
+    emit('cancelPickup');
+  }
+};
 </script>
 
 <template>
-  <div class="roster-section">
+  <div class="roster-section" @keydown="onKeydown">
+    <!-- Announces the keyboard move flow, which has no visible text of its own. -->
+    <div class="sr-only" role="status" aria-live="polite">{{ liveMessage }}</div>
+
     <!-- Starting Lineup Section -->
     <div class="lineup-section">
       <div class="section-header">
@@ -91,11 +121,21 @@ const ratedStarterCount = computed(
           :position="POSITIONS[posIndex]"
           :player="selectedPlayers.get(index)"
           :is-flipped="cardsFlipped.get(index)"
+          :is-dragging="draggingSlot === index"
+          :is-drop-target="dropTargetSlot === index"
+          :is-picked-up="pickedUpSlot === index"
+          :is-pickup-active="isPickupActive"
           @add="emit('addPlayer', $event)"
           @remove="emit('removePlayer', $event)"
           @flip="emit('flipCard', $event)"
           @view-stats="emit('viewStats', $event)"
           @compare="emit('compare', $event)"
+          @drag-start="(slot, event) => emit('dragStart', slot, event)"
+          @drag-end="emit('dragEnd')"
+          @drag-over="(slot, event) => emit('dragOver', slot, event)"
+          @drag-leave="emit('dragLeave', $event)"
+          @drop="(slot, event) => emit('dropSlot', slot, event)"
+          @pickup="emit('pickup', $event)"
         />
       </div>
     </div>
@@ -113,11 +153,21 @@ const ratedStarterCount = computed(
           :slot-index="index"
           :player="selectedPlayers.get(index)"
           :is-flipped="cardsFlipped.get(index)"
+          :is-dragging="draggingSlot === index"
+          :is-drop-target="dropTargetSlot === index"
+          :is-picked-up="pickedUpSlot === index"
+          :is-pickup-active="isPickupActive"
           @add="emit('addPlayer', $event)"
           @remove="emit('removePlayer', $event)"
           @flip="emit('flipCard', $event)"
           @view-stats="emit('viewStats', $event)"
           @compare="emit('compare', $event)"
+          @drag-start="(slot, event) => emit('dragStart', slot, event)"
+          @drag-end="emit('dragEnd')"
+          @drag-over="(slot, event) => emit('dragOver', slot, event)"
+          @drag-leave="emit('dragLeave', $event)"
+          @drop="(slot, event) => emit('dropSlot', slot, event)"
+          @pickup="emit('pickup', $event)"
         />
       </div>
     </div>

--- a/src/composables/useRosterDragDrop.ts
+++ b/src/composables/useRosterDragDrop.ts
@@ -1,0 +1,162 @@
+import { ref } from 'vue';
+
+/**
+ * Swap the values of two keys, treating "key absent" as a real value so that
+ * moving a player into an empty slot leaves the source slot empty rather than
+ * duplicating the entry.
+ */
+export const swapMapEntries = <K, V>(map: Map<K, V>, a: K, b: K): void => {
+    if (a === b) return;
+
+    const hasA = map.has(a);
+    const hasB = map.has(b);
+    const valueA = map.get(a);
+    const valueB = map.get(b);
+
+    if (hasB) map.set(a, valueB as V);
+    else map.delete(a);
+
+    if (hasA) map.set(b, valueA as V);
+    else map.delete(b);
+};
+
+/** Same idea for a Set: membership follows the card to its new slot. */
+export const swapSetMembers = <T>(set: Set<T>, a: T, b: T): void => {
+    if (a === b) return;
+
+    const hasA = set.has(a);
+    const hasB = set.has(b);
+
+    if (hasB) set.add(a);
+    else set.delete(a);
+
+    if (hasA) set.add(b);
+    else set.delete(b);
+};
+
+interface RosterDragDropOptions {
+    /** Performs the actual state swap. Only called for a valid, non-identical pair. */
+    onSwap: (from: number, to: number) => void;
+    /** True when the slot holds a player - empty slots can be dropped on but not dragged. */
+    isOccupied: (slot: number) => boolean;
+    /** Human-readable slot description used for the aria-live announcements. */
+    describeSlot: (slot: number) => string;
+}
+
+export function useRosterDragDrop(options: RosterDragDropOptions) {
+    const { onSwap, isOccupied, describeSlot } = options;
+
+    // The slot the pointer drag started from. This - not dataTransfer - is the
+    // source of truth, because getData() is unreadable during dragover.
+    const draggingSlot = ref<number | null>(null);
+    const dropTargetSlot = ref<number | null>(null);
+    // The slot "held" by the keyboard flow, which is a separate gesture from a
+    // pointer drag and can outlive any single event.
+    const pickedUpSlot = ref<number | null>(null);
+    const liveMessage = ref<string>('');
+
+    // Two empty slots trading places is a no-op, so don't bother the callback.
+    const applySwap = (from: number, to: number) => {
+        if (from === to) return false;
+        if (!isOccupied(from) && !isOccupied(to)) return false;
+        onSwap(from, to);
+        return true;
+    };
+
+    const startDrag = (slot: number, event: DragEvent) => {
+        if (!isOccupied(slot)) {
+            event.preventDefault();
+            return;
+        }
+
+        draggingSlot.value = slot;
+        pickedUpSlot.value = null;
+
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', String(slot));
+        }
+    };
+
+    const endDrag = () => {
+        draggingSlot.value = null;
+        dropTargetSlot.value = null;
+    };
+
+    const dragOverSlot = (slot: number, event: DragEvent) => {
+        if (draggingSlot.value === null || draggingSlot.value === slot) return;
+
+        // Without preventDefault the browser refuses the drop entirely.
+        event.preventDefault();
+        if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+        dropTargetSlot.value = slot;
+    };
+
+    // Guarded on identity because dragleave also fires when moving between a
+    // card's own children, which would otherwise clear a still-valid target.
+    const leaveSlot = (slot: number) => {
+        if (dropTargetSlot.value === slot) dropTargetSlot.value = null;
+    };
+
+    const dropOnSlot = (slot: number, event: DragEvent) => {
+        event.preventDefault();
+
+        const from = draggingSlot.value;
+        endDrag();
+
+        if (from === null) return;
+        if (applySwap(from, slot)) {
+            liveMessage.value = `Moved ${describeSlot(slot)}.`;
+        }
+    };
+
+    /**
+     * Keyboard equivalent of a drag: first press picks a card up, the next press
+     * on a different slot completes the swap, and a press on the same slot puts
+     * it back down.
+     */
+    const togglePickup = (slot: number) => {
+        const held = pickedUpSlot.value;
+
+        if (held === null) {
+            if (!isOccupied(slot)) return;
+            pickedUpSlot.value = slot;
+            liveMessage.value = `${describeSlot(slot)} picked up. Move to another slot and press Enter to swap, or press Escape to cancel.`;
+            return;
+        }
+
+        if (held === slot) {
+            pickedUpSlot.value = null;
+            liveMessage.value = `${describeSlot(slot)} put back.`;
+            return;
+        }
+
+        const target = describeSlot(slot);
+        const source = describeSlot(held);
+        pickedUpSlot.value = null;
+
+        if (applySwap(held, slot)) {
+            liveMessage.value = `Swapped ${source} with ${target}.`;
+        }
+    };
+
+    const cancelPickup = () => {
+        if (pickedUpSlot.value === null) return;
+        liveMessage.value = `${describeSlot(pickedUpSlot.value)} put back.`;
+        pickedUpSlot.value = null;
+    };
+
+    return {
+        draggingSlot,
+        dropTargetSlot,
+        pickedUpSlot,
+        liveMessage,
+        startDrag,
+        endDrag,
+        dragOverSlot,
+        leaveSlot,
+        dropOnSlot,
+        togglePickup,
+        cancelPickup,
+    };
+}

--- a/src/views/TeamBuilder.vue
+++ b/src/views/TeamBuilder.vue
@@ -11,6 +11,11 @@ import CoachSection from "@/components/TeamBuilder/CoachSection.vue";
 import ArenaSection from "@/components/TeamBuilder/ArenaSection.vue";
 import GMSection from "@/components/TeamBuilder/GMSection.vue";
 import PlayerComparison from "@/components/TeamBuilder/PlayerComparison.vue";
+import {
+    useRosterDragDrop,
+    swapMapEntries,
+    swapSetMembers,
+} from "@/composables/useRosterDragDrop";
 import { dataApi } from "@/network/api";
 import type { Team, DrawerSide, NBA2KRating } from "@/models/types";
 import type { GetPlayerStatsResponse } from "@/models/api";
@@ -122,6 +127,8 @@ const addPlayerFromDialog = async (player: any) => {
 
 const deletePlayer = (index: number) => {
     const player = selectedPlayersData.value.get(index);
+    // A held card that's just been removed has nothing left to drop.
+    if (pickedUpSlot.value === index) cancelPickup();
     selectedPlayersData.value.delete(index);
     cardsFlipped.value.delete(index);
     selectedPlayersForComparison.value.delete(index);
@@ -130,6 +137,49 @@ const deletePlayer = (index: number) => {
         toast.success(`Removed ${player.fullName} from team`);
     }
 };
+
+// Slots are fixed positions, not a list, so a drag is a swap: the two cards
+// trade places and nothing else in the roster shifts. Flip state and comparison
+// picks are keyed by slot as well, so they have to travel with the card or
+// they'd end up attached to whoever landed in that slot.
+const swapSlots = (from: number, to: number) => {
+    if (from === to) return;
+
+    const players = selectedPlayersData.value;
+    if (!players.has(from) && !players.has(to)) return;
+
+    swapMapEntries(players, from, to);
+    swapMapEntries(cardsFlipped.value, from, to);
+    swapSetMembers(selectedPlayersForComparison.value, from, to);
+};
+
+const slotLabel = (slot: number) =>
+    slot <= 5 ? ["PG", "SG", "SF", "PF", "C"][slot - 1] : `slot ${slot}`;
+
+const describeSlot = (slot: number) => {
+    const player = selectedPlayersData.value.get(slot);
+    return player
+        ? `${player.fullName} in ${slotLabel(slot)}`
+        : `empty ${slotLabel(slot)}`;
+};
+
+const {
+    draggingSlot,
+    dropTargetSlot,
+    pickedUpSlot,
+    liveMessage,
+    startDrag,
+    endDrag,
+    dragOverSlot,
+    leaveSlot,
+    dropOnSlot,
+    togglePickup,
+    cancelPickup,
+} = useRosterDragDrop({
+    onSwap: swapSlots,
+    isOccupied: (slot) => selectedPlayersData.value.has(slot),
+    describeSlot,
+});
 
 const flipCard = (n: number) => {
     const isFlipped = cardsFlipped.value.get(n);
@@ -185,6 +235,7 @@ watch(showPlayerComparison, (open) => {
 });
 
 const resetTeam = () => {
+    cancelPickup();
     selectedPlayersData.value.clear();
     cardsFlipped.value.clear();
     selectedPlayersForComparison.value.clear();
@@ -203,9 +254,11 @@ const resetTeam = () => {
 const saveTeam = () => {
     const uuid = crypto.randomUUID();
 
-    const players = Array.from(selectedPlayersData.value.values()).map(
-        (p) => p.fullName
-    );
+    // Sort by slot - Map iteration is insertion order, which would save a
+    // reordered roster in the order the players happened to be added.
+    const players = Array.from(selectedPlayersData.value.entries())
+        .sort(([a], [b]) => a - b)
+        .map(([, p]) => p.fullName);
 
     const newTeam: Team = {
         uuid,
@@ -250,11 +303,22 @@ const saveTeam = () => {
             <RosterSection
                 :selected-players="selectedPlayersData"
                 :cards-flipped="cardsFlipped"
+                :dragging-slot="draggingSlot"
+                :drop-target-slot="dropTargetSlot"
+                :picked-up-slot="pickedUpSlot"
+                :live-message="liveMessage"
                 @add-player="addPlayer"
                 @remove-player="deletePlayer"
                 @flip-card="flipCard"
                 @view-stats="viewPlayerStats"
                 @compare="togglePlayerInComparison"
+                @drag-start="startDrag"
+                @drag-end="endDrag"
+                @drag-over="dragOverSlot"
+                @drag-leave="leaveSlot"
+                @drop-slot="dropOnSlot"
+                @pickup="togglePickup"
+                @cancel-pickup="cancelPickup"
             />
 
             <!-- Team Staff Section -->

--- a/tests/components/RosterSection.test.ts
+++ b/tests/components/RosterSection.test.ts
@@ -4,16 +4,23 @@ import RosterSection from "@/components/TeamBuilder/RosterSection.vue";
 
 // Stub the PlayerSlot child so this test stays focused on RosterSection's own
 // counting logic rather than rendering the full slot tree.
-const mountRoster = (selected: Map<number, any>) =>
+const mountRoster = (selected: Map<number, any>, extraProps: object = {}) =>
     mount(RosterSection, {
         props: {
             selectedPlayers: selected,
             cardsFlipped: new Map<number, boolean>(),
+            ...extraProps,
         },
         global: {
             stubs: { PlayerSlot: true },
         },
     });
+
+// Slots render starters (1-5) then bench (6-15), so slot N is at index N-1.
+// The stub exposes props as DOM attributes, which is enough to assert that the
+// drag state lands on the right card.
+const slotAt = (wrapper: ReturnType<typeof mountRoster>, slot: number) =>
+    wrapper.findAll("player-slot-stub")[slot - 1];
 
 const player = (id: number) => ({
     id,
@@ -40,5 +47,63 @@ describe("RosterSection", () => {
         const wrapper = mountRoster(selected);
         const counts = wrapper.findAll(".starter-count").map((n) => n.text());
         expect(counts).toEqual(["2/5", "1/10"]);
+    });
+
+    it("renders all 15 slots across both sections", () => {
+        const wrapper = mountRoster(new Map());
+        expect(wrapper.findAll("player-slot-stub")).toHaveLength(15);
+    });
+
+    it("marks only the dragged, targeted and picked-up slots", () => {
+        const selected = new Map<number, any>([
+            [6, player(6)],
+            [7, player(7)],
+        ]);
+        const wrapper = mountRoster(selected, {
+            draggingSlot: 6,
+            dropTargetSlot: 7,
+            pickedUpSlot: 1,
+        });
+
+        expect(slotAt(wrapper, 6).attributes("isdragging")).toBe("true");
+        expect(slotAt(wrapper, 7).attributes("isdragging")).toBe("false");
+        expect(slotAt(wrapper, 7).attributes("isdroptarget")).toBe("true");
+        expect(slotAt(wrapper, 6).attributes("isdroptarget")).toBe("false");
+        expect(slotAt(wrapper, 1).attributes("ispickedup")).toBe("true");
+        expect(slotAt(wrapper, 6).attributes("ispickedup")).toBe("false");
+    });
+
+    it("tells every slot when a pickup is in progress", () => {
+        const wrapper = mountRoster(new Map([[6, player(6)]]), {
+            pickedUpSlot: 6,
+        });
+        expect(slotAt(wrapper, 9).attributes("ispickupactive")).toBe("true");
+    });
+
+    it("leaves the pickup flag off when nothing is held", () => {
+        const wrapper = mountRoster(new Map([[6, player(6)]]));
+        expect(slotAt(wrapper, 9).attributes("ispickupactive")).toBe("false");
+    });
+
+    it("announces the live message for the keyboard flow", () => {
+        const wrapper = mountRoster(new Map(), {
+            liveMessage: "Kevin Duckworth in slot 6 picked up.",
+        });
+        const live = wrapper.find('[aria-live="polite"]');
+        expect(live.text()).toBe("Kevin Duckworth in slot 6 picked up.");
+    });
+
+    it("emits cancelPickup on Escape while a card is held", async () => {
+        const wrapper = mountRoster(new Map([[6, player(6)]]), {
+            pickedUpSlot: 6,
+        });
+        await wrapper.find(".roster-section").trigger("keydown", { key: "Escape" });
+        expect(wrapper.emitted("cancelPickup")).toHaveLength(1);
+    });
+
+    it("ignores Escape when nothing is held", async () => {
+        const wrapper = mountRoster(new Map([[6, player(6)]]));
+        await wrapper.find(".roster-section").trigger("keydown", { key: "Escape" });
+        expect(wrapper.emitted("cancelPickup")).toBeUndefined();
     });
 });

--- a/tests/composables/useRosterDragDrop.test.ts
+++ b/tests/composables/useRosterDragDrop.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+    swapMapEntries,
+    swapSetMembers,
+    useRosterDragDrop,
+} from "@/composables/useRosterDragDrop";
+
+describe("swapMapEntries", () => {
+    it("swaps two occupied keys", () => {
+        const map = new Map([
+            [6, "Duckworth"],
+            [7, "Lawson"],
+        ]);
+        swapMapEntries(map, 6, 7);
+        expect(map.get(6)).toBe("Lawson");
+        expect(map.get(7)).toBe("Duckworth");
+    });
+
+    it("moves into an empty key without leaving the source behind", () => {
+        const map = new Map([[6, "Duckworth"]]);
+        swapMapEntries(map, 6, 9);
+        expect(map.has(6)).toBe(false);
+        expect(map.get(9)).toBe("Duckworth");
+    });
+
+    it("moves out of an empty key in the other direction", () => {
+        const map = new Map([[9, "Duckworth"]]);
+        swapMapEntries(map, 6, 9);
+        expect(map.get(6)).toBe("Duckworth");
+        expect(map.has(9)).toBe(false);
+    });
+
+    it("leaves the map untouched for identical keys", () => {
+        const map = new Map([[6, "Duckworth"]]);
+        swapMapEntries(map, 6, 6);
+        expect([...map.entries()]).toEqual([[6, "Duckworth"]]);
+    });
+
+    it("keeps falsy values instead of treating them as absent", () => {
+        const map = new Map([
+            [6, false],
+            [7, true],
+        ]);
+        swapMapEntries(map, 6, 7);
+        expect(map.get(6)).toBe(true);
+        expect(map.get(7)).toBe(false);
+    });
+});
+
+describe("swapSetMembers", () => {
+    it("moves membership from one slot to the other", () => {
+        const set = new Set([6]);
+        swapSetMembers(set, 6, 7);
+        expect(set.has(6)).toBe(false);
+        expect(set.has(7)).toBe(true);
+    });
+
+    it("leaves both members when both are present", () => {
+        const set = new Set([6, 7]);
+        swapSetMembers(set, 6, 7);
+        expect([...set].sort()).toEqual([6, 7]);
+    });
+
+    it("leaves both absent when neither is present", () => {
+        const set = new Set<number>();
+        swapSetMembers(set, 6, 7);
+        expect(set.size).toBe(0);
+    });
+});
+
+// Slots 6 and 7 hold players; 9 is empty. Mirrors the bench in the UI.
+const setup = (occupied = new Set([6, 7])) => {
+    const onSwap = vi.fn();
+    const dragDrop = useRosterDragDrop({
+        onSwap,
+        isOccupied: (slot) => occupied.has(slot),
+        describeSlot: (slot) => `slot ${slot}`,
+    });
+    return { onSwap, ...dragDrop };
+};
+
+const dragEvent = () => ({
+    preventDefault: vi.fn(),
+    dataTransfer: { effectAllowed: "", dropEffect: "", setData: vi.fn() },
+}) as unknown as DragEvent & { preventDefault: ReturnType<typeof vi.fn> };
+
+describe("useRosterDragDrop - pointer drag", () => {
+    it("swaps the source and target slots on drop", () => {
+        const { onSwap, startDrag, dropOnSlot, draggingSlot } = setup();
+
+        startDrag(6, dragEvent());
+        expect(draggingSlot.value).toBe(6);
+
+        dropOnSlot(7, dragEvent());
+        expect(onSwap).toHaveBeenCalledWith(6, 7);
+        expect(draggingSlot.value).toBeNull();
+    });
+
+    it("refuses to start a drag from an empty slot", () => {
+        const { startDrag, draggingSlot } = setup();
+        const event = dragEvent();
+
+        startDrag(9, event);
+        expect(draggingSlot.value).toBeNull();
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("moves a player into an empty slot", () => {
+        const { onSwap, startDrag, dropOnSlot } = setup();
+
+        startDrag(6, dragEvent());
+        dropOnSlot(9, dragEvent());
+        expect(onSwap).toHaveBeenCalledWith(6, 9);
+    });
+
+    it("does nothing when a card is dropped on itself", () => {
+        const { onSwap, startDrag, dropOnSlot } = setup();
+
+        startDrag(6, dragEvent());
+        dropOnSlot(6, dragEvent());
+        expect(onSwap).not.toHaveBeenCalled();
+    });
+
+    it("tracks and clears the drop target", () => {
+        const { startDrag, dragOverSlot, leaveSlot, dropTargetSlot } = setup();
+
+        startDrag(6, dragEvent());
+        dragOverSlot(7, dragEvent());
+        expect(dropTargetSlot.value).toBe(7);
+
+        // A dragleave from a slot that isn't the current target must not clear it.
+        leaveSlot(9);
+        expect(dropTargetSlot.value).toBe(7);
+
+        leaveSlot(7);
+        expect(dropTargetSlot.value).toBeNull();
+    });
+
+    it("allows the drop by preventing the dragover default", () => {
+        const { startDrag, dragOverSlot } = setup();
+        const event = dragEvent();
+
+        startDrag(6, dragEvent());
+        dragOverSlot(7, event);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});
+
+describe("useRosterDragDrop - keyboard pickup", () => {
+    it("picks up then swaps on the second slot", () => {
+        const { onSwap, togglePickup, pickedUpSlot, liveMessage } = setup();
+
+        togglePickup(6);
+        expect(pickedUpSlot.value).toBe(6);
+        expect(liveMessage.value).toContain("slot 6");
+
+        togglePickup(7);
+        expect(onSwap).toHaveBeenCalledWith(6, 7);
+        expect(pickedUpSlot.value).toBeNull();
+        expect(liveMessage.value).toBe("Swapped slot 6 with slot 7.");
+    });
+
+    it("puts the card back when the same slot is pressed twice", () => {
+        const { onSwap, togglePickup, pickedUpSlot } = setup();
+
+        togglePickup(6);
+        togglePickup(6);
+        expect(onSwap).not.toHaveBeenCalled();
+        expect(pickedUpSlot.value).toBeNull();
+    });
+
+    it("ignores a pickup on an empty slot", () => {
+        const { togglePickup, pickedUpSlot } = setup();
+
+        togglePickup(9);
+        expect(pickedUpSlot.value).toBeNull();
+    });
+
+    it("cancels a pickup without swapping", () => {
+        const { onSwap, togglePickup, cancelPickup, pickedUpSlot } = setup();
+
+        togglePickup(6);
+        cancelPickup();
+        expect(pickedUpSlot.value).toBeNull();
+        expect(onSwap).not.toHaveBeenCalled();
+    });
+
+    it("drops a keyboard pickup when a pointer drag takes over", () => {
+        const { togglePickup, startDrag, pickedUpSlot } = setup();
+
+        togglePickup(6);
+        startDrag(7, dragEvent());
+        expect(pickedUpSlot.value).toBeNull();
+    });
+});


### PR DESCRIPTION
## What

Drag a player card onto another slot to **swap** the two occupants, or onto an empty slot to **move**. Works anywhere in the roster — bench↔bench, starter↔starter, and bench→starters, so promoting a bench player into the starting five is one gesture.

Previously the only way to rearrange two players was to remove and re-add them (four interactions, and it re-fetches their stats).

## Design notes

Roster slots are fixed positions in a `Map<number, Player>`, not a list, so this is swap semantics rather than insert-and-shift — empty slots stay where they are.

Three containers are keyed by slot index: `selectedPlayersData`, `cardsFlipped`, and `selectedPlayersForComparison`. All three swap together, or flip state and comparison picks would stay attached to the slot instead of the player.

Native HTML5 drag events, no new dependency. `vuedraggable` is already in `package.json` but imported nowhere, and is array-oriented — a poor fit for a sparse slot `Map`.

Position labels on starter slots (PG/SG/SF/PF/C) are labels, not constraints — no position validation.

## Accessibility

HTML5 drag isn't keyboard accessible, so each filled card gets a grip handle: activate to pick up, activate another slot to swap, Escape to cancel. Empty slots surface a "Move here" button while a card is held. An `aria-live` region announces pickups and swaps.

## Also in this PR

Fixes `saveTeam` building its `players` array from `Map.values()` — that's insertion order, so a reordered roster saved in the order players happened to be added. Now sorted by slot index.

## Verification

- `pnpm run test` — 41 pass, 27 of them new (`tests/composables/useRosterDragDrop.test.ts`, extended `tests/components/RosterSection.test.ts`)
- `pnpm run type-check` — clean
- Driven in a real browser with Playwright using real HTML5 drag events: bench 6↔7 swap carried the flipped card's state; bench→empty starter updated the `2/5` count and starter OVR; keyboard swap and Escape-cancel both behaved; save payload confirmed in slot order.
- `pnpm run lint` could **not** run — it dies at startup with `Cannot find module 'ajv/lib/refs/json-schema-draft-04.json'`. Pre-existing on `main`, caused by the `ajv: 8.20.0` pnpm override vs ESLint 10. Unrelated to this change.

## Known limitation

HTML5 drag events don't fire on touch devices. Mobile keeps the existing Replace flow. A Pointer Events fallback is the natural follow-up.