### PR TITLE
feat(player-stats): stats display preferences and per-slot add feedback

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -172,6 +172,246 @@
     border-radius: 0.875rem !important;
   }
 
+  /* Popover Dialog Override */
+  [role="dialog"].stats-preferences-popover {
+    background: hsl(0 0% 12%) !important;
+    border: 1px solid hsl(0 0% 25%) !important;
+    padding: 1.25rem !important;
+    max-width: 24rem !important;
+    border-radius: 0.75rem !important;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.5) !important;
+  }
+
+  /* Checkbox Sizing & Styling */
+  button[role="checkbox"] {
+    width: 1.125rem !important;
+    height: 1.125rem !important;
+    min-width: 1.125rem !important;
+    min-height: 1.125rem !important;
+    border-radius: 0.25rem !important;
+    border: 1.5px solid hsl(0 0% 45%) !important;
+    background-color: hsl(0 0% 8%) !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    cursor: pointer !important;
+    flex-shrink: 0 !important;
+  }
+
+  button[role="checkbox"][data-state="checked"] {
+    background-color: hsl(var(--primary)) !important;
+    border-color: hsl(var(--primary)) !important;
+    color: hsl(var(--primary-foreground)) !important;
+  }
+
+  /* The popover's trigger. Sized against the table it configures, not as a
+     dialog action button. */
+  [role="dialog"] .prefs-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    height: 2rem;
+    min-height: 2rem !important;
+    padding: 0 0.75rem !important;
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+    border-radius: 0.5rem !important;
+    color: hsl(var(--muted-foreground));
+    border: 0.0625rem solid hsl(var(--border));
+    background-color: hsl(0 0% 16%);
+  }
+
+  [role="dialog"] .prefs-trigger:hover {
+    color: hsl(var(--foreground));
+    background-color: hsl(0 0% 20%);
+  }
+
+  /* Stats preferences popover.
+     These rules live here rather than in PlayerStatsDialog.vue's scoped block
+     because the popover is teleported out of the component by PopoverPortal and
+     does not receive the component's scope attribute. They also have to be in
+     this layer, not unlayered: for !important declarations the cascade reverses
+     layer order, so unlayered rules lose to the layered ones above no matter
+     how specific they are.
+
+     A popover carries role="dialog" too, so the modal-scale rules above land on
+     it: 1.0625rem body copy with a 2rem bottom margin, and 2.75rem-tall buttons
+     padded to 2rem a side. Right for a modal, far too big for a settings panel,
+     hence the !important on every metric that has to be taken back. */
+  [role="dialog"].stats-preferences-popover {
+    display: flex;
+    flex-direction: column;
+    gap: 1.125rem;
+    width: 20rem !important;
+    padding: 1.125rem !important;
+  }
+
+  [role="dialog"].stats-preferences-popover h4 {
+    font-size: 0.8125rem !important;
+    font-weight: 700 !important;
+    line-height: 1.3 !important;
+    letter-spacing: -0.01em !important;
+    margin-bottom: 0 !important;
+    color: hsl(var(--foreground)) !important;
+  }
+
+  [role="dialog"].stats-preferences-popover p {
+    font-size: 0.6875rem !important;
+    font-weight: 400 !important;
+    line-height: 1.45 !important;
+    margin-bottom: 0 !important;
+    color: hsl(var(--muted-foreground)) !important;
+  }
+
+  [role="dialog"].stats-preferences-popover button {
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+    padding: 0 0.625rem !important;
+    min-height: 2rem !important;
+    border-radius: 0.375rem !important;
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    padding-bottom: 1rem;
+    border-bottom: 0.0625rem solid hsl(var(--border));
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-head-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.5rem;
+    color: hsl(var(--primary));
+    background-color: hsl(var(--primary) / 0.15);
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-head-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1875rem;
+    min-width: 0;
+    /* Optically centres the two-line block against the 1.75rem icon. */
+    padding-top: 0.0625rem;
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-label {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    color: hsl(var(--muted-foreground));
+  }
+
+  /* ToggleGroup hard-codes `flex items-center justify-center gap-1` on its
+     root. Those are utilities, and the utilities layer outranks this one for
+     normal declarations, so the grid has to be declared !important to land. */
+  [role="dialog"].stats-preferences-popover .prefs-toggle-grid {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 0.3125rem !important;
+    padding: 0.3125rem;
+    border: 0.0625rem solid hsl(var(--border));
+    border-radius: 0.5rem;
+    background-color: hsl(0 0% 7%);
+  }
+
+  /* Same story as the grid above: `gap-2` is a utility and wins unless this is
+     marked important. flex-direction has no competing utility. */
+  [role="dialog"].stats-preferences-popover .prefs-toggle {
+    display: flex !important;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.0625rem !important;
+    width: 100%;
+    min-height: 2.5rem !important;
+    padding: 0.375rem 0.5rem !important;
+    border-radius: 0.375rem !important;
+    color: hsl(var(--muted-foreground));
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-toggle-value {
+    font-size: 0.75rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+  }
+
+  /* The sample answers the question; the hint only names it. Keeping the hint
+     dim and on its own line stops four options reading as eight labels. */
+  [role="dialog"].stats-preferences-popover .prefs-toggle-hint {
+    font-size: 0.625rem;
+    font-weight: 500;
+    line-height: 1.1;
+    opacity: 0.6;
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-check-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    padding: 0.875rem 0.5rem 0;
+    margin: 0 -0.5rem;
+    border-top: 0.0625rem solid hsl(var(--border));
+    cursor: pointer;
+    user-select: none;
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-check-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1875rem;
+    min-width: 0;
+  }
+
+  /* Matches the 1.25rem checkbox so the two sit on a shared baseline. */
+  [role="dialog"].stats-preferences-popover .prefs-check-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.25rem;
+    color: hsl(var(--foreground));
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-foot {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 0.875rem;
+    border-top: 0.0625rem solid hsl(var(--border));
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-reset {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 1.75rem !important;
+    padding: 0 0.5rem !important;
+    font-size: 0.6875rem !important;
+    color: hsl(var(--muted-foreground));
+  }
+
+  [role="dialog"].stats-preferences-popover .prefs-reset:hover {
+    color: hsl(var(--foreground));
+    background-color: hsl(0 0% 18%);
+  }
+
+  [role="dialog"].stats-preferences-popover button[role="checkbox"] {
+    min-height: 1.25rem !important;
+    padding: 0 !important;
+  }
+
   /* Opt-out for dialogs holding wide tabular data. The player stats table is
      21 columns; at 45rem only about a third of it is reachable. Needs to beat
      the !important above, hence the class + attribute selector. */
@@ -459,3 +699,31 @@
     padding: 0 2rem;
   }
 } */
+
+/* Direct, un-layered overrides for Checkbox and Popover */
+button[role="checkbox"],
+button.peer[role="checkbox"] {
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+  min-width: 1.25rem !important;
+  min-height: 1.25rem !important;
+  max-width: 1.25rem !important;
+  max-height: 1.25rem !important;
+  border-radius: 0.25rem !important;
+  border: 1.5px solid #71717a !important;
+  background-color: #09090b !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  cursor: pointer !important;
+  flex-shrink: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+button[role="checkbox"][data-state="checked"],
+button.peer[role="checkbox"][data-state="checked"] {
+  background-color: hsl(var(--primary)) !important;
+  border-color: hsl(var(--primary)) !important;
+  color: #18181b !important;
+}

--- a/src/components/TeamBuilder/PlayerSlot.vue
+++ b/src/components/TeamBuilder/PlayerSlot.vue
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
-import { X, UserPlus, Plus, BarChart3, ArrowLeftRight, GitCompareArrows, GripVertical } from 'lucide-vue-next';
+import { X, UserPlus, Plus, BarChart3, ArrowLeftRight, GitCompareArrows, GripVertical, Loader2 } from 'lucide-vue-next';
 import { getWikipediaUrl } from '@/constants/utilities';
 import ExternalLinksMenu from '@/components/ExternalLinksMenu.vue';
 import { ratingTier, ratingSourceLabel } from '@/constants/ratings';
@@ -32,6 +32,8 @@ interface Props {
   slotIndex: number;
   player?: Player | null;
   position?: string;
+  /** Name of the player being fetched into this slot, while that is in flight. */
+  pendingName?: string;
   isFlipped?: boolean;
   isDragging?: boolean;
   isDropTarget?: boolean;
@@ -43,6 +45,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   player: null,
   position: undefined,
+  pendingName: undefined,
   isFlipped: false,
   isDragging: false,
   isDropTarget: false,
@@ -65,6 +68,9 @@ const emit = defineEmits<{
 }>();
 
 const hasPlayer = computed(() => !!props.player);
+// The player lands in the slot only once their stats have been fetched, so a
+// pending slot is still empty - it just shouldn't offer to be filled again.
+const isPending = computed(() => !props.player && !!props.pendingName);
 const slotLabel = computed(() => props.position || `Slot ${props.slotIndex}`);
 const moveLabel = computed(() => {
   if (props.isPickedUp) return `Put ${props.player?.fullName} back in ${slotLabel.value}`;
@@ -105,6 +111,7 @@ const averageStats = computed(() => {
       'is-dragging': isDragging,
       'is-drop-target': isDropTarget,
       'is-picked-up': isPickedUp,
+      'is-pending': isPending,
     }"
     :draggable="hasPlayer"
     @dragstart="emit('dragStart', slotIndex, $event)"
@@ -155,8 +162,19 @@ const averageStats = computed(() => {
       <Separator />
 
       <CardContent class="main-content" @click="hasPlayer ? emit('flip', slotIndex) : undefined" :class="{ 'cursor-pointer': hasPlayer }">
+        <!-- Pending State - this slot's player is still being fetched -->
+        <template v-if="isPending">
+          <div class="empty-state" role="status" aria-live="polite">
+            <div class="empty-icon-wrapper is-pending">
+              <Loader2 class="empty-icon pending-spinner" />
+            </div>
+            <p class="pending-name">{{ pendingName }}</p>
+            <p class="empty-text">Adding to {{ slotLabel }}...</p>
+          </div>
+        </template>
+
         <!-- Empty State -->
-        <template v-if="!hasPlayer">
+        <template v-else-if="!hasPlayer">
           <div class="empty-state">
             <div class="empty-icon-wrapper">
               <UserPlus class="empty-icon" />
@@ -294,6 +312,12 @@ const averageStats = computed(() => {
   transform: scale(1.02);
 }
 
+/* Solid rather than dashed: the slot is committed, not awaiting a drop. */
+.player-card-wrapper.is-pending {
+  border-color: hsl(var(--primary) / 0.6);
+  box-shadow: 0 0 0.75rem hsla(var(--primary), 0.25);
+}
+
 /* The card held by the keyboard flow, which persists between keypresses. */
 .player-card-wrapper.is-picked-up {
   border-style: dashed;
@@ -412,6 +436,39 @@ const averageStats = computed(() => {
   width: 2rem;
   height: 2rem;
   color: hsl(var(--muted-foreground));
+}
+
+/* Pending State */
+.empty-icon-wrapper.is-pending {
+  background-color: hsl(var(--primary) / 0.12);
+}
+
+.pending-spinner {
+  color: hsl(var(--primary));
+  animation: pending-spin 0.9s linear infinite;
+}
+
+@keyframes pending-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pending-spinner {
+    animation-duration: 2.5s;
+  }
+}
+
+.pending-name {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: hsl(var(--foreground));
+  text-align: center;
+  margin: 0;
+  /* Long names must not widen the card out of its grid track. */
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .empty-text {

--- a/src/components/TeamBuilder/PlayerStatsDialog.vue
+++ b/src/components/TeamBuilder/PlayerStatsDialog.vue
@@ -15,6 +15,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableFooter,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,8 +24,21 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ArrowDown, ArrowUp } from "lucide-vue-next";
-import { STAT_COLUMNS } from "@/constants/playerStats";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { ArrowDown, ArrowUp, Settings, SlidersHorizontal, RotateCcw } from "lucide-vue-next";
+import {
+  STAT_COLUMNS,
+  COUNTING_STATS,
+  formatStat,
+  formatCellValue,
+  careerAverages,
+  careerTotals,
+  type StatColumn,
+} from "@/constants/playerStats";
+import { usePlayerStatsPreferences } from "@/composables/usePlayerStatsPreferences";
 
 const props = withDefaults(
   defineProps<{
@@ -38,6 +52,17 @@ const props = withDefaults(
     playerName: '',
   },
 );
+
+const { preferences, resetPreferences } = usePlayerStatsPreferences();
+
+// Each option shows the same season rendered its own way, so the choice is made
+// by reading the samples rather than by decoding the format token.
+const seasonFormatOptions = [
+  { value: 'YYYY-YY', sample: '2010-11', hint: 'NBA style' },
+  { value: 'YYYY-YYYY', sample: '2010-2011', hint: 'Full years' },
+  { value: 'YYYY', sample: '2010', hint: 'Start year' },
+  { value: 'YYYY+1', sample: '2011', hint: 'End year' },
+] as const;
 
 // Oldest release on the left, so the line reads left-to-right as a career.
 const ratingTimeline = computed(() =>
@@ -138,6 +163,22 @@ const sortedRows = computed(() => {
   });
 });
 
+const summaryData = computed(() => {
+  const rows = Array.isArray(localData.value) ? localData.value : [];
+  if (!rows.length) return null;
+  if (preferences.value.statMode === 'totals') {
+    return careerTotals(rows);
+  }
+  return careerAverages(rows);
+});
+
+const getColumnTitle = (column: StatColumn) => {
+  if (preferences.value.statMode === 'totals' && COUNTING_STATS.includes(column.field)) {
+    return column.title.replace(' per Game', ' Total in Season');
+  }
+  return column.title;
+};
+
 // A new player's stats shouldn't inherit the previous player's sort.
 watch(() => props.data, () => {
   sortField.value = null;
@@ -152,13 +193,110 @@ const columns = STAT_COLUMNS;
     <!-- wide-dialog opts out of the global 45rem cap in main.css, which is
          !important and beats any max-w-* utility. -->
     <DialogContent class="wide-dialog w-[95vw] max-h-[90vh] overflow-y-auto">
-      <DialogHeader>
-        <DialogTitle>{{ playerName ? `${playerName} — Stats` : 'Player Stats' }}</DialogTitle>
+      <!-- pr-14 keeps the title clear of the close button, which DialogContent
+           positions absolutely in this same corner. -->
+      <!-- No bottom padding: the global `[role="dialog"] h2` rule already puts
+           1.25rem under the title, and doubling it strands the rule. -->
+      <DialogHeader class="border-b border-zinc-800/60 pr-14">
+        <DialogTitle class="text-xl font-bold text-white tracking-tight">
+          {{ playerName ? `${playerName} — Stats` : 'Player Stats' }}
+        </DialogTitle>
       </DialogHeader>
+
+      <!-- The preferences trigger gets its own row rather than sharing the
+           header: beside the title it collides with the absolutely-positioned
+           close button, which sits outside this flow and can't be flexed around. -->
+      <div class="flex justify-end -mt-1 -mb-2">
+        <Popover>
+          <PopoverTrigger as-child>
+            <Button
+              variant="outline"
+              size="sm"
+              class="prefs-trigger"
+              title="Stats display preferences"
+            >
+              <Settings class="h-3.5 w-3.5 text-primary" />
+              <span>Preferences</span>
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            :side-offset="8"
+            class="stats-preferences-popover prefs-panel"
+          >
+            <header class="prefs-head">
+              <span class="prefs-head-icon">
+                <SlidersHorizontal class="h-4 w-4" />
+              </span>
+              <div class="prefs-head-text">
+                <h4>Stats Display</h4>
+                <p>Applies to every player's stats table.</p>
+              </div>
+            </header>
+
+            <section class="prefs-section">
+              <Label class="prefs-label">Season format</Label>
+              <ToggleGroup
+                v-model="preferences.seasonFormat"
+                type="single"
+                class="prefs-toggle-grid"
+                @update:model-value="(val) => { if (!val) preferences.seasonFormat = 'YYYY-YY'; }"
+              >
+                <ToggleGroupItem
+                  v-for="option in seasonFormatOptions"
+                  :key="option.value"
+                  :value="option.value"
+                  class="prefs-toggle"
+                >
+                  <span class="prefs-toggle-value">{{ option.sample }}</span>
+                  <span class="prefs-toggle-hint">{{ option.hint }}</span>
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </section>
+
+            <section class="prefs-section">
+              <Label class="prefs-label">Stat values</Label>
+              <ToggleGroup
+                v-model="preferences.statMode"
+                type="single"
+                class="prefs-toggle-grid"
+                @update:model-value="(val) => { if (!val) preferences.statMode = 'per_game'; }"
+              >
+                <ToggleGroupItem value="per_game" class="prefs-toggle">
+                  <span class="prefs-toggle-value">Per game</span>
+                  <span class="prefs-toggle-hint">Averages</span>
+                </ToggleGroupItem>
+                <ToggleGroupItem value="totals" class="prefs-toggle">
+                  <span class="prefs-toggle-value">Totals</span>
+                  <span class="prefs-toggle-hint">Season sums</span>
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </section>
+
+            <label for="show-career-summary" class="prefs-check-row">
+              <Checkbox
+                id="show-career-summary"
+                v-model:checked="preferences.showCareerSummary"
+              />
+              <span class="prefs-check-text">
+                <span class="prefs-check-title">Career summary row</span>
+                <p>Totals line pinned to the bottom of the table.</p>
+              </span>
+            </label>
+
+            <footer class="prefs-foot">
+              <Button variant="ghost" size="sm" class="prefs-reset" @click="resetPreferences">
+                <RotateCcw class="h-3 w-3" />
+                Reset defaults
+              </Button>
+            </footer>
+          </PopoverContent>
+        </Popover>
+      </div>
 
       <!-- NBA 2K rating history. Only current-roster players have one; retired
            players are rated as their All-Time selves, with no year-by-year run. -->
-      <section v-if="ratingTimeline.length > 1" class="rating-history">
+      <section v-if="ratingTimeline.length > 1" class="rating-history mt-2">
         <header class="rating-history-header">
           <h4 class="rating-history-title">NBA 2K Rating History</h4>
           <span v-if="ratingRange" class="rating-history-range">
@@ -222,7 +360,7 @@ const columns = STAT_COLUMNS;
                       />
                     </TooltipTrigger>
                     <TooltipContent>
-                      {{ column.title }}
+                      {{ getColumnTitle(column) }}
                       <span class="stat-sort-hint">Click to sort</span>
                     </TooltipContent>
                   </Tooltip>
@@ -240,10 +378,32 @@ const columns = STAT_COLUMNS;
                   :key="column.name"
                   class="text-gray-300 whitespace-nowrap"
                 >
-                  {{ row[column.field] }}
+                  {{ formatCellValue(column.field, row, preferences.seasonFormat, preferences.statMode) }}
                 </TableCell>
               </TableRow>
             </TableBody>
+            <TableFooter v-if="preferences.showCareerSummary && summaryData">
+              <TableRow class="bg-zinc-800/80 font-bold border-t-2 border-primary/50">
+                <TableCell
+                  v-for="column in columns"
+                  :key="column.name"
+                  class="whitespace-nowrap font-bold text-primary"
+                >
+                  <template v-if="column.field === 'season'">
+                    {{ preferences.statMode === 'totals' ? 'Career Total' : 'Career' }}
+                  </template>
+                  <template v-else-if="column.field === 'games_played'">
+                    {{ summaryData.games_played }}
+                  </template>
+                  <template v-else-if="preferences.statMode === 'totals' && COUNTING_STATS.includes(column.field)">
+                    {{ summaryData[column.field]?.toLocaleString() }}
+                  </template>
+                  <template v-else>
+                    {{ formatStat(column.field, summaryData[column.field]) }}
+                  </template>
+                </TableCell>
+              </TableRow>
+            </TableFooter>
           </Table>
         </TooltipProvider>
       </div>
@@ -258,6 +418,13 @@ const columns = STAT_COLUMNS;
 </template>
 
 <style scoped>
+/* The preferences trigger and popover are styled in main.css, not here. The
+   popover is teleported out of this component by PopoverPortal so the scope
+   attribute never reaches it, and both have to override modal-scale
+   `[role="dialog"]` rules that are !important inside a cascade layer - which
+   unlayered scoped styles cannot beat, since layer order reverses for
+   important declarations. */
+
 /* Dotted underline is the convention for "this abbreviation has a definition";
    the arrow carries the sortable affordance. */
 .stat-header {

--- a/src/components/TeamBuilder/RosterSection.vue
+++ b/src/components/TeamBuilder/RosterSection.vue
@@ -23,6 +23,8 @@ interface Player {
 interface Props {
   selectedPlayers: Map<number, Player>;
   cardsFlipped: Map<number, boolean>;
+  /** Slot index -> name of the player currently being fetched into that slot. */
+  pendingPlayers?: Map<number, string>;
   draggingSlot?: number | null;
   dropTargetSlot?: number | null;
   pickedUpSlot?: number | null;
@@ -30,6 +32,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  pendingPlayers: () => new Map(),
   draggingSlot: null,
   dropTargetSlot: null,
   pickedUpSlot: null,
@@ -121,6 +124,7 @@ const onKeydown = (event: KeyboardEvent) => {
           :position="POSITIONS[posIndex]"
           :player="selectedPlayers.get(index)"
           :is-flipped="cardsFlipped.get(index)"
+          :pending-name="pendingPlayers.get(index)"
           :is-dragging="draggingSlot === index"
           :is-drop-target="dropTargetSlot === index"
           :is-picked-up="pickedUpSlot === index"
@@ -153,6 +157,7 @@ const onKeydown = (event: KeyboardEvent) => {
           :slot-index="index"
           :player="selectedPlayers.get(index)"
           :is-flipped="cardsFlipped.get(index)"
+          :pending-name="pendingPlayers.get(index)"
           :is-dragging="draggingSlot === index"
           :is-drop-target="dropTargetSlot === index"
           :is-picked-up="pickedUpSlot === index"

--- a/src/components/ui/checkbox/Checkbox.vue
+++ b/src/components/ui/checkbox/Checkbox.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Check } from "lucide-vue-next";
+
+const props = withDefaults(
+  defineProps<{
+    checked?: boolean;
+    id?: string;
+  }>(),
+  {
+    checked: false,
+    id: undefined,
+  }
+);
+
+const emit = defineEmits<{
+  'update:checked': [value: boolean];
+}>();
+
+// The app-wide checkbox styling in main.css is written with !important against
+// [data-state="checked"], matching what Reka's primitives emit. The Tailwind
+// classes below lose to it, so without this attribute a checked box paints as
+// if it were empty.
+const dataState = computed(() => (props.checked ? 'checked' : 'unchecked'));
+
+const toggle = () => {
+  emit('update:checked', !props.checked);
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    role="checkbox"
+    :aria-checked="props.checked"
+    :data-state="dataState"
+    :id="props.id"
+    @click.stop="toggle"
+    class="relative inline-flex items-center justify-center shrink-0 rounded-md border-2 transition-colors cursor-pointer select-none"
+    :class="[
+      props.checked
+        ? 'bg-amber-500 border-amber-500 text-zinc-950 shadow-sm'
+        : 'bg-zinc-950 border-zinc-500 hover:border-zinc-400 text-transparent'
+    ]"
+    style="width: 1.25rem !important; height: 1.25rem !important; min-width: 1.25rem !important; min-height: 1.25rem !important; flex-shrink: 0 !important; padding: 0 !important; margin: 0 !important; line-height: 1 !important;"
+  >
+    <Check v-if="props.checked" class="w-3.5 h-3.5 stroke-[3.5]" />
+  </button>
+</template>

--- a/src/components/ui/checkbox/index.ts
+++ b/src/components/ui/checkbox/index.ts
@@ -1,0 +1,1 @@
+export { default as Checkbox } from './Checkbox.vue'

--- a/src/composables/usePlayerStatsPreferences.ts
+++ b/src/composables/usePlayerStatsPreferences.ts
@@ -1,0 +1,30 @@
+import { useStorage } from '@vueuse/core';
+import type { SeasonFormat, StatDisplayMode } from '@/constants/playerStats';
+
+export interface PlayerStatsPreferences {
+  seasonFormat: SeasonFormat;
+  statMode: StatDisplayMode;
+  showCareerSummary: boolean;
+}
+
+const DEFAULT_PREFERENCES: PlayerStatsPreferences = {
+  seasonFormat: 'YYYY-YY', // Standard NBA format (e.g. 2010-11)
+  statMode: 'per_game',
+  showCareerSummary: true,
+};
+
+export const usePlayerStatsPreferences = () => {
+  const preferences = useStorage<PlayerStatsPreferences>(
+    'nba-player-stats-preferences',
+    DEFAULT_PREFERENCES
+  );
+
+  const resetPreferences = () => {
+    preferences.value = { ...DEFAULT_PREFERENCES };
+  };
+
+  return {
+    preferences,
+    resetPreferences,
+  };
+};

--- a/src/composables/useRosterDragDrop.ts
+++ b/src/composables/useRosterDragDrop.ts
@@ -39,12 +39,19 @@ interface RosterDragDropOptions {
     onSwap: (from: number, to: number) => void;
     /** True when the slot holds a player - empty slots can be dropped on but not dragged. */
     isOccupied: (slot: number) => boolean;
+    /**
+     * True when a player is still being fetched into the slot. Such a slot
+     * reads as empty but is already spoken for: anything moved into it would be
+     * overwritten the moment the fetch lands, so it refuses moves entirely.
+     */
+    isPending?: (slot: number) => boolean;
     /** Human-readable slot description used for the aria-live announcements. */
     describeSlot: (slot: number) => string;
 }
 
 export function useRosterDragDrop(options: RosterDragDropOptions) {
     const { onSwap, isOccupied, describeSlot } = options;
+    const isPending = options.isPending ?? (() => false);
 
     // The slot the pointer drag started from. This - not dataTransfer - is the
     // source of truth, because getData() is unreadable during dragover.
@@ -59,6 +66,7 @@ export function useRosterDragDrop(options: RosterDragDropOptions) {
     const applySwap = (from: number, to: number) => {
         if (from === to) return false;
         if (!isOccupied(from) && !isOccupied(to)) return false;
+        if (isPending(from) || isPending(to)) return false;
         onSwap(from, to);
         return true;
     };
@@ -85,6 +93,9 @@ export function useRosterDragDrop(options: RosterDragDropOptions) {
 
     const dragOverSlot = (slot: number, event: DragEvent) => {
         if (draggingSlot.value === null || draggingSlot.value === slot) return;
+        // Skipping preventDefault below leaves the browser showing "no drop"
+        // over a pending slot, which is the feedback we want anyway.
+        if (isPending(slot)) return;
 
         // Without preventDefault the browser refuses the drop entirely.
         event.preventDefault();
@@ -128,6 +139,13 @@ export function useRosterDragDrop(options: RosterDragDropOptions) {
         if (held === slot) {
             pickedUpSlot.value = null;
             liveMessage.value = `${describeSlot(slot)} put back.`;
+            return;
+        }
+
+        // Keep the card held rather than dropping it into a slot that is about
+        // to be filled - the user still has somewhere to put it.
+        if (isPending(slot)) {
+            liveMessage.value = 'That slot is still loading. Choose another slot.';
             return;
         }
 

--- a/src/constants/playerStats.ts
+++ b/src/constants/playerStats.ts
@@ -45,8 +45,11 @@ const LOWER_IS_BETTER = new Set(['turnover', 'pf']);
 export const isBetter = (field: string, value: number, other: number): boolean =>
     LOWER_IS_BETTER.has(field) ? value < other : value > other;
 
+export type SeasonFormat = 'YYYY-YY' | 'YYYY-YYYY' | 'YYYY' | 'YYYY+1';
+export type StatDisplayMode = 'per_game' | 'totals';
+
 /** Shooting percentages must be recomputed from makes and attempts, never averaged. */
-const PERCENTAGE_SOURCES: Record<string, [string, string]> = {
+export const PERCENTAGE_SOURCES: Record<string, [string, string]> = {
     fg_pct: ['fgm', 'fga'],
     fg3_pct: ['fg3m', 'fg3a'],
     ft_pct: ['ftm', 'fta'],
@@ -55,7 +58,7 @@ const PERCENTAGE_SOURCES: Record<string, [string, string]> = {
 // Season rows are already per-game, so a career rate is the games-weighted mean
 // of the seasons - a plain mean would let a 5-game season count as much as an
 // 82-game one.
-const COUNTING_STATS = [
+export const COUNTING_STATS = [
     'min', 'fgm', 'fga', 'fg3m', 'fg3a', 'ftm', 'fta',
     'oreb', 'dreb', 'reb', 'ast', 'stl', 'blk', 'turnover', 'pf', 'pts',
 ];
@@ -99,6 +102,46 @@ export const careerAverages = (
     return out as CareerAverages;
 };
 
+export type CareerTotals = Record<string, number> & {
+    games_played: number;
+    seasons: number;
+};
+
+export const careerTotals = (
+    seasons: PlayerSeasonStats[] | undefined | null,
+): CareerTotals | null => {
+    const rows = (seasons ?? []).filter(
+        (row) => row && Number.isFinite(Number(row.games_played)),
+    );
+    if (!rows.length) return null;
+
+    const totalGames = rows.reduce((sum, row) => sum + Number(row.games_played), 0);
+    if (totalGames <= 0) return null;
+
+    const out: Record<string, number> = {
+        games_played: totalGames,
+        seasons: rows.length,
+    };
+
+    for (const field of COUNTING_STATS) {
+        const sumTotal = rows.reduce((sum, row) => {
+            const value = Number((row as any)[field]);
+            const games = Number(row.games_played);
+            return Number.isFinite(value) && Number.isFinite(games)
+                ? sum + Math.round(value * games)
+                : sum;
+        }, 0);
+        out[field] = sumTotal;
+    }
+
+    for (const [pct, [madeField, attemptedField]] of Object.entries(PERCENTAGE_SOURCES)) {
+        const attempted = out[attemptedField];
+        out[pct] = attempted > 0 ? out[madeField] / attempted : 0;
+    }
+
+    return out as CareerTotals;
+};
+
 /** Percentages read as .513; counting stats as 24.4; games played as a whole number. */
 export const formatStat = (field: string, value: number | undefined): string => {
     if (value === undefined || !Number.isFinite(value)) return '—';
@@ -108,3 +151,69 @@ export const formatStat = (field: string, value: number | undefined): string => 
     }
     return value.toFixed(1);
 };
+
+/**
+ * Formats a season start year into standard NBA or custom year formats.
+ * E.g., for start year 2010:
+ * - YYYY-YY: '2010-11' (Standard NBA format)
+ * - YYYY-YYYY: '2010-2011' (Full year range)
+ * - YYYY: '2010' (Start year)
+ * - YYYY+1: '2011' (End year)
+ */
+export const formatSeason = (
+    season: number | string | undefined | null,
+    format: SeasonFormat = 'YYYY-YY',
+): string => {
+    if (season === undefined || season === null) return '—';
+    if (typeof season === 'string' && season.includes('-')) return season;
+
+    const year = typeof season === 'number' ? season : parseInt(String(season), 10);
+    if (isNaN(year)) return String(season);
+
+    switch (format) {
+        case 'YYYY-YY': {
+            const nextYear = Math.abs(year + 1) % 100;
+            const nextYearStr = nextYear < 10 ? `0${nextYear}` : `${nextYear}`;
+            return `${year}-${nextYearStr}`;
+        }
+        case 'YYYY-YYYY':
+            return `${year}-${year + 1}`;
+        case 'YYYY+1':
+            return `${year + 1}`;
+        case 'YYYY':
+        default:
+            return `${year}`;
+    }
+};
+
+/** Formats a table cell value based on column field, season format preference, and stat mode. */
+export const formatCellValue = (
+    field: string,
+    row: any,
+    seasonFormat: SeasonFormat = 'YYYY-YY',
+    statMode: StatDisplayMode = 'per_game',
+): string => {
+    if (!row) return '—';
+
+    if (field === 'season') {
+        return formatSeason(row.season, seasonFormat);
+    }
+
+    if (field === 'games_played') {
+        return formatStat('games_played', row.games_played);
+    }
+
+    const val = Number(row[field]);
+    if (!Number.isFinite(val)) return '—';
+
+    if (statMode === 'totals') {
+        const games = Number(row.games_played);
+        if (COUNTING_STATS.includes(field) && Number.isFinite(games) && games > 0) {
+            const total = Math.round(val * games);
+            return total.toLocaleString();
+        }
+    }
+
+    return formatStat(field, val);
+};
+

--- a/src/views/TeamBuilder.vue
+++ b/src/views/TeamBuilder.vue
@@ -44,6 +44,10 @@ const selectedPlayerRatingHistory = ref<NBA2KRating[]>([]);
 const selectedPlayerName = ref<string>("");
 
 const cardsFlipped = ref<Map<any, boolean>>(new Map());
+
+// Slot index -> name of the player being fetched into it. Keyed by slot rather
+// than a single flag so two slots can be filling at once.
+const pendingPlayers = ref<Map<number, string>>(new Map());
 const showPlayerStatsDialog = ref<boolean>(false);
 
 const selectedView = ref<string>("Default");
@@ -107,20 +111,33 @@ const addPlayer = (index: number) => {
 
 const addPlayerFromDialog = async (player: any) => {
     const playerIndex = selectedPlayerIndex.value;
+    // The dialog is only opened from a slot, so this is set - but the ref is
+    // nullable and there is no slot to report progress against without it.
+    if (playerIndex === null) return;
+
+    const playerName = `${player.first_name} ${player.last_name}`;
+
+    // The toast lives in the corner, far from the slot the player is landing
+    // in. Marking the slot pending lets the card show the same wait in place.
+    pendingPlayers.value.set(playerIndex, playerName);
 
     toast.promise(
         async () => {
-            const { id } = player;
-            const { data: playerStats, ratingHistory } =
-                await getPlayerStats(id);
-            const updatedPlayerData = { ...player, playerStats, ratingHistory };
-            selectedPlayersData.value.set(playerIndex, updatedPlayerData);
-            cardsFlipped.value.set(playerIndex, false);
+            try {
+                const { id } = player;
+                const { data: playerStats, ratingHistory } =
+                    await getPlayerStats(id);
+                const updatedPlayerData = { ...player, playerStats, ratingHistory };
+                selectedPlayersData.value.set(playerIndex, updatedPlayerData);
+                cardsFlipped.value.set(playerIndex, false);
+            } finally {
+                pendingPlayers.value.delete(playerIndex);
+            }
         },
         {
-            loading: 'Adding player...',
-            success: `Added ${player.first_name} ${player.last_name} to your team`,
-            error: 'Failed to add player',
+            loading: `Adding ${playerName} to ${slotLabel(playerIndex)}...`,
+            success: `Added ${playerName} to ${slotLabel(playerIndex)}`,
+            error: `Failed to add ${playerName} to ${slotLabel(playerIndex)}`,
         }
     );
 };
@@ -178,6 +195,7 @@ const {
 } = useRosterDragDrop({
     onSwap: swapSlots,
     isOccupied: (slot) => selectedPlayersData.value.has(slot),
+    isPending: (slot) => pendingPlayers.value.has(slot),
     describeSlot,
 });
 
@@ -303,6 +321,7 @@ const saveTeam = () => {
             <RosterSection
                 :selected-players="selectedPlayersData"
                 :cards-flipped="cardsFlipped"
+                :pending-players="pendingPlayers"
                 :dragging-slot="draggingSlot"
                 :drop-target-slot="dropTargetSlot"
                 :picked-up-slot="pickedUpSlot"

--- a/tests/composables/usePlayerStatsPreferences.test.ts
+++ b/tests/composables/usePlayerStatsPreferences.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { usePlayerStatsPreferences } from '@/composables/usePlayerStatsPreferences';
+
+describe('usePlayerStatsPreferences', () => {
+  it('provides default preferences', () => {
+    const { preferences } = usePlayerStatsPreferences();
+    expect(preferences.value.seasonFormat).toBe('YYYY-YY');
+    expect(preferences.value.statMode).toBe('per_game');
+    expect(preferences.value.showCareerSummary).toBe(true);
+  });
+
+  it('allows updating preferences', () => {
+    const { preferences } = usePlayerStatsPreferences();
+    preferences.value.seasonFormat = 'YYYY';
+    expect(preferences.value.seasonFormat).toBe('YYYY');
+  });
+
+  it('resets preferences back to defaults', () => {
+    const { preferences, resetPreferences } = usePlayerStatsPreferences();
+    preferences.value.seasonFormat = 'YYYY+1';
+    preferences.value.statMode = 'totals';
+    preferences.value.showCareerSummary = false;
+
+    resetPreferences();
+
+    expect(preferences.value.seasonFormat).toBe('YYYY-YY');
+    expect(preferences.value.statMode).toBe('per_game');
+    expect(preferences.value.showCareerSummary).toBe(true);
+  });
+});

--- a/tests/composables/useRosterDragDrop.test.ts
+++ b/tests/composables/useRosterDragDrop.test.ts
@@ -69,11 +69,12 @@ describe("swapSetMembers", () => {
 });
 
 // Slots 6 and 7 hold players; 9 is empty. Mirrors the bench in the UI.
-const setup = (occupied = new Set([6, 7])) => {
+const setup = (occupied = new Set([6, 7]), pending = new Set<number>()) => {
     const onSwap = vi.fn();
     const dragDrop = useRosterDragDrop({
         onSwap,
         isOccupied: (slot) => occupied.has(slot),
+        isPending: (slot) => pending.has(slot),
         describeSlot: (slot) => `slot ${slot}`,
     });
     return { onSwap, ...dragDrop };
@@ -191,5 +192,52 @@ describe("useRosterDragDrop - keyboard pickup", () => {
         togglePickup(6);
         startDrag(7, dragEvent());
         expect(pickedUpSlot.value).toBeNull();
+    });
+});
+
+// A pending slot renders empty but already has a player on the way. Anything
+// moved into it would be overwritten the moment that fetch lands.
+describe("useRosterDragDrop - pending slots", () => {
+    it("refuses a pointer drop onto a pending slot", () => {
+        const { onSwap, startDrag, dropOnSlot } = setup(new Set([6]), new Set([9]));
+
+        startDrag(6, dragEvent());
+        dropOnSlot(9, dragEvent());
+        expect(onSwap).not.toHaveBeenCalled();
+    });
+
+    it("does not offer a pending slot as a drop target", () => {
+        const { startDrag, dragOverSlot, dropTargetSlot } = setup(
+            new Set([6]),
+            new Set([9]),
+        );
+        const event = dragEvent();
+
+        startDrag(6, dragEvent());
+        dragOverSlot(9, event);
+        expect(dropTargetSlot.value).toBeNull();
+        // Leaving the default in place is what makes the browser refuse the drop.
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("keeps a keyboard pickup held when the target slot is pending", () => {
+        const { onSwap, togglePickup, pickedUpSlot, liveMessage } = setup(
+            new Set([6]),
+            new Set([9]),
+        );
+
+        togglePickup(6);
+        togglePickup(9);
+        expect(onSwap).not.toHaveBeenCalled();
+        expect(pickedUpSlot.value).toBe(6);
+        expect(liveMessage.value).toContain("still loading");
+    });
+
+    it("still allows moves between slots that are not pending", () => {
+        const { onSwap, startDrag, dropOnSlot } = setup(new Set([6]), new Set([9]));
+
+        startDrag(6, dragEvent());
+        dropOnSlot(7, dragEvent());
+        expect(onSwap).toHaveBeenCalledWith(6, 7);
     });
 });

--- a/tests/constants/playerStats.test.ts
+++ b/tests/constants/playerStats.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatSeason,
+  formatCellValue,
+  careerAverages,
+  careerTotals,
+} from '@/constants/playerStats';
+
+describe('playerStats helpers', () => {
+  describe('formatSeason', () => {
+    it('formats season start year to standard NBA format YYYY-YY by default', () => {
+      expect(formatSeason(2010)).toBe('2010-11');
+      expect(formatSeason(2019)).toBe('2019-20');
+      expect(formatSeason(1999)).toBe('1999-00');
+      expect(formatSeason(2009)).toBe('2009-10');
+    });
+
+    it('formats season to full range YYYY-YYYY', () => {
+      expect(formatSeason(2010, 'YYYY-YYYY')).toBe('2010-2011');
+      expect(formatSeason(2019, 'YYYY-YYYY')).toBe('2019-2020');
+    });
+
+    it('formats season to start year YYYY', () => {
+      expect(formatSeason(2010, 'YYYY')).toBe('2010');
+    });
+
+    it('formats season to end year YYYY+1', () => {
+      expect(formatSeason(2010, 'YYYY+1')).toBe('2011');
+    });
+
+    it('preserves already formatted strings or invalid input', () => {
+      expect(formatSeason('2010-11')).toBe('2010-11');
+      expect(formatSeason(null)).toBe('—');
+      expect(formatSeason(undefined)).toBe('—');
+    });
+  });
+
+  describe('formatCellValue', () => {
+    const mockRow = {
+      season: 2010,
+      games_played: 81,
+      min: 17.9,
+      pts: 5.6,
+      fg_pct: 0.394,
+    };
+
+    it('formats season field according to preference', () => {
+      expect(formatCellValue('season', mockRow, 'YYYY-YY')).toBe('2010-11');
+      expect(formatCellValue('season', mockRow, 'YYYY')).toBe('2010');
+    });
+
+    it('formats per_game counting stats and percentages', () => {
+      expect(formatCellValue('pts', mockRow, 'YYYY-YY', 'per_game')).toBe('5.6');
+      expect(formatCellValue('fg_pct', mockRow, 'YYYY-YY', 'per_game')).toBe('.394');
+    });
+
+    it('formats totals mode counting stats', () => {
+      expect(formatCellValue('pts', mockRow, 'YYYY-YY', 'totals')).toBe('454');
+      expect(formatCellValue('fg_pct', mockRow, 'YYYY-YY', 'totals')).toBe('.394');
+    });
+  });
+
+  describe('careerTotals', () => {
+    it('calculates total career counting stats accurately', () => {
+      const mockSeasons = [
+        { season: 2010, games_played: 81, pts: 5.6, fgm: 2, fga: 5, fg_pct: 0.4 },
+        { season: 2011, games_played: 66, pts: 6.0, fgm: 2.3, fga: 5.5, fg_pct: 0.418 },
+      ] as any[];
+
+      const totals = careerTotals(mockSeasons);
+      expect(totals).not.toBeNull();
+      expect(totals?.games_played).toBe(147);
+      expect(totals?.seasons).toBe(2);
+      expect(totals?.pts).toBe(850);
+    });
+  });
+});


### PR DESCRIPTION
## What

Three related pieces of work on the Team Builder.

**Stats display preferences.** A Preferences popover on the player stats
dialog controls season notation, per-game vs season totals, and whether the
career summary row is shown. Choices persist across sessions. Season formats
are picked by their rendered sample (`2010-11`, `2010-2011`, ...) rather than
by a format token.

**Per-slot add feedback.** The add-player toast sat in the corner and said only
"Adding player...", with nothing tying the wait to the slot it was for. Slots
being filled now show a spinner, the incoming player's name, and the
destination, and the toast names the slot too. Pending slots are tracked in a
map keyed by slot so two can fill at once.

**Drag guard.** A pending slot renders empty but is already spoken for, so it
now refuses drags and keyboard moves — anything moved into it would be
overwritten the moment the fetch lands.

## Notable details

- `careerTotals()` reconstructs totals by multiplying each season row back out
  by its games played, because the API only returns per-game figures. Shooting
  percentages stay derived from makes over attempts rather than summed.
- Pending state is cleared in a `finally`, so a failed fetch cannot strand a
  slot.
- The `Checkbox` primitive now mirrors Reka's `data-state` attribute. The
  app-wide checkbox styling in `main.css` selects on it with `!important`, so
  without it a checked box painted as if it were empty.
- The popover's styling lives in `main.css`, not a scoped block: `PopoverPortal`
  teleports the panel out of the component so the scope attribute never reaches
  it, and the panel has to override modal-scale `[role="dialog"]` rules that are
  `!important` inside a cascade layer — layer order reverses for important
  declarations, so an unlayered rule loses to them regardless of specificity.

## Testing

- `pnpm test` — 57 passing, including new coverage for `careerTotals`, the
  preferences store, and the pending-slot drag guard.
- `pnpm type-check` and `pnpm build` clean.
- Driven manually in the browser: all four season formats, per-game/totals,
  the career row toggle, reset to defaults, two slots loading simultaneously,
  and a drag onto a pending slot being refused while a drag onto a normal
  empty slot still works.
