### PR TITLE
fix(auth): surface Logto sign-in errors instead of hanging on Redirecting

### DIFF
--- a/src/composables/useLogtoSignIn.ts
+++ b/src/composables/useLogtoSignIn.ts
@@ -1,0 +1,45 @@
+import { ref } from 'vue';
+import { useLogto } from '@logto/vue';
+import { useRouter } from 'vue-router';
+import { getApiErrorMessage } from '@/composables/useApiErrorMessage';
+
+interface SignInOptions {
+    redirectUri: string;
+    firstScreen?: 'register';
+}
+
+// useLogto()'s `error` ref is a single app-wide singleton shared by every
+// Logto operation (signIn, getAccessToken, ...) and is never reset by the
+// library — an unrelated token refresh failing elsewhere in the app would
+// otherwise show up here as a false "sign-in failed". We only treat it as
+// our own failure if this call is the one that just set it.
+export function useLogtoSignIn(buildOptions: () => SignInOptions) {
+    const { signIn, isAuthenticated, error: logtoError } = useLogto();
+    const router = useRouter();
+    const error = ref<string>();
+    const isSigningIn = ref(false);
+
+    async function startSignIn() {
+        if (isAuthenticated.value) {
+            router.push('/');
+            return;
+        }
+        if (isSigningIn.value) {
+            return;
+        }
+
+        isSigningIn.value = true;
+        error.value = undefined;
+        const errorBeforeCall = logtoError.value;
+        await signIn(buildOptions());
+        if (logtoError.value && logtoError.value !== errorBeforeCall) {
+            error.value = getApiErrorMessage(
+                logtoError.value,
+                'Something went wrong. Please try again.',
+            );
+        }
+        isSigningIn.value = false;
+    }
+
+    return { error, isSigningIn, isAuthenticated, startSignIn };
+}

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
-import { useLogto } from '@logto/vue';
-import { useRouter } from 'vue-router';
+import { useLogtoSignIn } from '@/composables/useLogtoSignIn';
 import { Button } from '@/components/ui/button';
-
-const { signIn, isAuthenticated, error } = useLogto();
-const router = useRouter();
 
 // Logto has no embeddable sign-in form (unlike Clerk's <SignIn>) — it
 // redirects to its own hosted sign-in page. This view's only job is to kick
@@ -13,26 +9,22 @@ const router = useRouter();
 //
 // isAuthenticated only checks that tokens are present, not that they're
 // unexpired — a stale session left here with nothing to do, stuck on
-// "Redirecting to sign in..." forever. Send them home instead; anything
-// that actually needs a fresh token refreshes it on use.
-function startSignIn() {
-    signIn({ redirectUri: `${window.location.origin}/callback` });
-}
+// "Redirecting to sign in..." forever. useLogtoSignIn sends them home
+// instead; anything that actually needs a fresh token refreshes it on use.
+const { error, isSigningIn, startSignIn } = useLogtoSignIn(() => ({
+    redirectUri: `${window.location.origin}/callback`,
+}));
 
-onMounted(() => {
-    if (isAuthenticated.value) {
-        router.push('/');
-    } else {
-        startSignIn();
-    }
-});
+onMounted(startSignIn);
 </script>
 
 <template>
     <div class="auth-container">
         <template v-if="error">
-            <p>Couldn't reach sign-in. {{ error.message }}</p>
-            <Button @click="startSignIn">Try again</Button>
+            <p class="text-destructive">Couldn't sign in. {{ error }}</p>
+            <Button variant="outline" :disabled="isSigningIn" @click="startSignIn">
+                Try again
+            </Button>
         </template>
         <p v-else>Redirecting to sign in...</p>
     </div>
