### PR TITLE
feat(player-stats): highlight career highs in the season table

### DIFF
--- a/src/components/TeamBuilder/PlayerStatsDialog.vue
+++ b/src/components/TeamBuilder/PlayerStatsDialog.vue
@@ -36,6 +36,10 @@ import {
   formatCellValue,
   careerAverages,
   careerTotals,
+  careerBests,
+  isCareerBest,
+  CAREER_BEST_MIN_GAMES,
+  LOWER_IS_BETTER,
   type StatColumn,
 } from "@/constants/playerStats";
 import { usePlayerStatsPreferences } from "@/composables/usePlayerStatsPreferences";
@@ -172,6 +176,22 @@ const summaryData = computed(() => {
   return careerAverages(rows);
 });
 
+// Highs are read off the unsorted rows, and recomputed for totals mode because
+// a 60-game season can lead per game while a 82-game one leads on the season.
+const bests = computed(() => {
+  if (!preferences.value.highlightCareerHighs) return null;
+  const rows = Array.isArray(localData.value) ? localData.value : [];
+  if (rows.length < 2) return null;
+  return careerBests(rows, preferences.value.statMode);
+});
+
+const highlightCell = (field: string, row: any) =>
+  isCareerBest(field, row, bests.value, preferences.value.statMode);
+
+// Colour alone can't carry the meaning, so the marked cell says what it is.
+const highlightTitle = (field: string) =>
+  LOWER_IS_BETTER.has(field) ? 'Career low' : 'Career high';
+
 const getColumnTitle = (column: StatColumn) => {
   if (preferences.value.statMode === 'totals' && COUNTING_STATS.includes(column.field)) {
     return column.title.replace(' per Game', ' Total in Season');
@@ -284,6 +304,20 @@ const columns = STAT_COLUMNS;
               </span>
             </label>
 
+            <label for="highlight-career-highs" class="prefs-check-row">
+              <Checkbox
+                id="highlight-career-highs"
+                v-model:checked="preferences.highlightCareerHighs"
+              />
+              <span class="prefs-check-text">
+                <span class="prefs-check-title">Highlight career highs</span>
+                <p>
+                  Best season in each column, in orange. Seasons under
+                  {{ CAREER_BEST_MIN_GAMES }} games don't count.
+                </p>
+              </span>
+            </label>
+
             <footer class="prefs-foot">
               <Button variant="ghost" size="sm" class="prefs-reset" @click="resetPreferences">
                 <RotateCcw class="h-3 w-3" />
@@ -377,6 +411,8 @@ const columns = STAT_COLUMNS;
                   v-for="column in columns"
                   :key="column.name"
                   class="text-gray-300 whitespace-nowrap"
+                  :class="{ 'stat-career-best': highlightCell(column.field, row) }"
+                  :title="highlightCell(column.field, row) ? highlightTitle(column.field) : undefined"
                 >
                   {{ formatCellValue(column.field, row, preferences.seasonFormat, preferences.statMode) }}
                 </TableCell>
@@ -468,6 +504,13 @@ const columns = STAT_COLUMNS;
   margin-top: 0.125rem;
   font-size: 0.6875rem;
   opacity: 0.7;
+}
+
+/* Career best in a column. The scoped attribute takes this past the .text-gray-300
+   utility on the same cell, so no !important is needed. */
+.stat-career-best {
+  color: hsl(var(--primary));
+  font-weight: 700;
 }
 
 .rating-history {

--- a/src/composables/usePlayerStatsPreferences.ts
+++ b/src/composables/usePlayerStatsPreferences.ts
@@ -5,18 +5,24 @@ export interface PlayerStatsPreferences {
   seasonFormat: SeasonFormat;
   statMode: StatDisplayMode;
   showCareerSummary: boolean;
+  highlightCareerHighs: boolean;
 }
 
 const DEFAULT_PREFERENCES: PlayerStatsPreferences = {
   seasonFormat: 'YYYY-YY', // Standard NBA format (e.g. 2010-11)
   statMode: 'per_game',
   showCareerSummary: true,
+  highlightCareerHighs: true,
 };
 
 export const usePlayerStatsPreferences = () => {
   const preferences = useStorage<PlayerStatsPreferences>(
     'nba-player-stats-preferences',
-    DEFAULT_PREFERENCES
+    DEFAULT_PREFERENCES,
+    undefined,
+    // Without this, anyone with preferences already in localStorage gets
+    // `undefined` for every key added after they first saved them.
+    { mergeDefaults: true }
   );
 
   const resetPreferences = () => {

--- a/src/constants/playerStats.ts
+++ b/src/constants/playerStats.ts
@@ -40,7 +40,7 @@ export const STAT_COLUMNS: StatColumn[] = [
 ];
 
 /** Stats where a lower number is the better performance. */
-const LOWER_IS_BETTER = new Set(['turnover', 'pf']);
+export const LOWER_IS_BETTER = new Set(['turnover', 'pf']);
 
 export const isBetter = (field: string, value: number, other: number): boolean =>
     LOWER_IS_BETTER.has(field) ? value < other : value > other;
@@ -184,6 +184,98 @@ export const formatSeason = (
         default:
             return `${year}`;
     }
+};
+
+/**
+ * The number a cell shows, as a number rather than a string, rounded to the
+ * precision it is displayed at so that two seasons printed identically are also
+ * compared identically. Returns null for cells that aren't a comparable stat.
+ */
+export const statCellValue = (
+    field: string,
+    row: any,
+    statMode: StatDisplayMode = 'per_game',
+): number | null => {
+    if (!row || field === 'season') return null;
+
+    if (field === 'games_played') {
+        const games = Number(row.games_played);
+        return Number.isFinite(games) ? Math.round(games) : null;
+    }
+
+    const val = Number(row[field]);
+    if (!Number.isFinite(val)) return null;
+
+    if (field in PERCENTAGE_SOURCES) return Math.round(val * 1000) / 1000;
+
+    if (statMode === 'totals' && COUNTING_STATS.includes(field)) {
+        const games = Number(row.games_played);
+        if (Number.isFinite(games) && games > 0) return Math.round(val * games);
+    }
+
+    return Math.round(val * 10) / 10;
+};
+
+/**
+ * Seasons shorter than this are left out of the career-high hunt: a 6-game
+ * cameo can top a percentage column on a handful of attempts, which is a
+ * sample-size artefact rather than a peak.
+ */
+export const CAREER_BEST_MIN_GAMES = 15;
+
+export type CareerBests = {
+    /** Best displayed value per stat field. Fields with no usable value are absent. */
+    values: Record<string, number>;
+    /** Games a season needs to be eligible; 0 when the threshold was dropped. */
+    minGames: number;
+};
+
+/**
+ * Per-column career best across a player's seasons. "Best" follows
+ * LOWER_IS_BETTER, so the marked turnover and foul seasons are the cleanest
+ * ones rather than the worst ones.
+ */
+export const careerBests = (
+    seasons: PlayerSeasonStats[] | undefined | null,
+    statMode: StatDisplayMode = 'per_game',
+): CareerBests => {
+    const rows = (seasons ?? []).filter(Boolean) as any[];
+    const qualified = rows.filter(
+        (row) => Number(row.games_played) >= CAREER_BEST_MIN_GAMES,
+    );
+    // A career made up entirely of short seasons still has a peak, so only
+    // apply the threshold when it leaves something to compare.
+    const pool = qualified.length ? qualified : rows;
+    const minGames = qualified.length ? CAREER_BEST_MIN_GAMES : 0;
+
+    const values: Record<string, number> = {};
+    for (const column of STAT_COLUMNS) {
+        if (column.field === 'season') continue;
+
+        let best: number | null = null;
+        for (const row of pool) {
+            const value = statCellValue(column.field, row, statMode);
+            if (value === null) continue;
+            if (best === null || isBetter(column.field, value, best)) best = value;
+        }
+        if (best !== null) values[column.field] = best;
+    }
+
+    return { values, minGames };
+};
+
+/** Whether this cell is the player's career best in its column. Ties all mark. */
+export const isCareerBest = (
+    field: string,
+    row: any,
+    bests: CareerBests | null,
+    statMode: StatDisplayMode = 'per_game',
+): boolean => {
+    if (!bests || !(field in bests.values)) return false;
+    if (Number(row?.games_played) < bests.minGames) return false;
+
+    const value = statCellValue(field, row, statMode);
+    return value !== null && value === bests.values[field];
 };
 
 /** Formats a table cell value based on column field, season format preference, and stat mode. */


### PR DESCRIPTION
Marks the best season in each column of the player stats dialog in the primary orange, so a career's peaks read off the table at a glance instead of needing a column-by-column scan.

## Behaviour

- **Direction follows `LOWER_IS_BETTER`.** The marked turnover and foul seasons are the cleanest ones, not the worst ones, and the cell title reads "Career low" there rather than "Career high".
- **Seasons under 15 games are excluded.** A six-game cameo can top a percentage column on a handful of attempts. The threshold is dropped for players who never had a 15-game season, so a fringe career still shows its peak.
- **Comparison runs on the displayed value**, rounded to the precision the cell shows, so two seasons printed identically both mark.
- **Highs are recomputed for totals mode**, where a longer season can lead a column that a shorter one leads per game.
- Ties all mark.

## Preference

New "Highlight career highs" checkbox in the stats Preferences popover, on by default.

Preference storage now passes `mergeDefaults: true` to `useStorage`. Without it, everyone with preferences already in localStorage would read `undefined` for the new key and never see the feature — and the same would apply to every key added after this one.

## Accessibility

Colour alone doesn't carry the meaning: each marked cell gets a `title` of "Career high" / "Career low".

## Verification

- `pnpm run type-check` clean
- `pnpm run test` — 57 passed (7 files)
- `pnpm run lint` not run; it still crashes at startup from the `ajv` override, unrelated to this change