### PR TITLE
fix(deploy): drop environment: production from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production
+    # No `environment:` here — declaring one changes the OIDC token's `sub`
+    # claim to repo:...:environment:production instead of
+    # repo:...:ref:refs/heads/main, which the deploy role's trust policy
+    # doesn't match (and there's no environment protection rule configured
+    # to make declaring one worth it).
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Fixes the OIDC AssumeRoleWithWebIdentity failure on the first live run of deploy.yml (nba-central#14) — see commit message.