@@ -41,8 +33,10 @@ onMounted(() => {
 <style scoped>
 .auth-container {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
+    justify-content: center;
+    gap: 1rem;
     min-height: 80vh;
     padding: 2rem;
     background-color: var(--vt-c-black-soft);

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -2,8 +2,9 @@
 import { onMounted } from 'vue';
 import { useLogto } from '@logto/vue';
 import { useRouter } from 'vue-router';
+import { Button } from '@/components/ui/button';
 
-const { signIn, isAuthenticated } = useLogto();
+const { signIn, isAuthenticated, error } = useLogto();
 const router = useRouter();
 
 // Logto has no embeddable sign-in form (unlike Clerk's <SignIn>) — it
@@ -14,18 +15,26 @@ const router = useRouter();
 // unexpired — a stale session left here with nothing to do, stuck on
 // "Redirecting to sign in..." forever. Send them home instead; anything
 // that actually needs a fresh token refreshes it on use.
+function startSignIn() {
+    signIn({ redirectUri: `${window.location.origin}/callback` });
+}
+
 onMounted(() => {
     if (isAuthenticated.value) {
         router.push('/');
     } else {
-        signIn({ redirectUri: `${window.location.origin}/callback` });
+        startSignIn();
     }
 });
 </script>
 
 <template>
     <div class="auth-container">
-        <p>Redirecting to sign in...</p>
+        <template v-if="error">
+            <p>Couldn't reach sign-in. {{ error.message }}</p>
+            <Button @click="startSignIn">Try again</Button>
+        </template>
+        <p v-else>Redirecting to sign in...</p>
     </div>
 </template>
 

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -1,26 +1,35 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
 import { useLogto } from '@logto/vue';
+import { Button } from '@/components/ui/button';
 
-const { signIn, isAuthenticated } = useLogto();
+const { signIn, isAuthenticated, error } = useLogto();
 
 // Same redirect as Login.vue, just landing on Logto's registration screen
 // first instead of sign-in — Logto's hosted sign-in/register pages cross-link
 // to each other from there, same as the sign-in-vs-create-account link on
 // Logto's own demo app.
+function startSignIn() {
+    signIn({
+        redirectUri: `${window.location.origin}/callback`,
+        firstScreen: 'register',
+    });
+}
+
 onMounted(() => {
     if (!isAuthenticated.value) {
-        signIn({
-            redirectUri: `${window.location.origin}/callback`,
-            firstScreen: 'register',
-        });
+        startSignIn();
     }
 });
 </script>
 
 <template>
     <div class="auth-container">
-        <p>Redirecting to sign up...</p>
+        <template v-if="error">
+            <p>Couldn't reach sign-up. {{ error.message }}</p>
+            <Button @click="startSignIn">Try again</Button>
+        </template>
+        <p v-else>Redirecting to sign up...</p>
     </div>
 </template>
 

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -1,33 +1,27 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
-import { useLogto } from '@logto/vue';
+import { useLogtoSignIn } from '@/composables/useLogtoSignIn';
 import { Button } from '@/components/ui/button';
-
-const { signIn, isAuthenticated, error } = useLogto();
 
 // Same redirect as Login.vue, just landing on Logto's registration screen
 // first instead of sign-in — Logto's hosted sign-in/register pages cross-link
 // to each other from there, same as the sign-in-vs-create-account link on
 // Logto's own demo app.
-function startSignIn() {
-    signIn({
-        redirectUri: `${window.location.origin}/callback`,
-        firstScreen: 'register',
-    });
-}
+const { error, isSigningIn, startSignIn } = useLogtoSignIn(() => ({
+    redirectUri: `${window.location.origin}/callback`,
+    firstScreen: 'register',
+}));
 
-onMounted(() => {
-    if (!isAuthenticated.value) {
-        startSignIn();
-    }
-});
+onMounted(startSignIn);
 </script>
 
 <template>
     <div class="auth-container">
         <template v-if="error">
-            <p>Couldn't reach sign-up. {{ error.message }}</p>
-            <Button @click="startSignIn">Try again</Button>
+            <p class="text-destructive">Couldn't sign up. {{ error }}</p>
+            <Button variant="outline" :disabled="isSigningIn" @click="startSignIn">
+                Try again
+            </Button>
         </template>
         <p v-else>Redirecting to sign up...</p>
     </div>
@@ -36,8 +30,10 @@ onMounted(() => {
 <style scoped>
 .auth-container {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
+    justify-content: center;
+    gap: 1rem;
     min-height: 80vh;
     padding: 2rem;
     background-color: var(--vt-c-black-soft);


### PR DESCRIPTION
## What

signIn() failures were silently swallowed. Login.vue / SignUp.vue now read `error` from `useLogto()` and show a retry button instead of hanging forever on "Redirecting to sign in...".

## Root cause

`@logto/vue`'s plugin wraps every method (including `signIn`) in a try/catch that sets a reactive `error` ref but never rethrows (`@logto/vue/lib/plugin.js`). `signIn()` does a network round-trip (fetches `${endpoint}/oidc/.well-known/openid-configuration`) *before* it navigates, so any transient failure there — a slow/cold Logto instance, a dropped request — leaves `signIn()` resolved-but-failed with nothing visible.

Login.vue / SignUp.vue never read `error`, so the page just sat on its static "Redirecting to sign in..." text forever. And since `RouterLink` doesn't remount a component when navigating to the route that's already active, clicking the nav "Login" item again did nothing — `onMounted" (the only place `signIn()` is called) never re-fired.

## Fix

Read `error` from `useLogto()`; when set, show the message plus a "Try again" button that re-invokes `signIn()` directly from the stuck page — no navigation/remount needed.

## Verification

- `pnpm type-check` — clean
- `pnpm build` — clean
- `pnpm test` — 57/57 passing
- `pnpm lint` — fails at startup on this repo regardless of this change (pre-existing ajv/ESLint 10 issue, see repo memory)
