### PR TITLE
feat(team-builder): persist full teams and make /teams real

### DIFF
--- a/src/composables/useTeamPersistence.ts
+++ b/src/composables/useTeamPersistence.ts
@@ -1,0 +1,106 @@
+import type { Player } from "@/models/types";
+import type {
+    EntityRef,
+    PlayerSnapshot,
+    SaveTeamPayload,
+    SavedTeam,
+    TeamArenaRef,
+    TeamRosterEntry,
+} from "@/models/api";
+
+interface BuilderState {
+    teamName: string;
+    teamDescription: string;
+    teamCity: string;
+    teamCountry: string;
+    teamLogo: string;
+    selectedPlayersData: Map<number, any>;
+    teamCoach: any;
+    teamArena: any;
+    teamGM: any;
+}
+
+// Career stats/rating history are fetched per slot (getPlayerStats) rather
+// than saved on the team - they're derived from the player's id, not part
+// of the roster choice, and re-fetching keeps a saved team from going stale
+// the moment a player's career continues.
+const toSnapshot = (player: any): PlayerSnapshot => {
+    const {
+        playerStats: _playerStats,
+        ratingHistory: _ratingHistory,
+        heightAndWeight: _heightAndWeight,
+        ...snapshot
+    } = player;
+    return snapshot as PlayerSnapshot;
+};
+
+const toEntityRef = (entity: any): EntityRef | null => {
+    if (!entity) return null;
+    return {
+        name: entity.name,
+        isCustom: !!entity.isCustom,
+        uuid: entity.coachUUID || entity.gmUUID || entity.playerUUID || undefined,
+    };
+};
+
+const toArenaRef = (arena: any): TeamArenaRef | null => {
+    if (!arena) return null;
+    return { name: arena.name, imgLink: arena.imgLink };
+};
+
+/**
+ * Builds the save/update payload from the builder's live refs. Roster is
+ * sorted by slot - Map iteration is insertion order, which would save a
+ * reordered roster in the order the players happened to be added.
+ */
+export const serializeTeam = (state: BuilderState): SaveTeamPayload => {
+    const roster: TeamRosterEntry[] = Array.from(
+        state.selectedPlayersData.entries(),
+    )
+        .sort(([a], [b]) => a - b)
+        .map(([slot, player]) => ({ slot, player: toSnapshot(player) }));
+
+    return {
+        title: state.teamName,
+        description: state.teamDescription,
+        city: state.teamCity,
+        country: state.teamCountry,
+        logoUrl: state.teamLogo,
+        roster,
+        coach: toEntityRef(state.teamCoach),
+        gm: toEntityRef(state.teamGM),
+        arena: toArenaRef(state.teamArena),
+    };
+};
+
+export interface HydratedTeam {
+    teamName: string;
+    teamDescription: string;
+    teamCity: string;
+    teamCountry: string;
+    teamLogo: string;
+    players: Map<number, Player>;
+    teamCoach: EntityRef | null;
+    teamArena: TeamArenaRef | null;
+    teamGM: EntityRef | null;
+}
+
+/** Inverse of serializeTeam - tolerates a null coach/GM/arena and an empty roster. */
+export const hydrateTeam = (saved: SavedTeam): HydratedTeam => {
+    const players = new Map<number, Player>();
+    for (const entry of saved.roster ?? []) {
+        players.set(entry.slot, entry.player);
+    }
+
+    return {
+        teamName: saved.title ?? "",
+        teamDescription: saved.description ?? "",
+        teamCity: saved.city ?? "",
+        teamCountry: saved.country ?? "",
+        teamLogo: saved.logoUrl ?? "",
+        players,
+        teamCoach: saved.coach ?? null,
+        teamArena: saved.arena ?? null,
+        teamGM: saved.gm ?? null,
+    };
+};

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -1,4 +1,4 @@
-import type { NBA2KRating, RatingSource } from './types';
+import type { NBA2KRating, Player, RatingSource } from './types';
 
 // #region File API Types
 export interface InitiateMultipartUploadPayload {
@@ -51,40 +51,82 @@ export interface DeleteFileResponse {
 }
 // #endregion
 
-//#region User API Types
-export interface GetUserPayload {
-    userId: string;
-}
-
-export interface GetUserResponse {
-    id: string;
-    email: string;
-    name: string;
-    // Add other user fields
-}
-
-// #endregion
-
 //#region Team API Types
-export interface CreateTeamPayload {
-    name: string;
-    description?: string;
-    players?: string[];
+
+// A player as stored on a saved team - the same `Player` union already used
+// while building a roster (API and custom players have different field
+// sets), snapshotted so a saved team renders exactly as it did when saved
+// rather than drifting with later roster/rating changes upstream. `fullName`
+// is always set on a player before it reaches the roster, so it's the one
+// required field here.
+export type PlayerSnapshot = Player & { fullName: string };
+
+export interface TeamRosterEntry {
+    slot: number;
+    player: PlayerSnapshot;
 }
 
-export interface CreateTeamResponse {
-    message: string;
-    team: {
-        teamUUID: string;
-        title: string;
-        description: string;
-        players: string[];
-        username: string;
-        userUUID: string;
-        createdAt: number;
-        updatedAt: number;
-    };
+// Coaches/GMs from the checked-in JSON are only identified by name; custom
+// ones also carry a UUID.
+export interface EntityRef {
+    name: string;
+    isCustom: boolean;
+    uuid?: string;
 }
+
+export interface TeamArenaRef {
+    name: string;
+    imgLink?: string;
+}
+
+export interface SaveTeamPayload {
+    title: string;
+    description?: string;
+    city?: string;
+    country?: string;
+    logoUrl?: string;
+    roster: TeamRosterEntry[];
+    coach: EntityRef | null;
+    gm: EntityRef | null;
+    arena: TeamArenaRef | null;
+}
+
+export interface UpdateTeamPayload extends SaveTeamPayload {
+    teamUUID: string;
+}
+
+export interface SavedTeam {
+    teamUUID: string;
+    userUUID: string;
+    username: string;
+    title: string;
+    description: string;
+    city: string;
+    country: string;
+    logoUrl: string;
+    playerCount: number;
+    roster: TeamRosterEntry[];
+    coach: EntityRef | null;
+    gm: EntityRef | null;
+    arena: TeamArenaRef | null;
+    favorited: boolean;
+    label: string;
+    lastViewed: number;
+    createdAt: number;
+    updatedAt: number;
+}
+
+export type TeamSummary = Omit<SavedTeam, 'roster' | 'coach' | 'gm' | 'arena'>;
+
+export type ApiResult<T> =
+    | { success: true; data: T }
+    | { success: false; error: string };
+
+export type CreateTeamResponse = ApiResult<SavedTeam>;
+export type ListTeamsResponse = ApiResult<{ teams: TeamSummary[] }>;
+export type GetTeamResponse = ApiResult<SavedTeam>;
+export type UpdateTeamResponse = ApiResult<SavedTeam>;
+export type DeleteTeamResponse = ApiResult<void>;
 
 // #endregion
 
@@ -137,6 +179,7 @@ export interface PlayerRecord {
     ratingSource?: RatingSource;
     // Specific positions (PG/SG/SF/PF/C) from 2K, when the player is rated.
     positions?: string[];
+    isCustom?: boolean;
 }
 
 export interface GetPlayersResponse {

--- a/src/network/api.ts
+++ b/src/network/api.ts
@@ -8,10 +8,13 @@ import type {
     GetMultipartSignedUrlsResponse,
     DeleteFilePayload,
     DeleteFileResponse,
-    GetUserPayload,
-    GetUserResponse,
-    CreateTeamPayload,
+    SaveTeamPayload,
+    UpdateTeamPayload,
     CreateTeamResponse,
+    ListTeamsResponse,
+    GetTeamResponse,
+    UpdateTeamResponse,
+    DeleteTeamResponse,
     GetTeamLogosResponse,
     GetNewsResponse,
     GetPlayersParams,
@@ -86,10 +89,6 @@ export const fileApi = {
 
 // Users API - matches USERS_ROUTES in CDK
 export const userApi = {
-    getUser: async (payload: GetUserPayload): Promise<GetUserResponse> => {
-        const response = await api.post('/api/users/get', payload);
-        return response.data;
-    },
     saveUserData: async (payload: {
         userId: string;
         [key: string]: any;
@@ -102,9 +101,27 @@ export const userApi = {
 // Teams API - matches TEAMS_ROUTES in CDK
 export const teamApi = {
     createTeam: async (
-        payload: CreateTeamPayload,
+        payload: SaveTeamPayload,
     ): Promise<CreateTeamResponse> => {
         const response = await api.post('/api/teams/create', payload);
+        return response.data;
+    },
+    listTeams: async (): Promise<ListTeamsResponse> => {
+        const response = await api.get('/api/teams/list');
+        return response.data;
+    },
+    getTeam: async (teamUUID: string): Promise<GetTeamResponse> => {
+        const response = await api.get(`/api/teams/get/${teamUUID}`);
+        return response.data;
+    },
+    updateTeam: async (
+        payload: UpdateTeamPayload,
+    ): Promise<UpdateTeamResponse> => {
+        const response = await api.put('/api/teams/update', payload);
+        return response.data;
+    },
+    deleteTeam: async (teamUUID: string): Promise<DeleteTeamResponse> => {
+        const response = await api.delete(`/api/teams/delete/${teamUUID}`);
         return response.data;
     },
 };

--- a/src/stores/userTeams.ts
+++ b/src/stores/userTeams.ts
@@ -1,0 +1,72 @@
+import { defineStore } from "pinia";
+import { teamApi } from "@/network/api";
+import type {
+    SaveTeamPayload,
+    UpdateTeamPayload,
+    TeamSummary,
+} from "@/models/api";
+
+interface UserTeamsState {
+    teams: TeamSummary[];
+    loading: boolean;
+    error: string | null;
+}
+
+// Separate from `stores/teams.ts`, which owns the 30 NBA franchises' logos
+// and is fetched by every visitor, signed in or not. This store is the
+// signed-in user's own saved teams - a different "teams" entirely.
+export const useUserTeamsStore = defineStore("userTeams", {
+    state: (): UserTeamsState => ({
+        teams: [],
+        loading: false,
+        error: null,
+    }),
+
+    actions: {
+        async fetch() {
+            this.loading = true;
+            this.error = null;
+
+            try {
+                const response = await teamApi.listTeams();
+                if (response.success) {
+                    this.teams = response.data.teams;
+                } else {
+                    this.error = response.error;
+                }
+            } catch (error) {
+                this.error =
+                    error instanceof Error
+                        ? error.message
+                        : "Failed to fetch teams";
+                console.error("Error fetching teams:", error);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async save(payload: SaveTeamPayload) {
+            const response = await teamApi.createTeam(payload);
+            if (!response.success) {
+                throw new Error(response.error);
+            }
+            return response.data;
+        },
+
+        async update(payload: UpdateTeamPayload) {
+            const response = await teamApi.updateTeam(payload);
+            if (!response.success) {
+                throw new Error(response.error);
+            }
+            return response.data;
+        },
+
+        async remove(teamUUID: string) {
+            const response = await teamApi.deleteTeam(teamUUID);
+            if (!response.success) {
+                throw new Error(response.error);
+            }
+            this.teams = this.teams.filter((t) => t.teamUUID !== teamUUID);
+        },
+    },
+});

--- a/src/views/TeamBuilder.vue
+++ b/src/views/TeamBuilder.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { toast } from 'vue-sonner';
 import PageTitle from "@/components/PageTitle.vue";
 import TeamBuilderHeader from "@/components/TeamBuilder/TeamBuilderHeader.vue";
@@ -15,9 +16,20 @@ import {
     swapMapEntries,
     swapSetMembers,
 } from "@/composables/useRosterDragDrop";
+import { serializeTeam, hydrateTeam } from "@/composables/useTeamPersistence";
 import { dataApi, teamApi } from "@/network/api";
+import { useUserTeamsStore } from "@/stores/userTeams";
 import type { DrawerSide, NBA2KRating } from "@/models/types";
-import type { GetPlayerStatsResponse, CreateTeamPayload } from "@/models/api";
+import type { GetPlayerStatsResponse } from "@/models/api";
+
+const route = useRoute();
+const router = useRouter();
+const userTeamsStore = useUserTeamsStore();
+
+// Set once a team is loaded from /teams (route query `team`) or freshly
+// saved. Present means saveTeam() updates that team in place; absent means
+// it creates a new one.
+const loadedTeamUUID = ref<string | null>(null);
 
 /* Team Metadata */
 const teamName = ref<string>("");
@@ -108,6 +120,24 @@ const addPlayer = (index: number) => {
     showPlayerDialog.value = true;
 };
 
+// Fetches a player's career stats/rating history and lands the full record
+// in the slot. Shared by adding a new player from the dialog and hydrating a
+// loaded team - both start from a full player object and only need the
+// stats round trip. Marking the slot pending first lets the card show an
+// in-place wait rather than nothing while that request is out.
+const loadPlayerIntoSlot = async (slot: number, player: any) => {
+    pendingPlayers.value.set(slot, player.fullName ?? "");
+    try {
+        const { id } = player;
+        const { data: playerStats, ratingHistory } = await getPlayerStats(id);
+        const updatedPlayerData = { ...player, playerStats, ratingHistory };
+        selectedPlayersData.value.set(slot, updatedPlayerData);
+        cardsFlipped.value.set(slot, false);
+    } finally {
+        pendingPlayers.value.delete(slot);
+    }
+};
+
 const addPlayerFromDialog = async (player: any) => {
     const playerIndex = selectedPlayerIndex.value;
     // The dialog is only opened from a slot, so this is set - but the ref is
@@ -117,28 +147,13 @@ const addPlayerFromDialog = async (player: any) => {
     const playerName = `${player.first_name} ${player.last_name}`;
 
     // The toast lives in the corner, far from the slot the player is landing
-    // in. Marking the slot pending lets the card show the same wait in place.
-    pendingPlayers.value.set(playerIndex, playerName);
-
-    toast.promise(
-        async () => {
-            try {
-                const { id } = player;
-                const { data: playerStats, ratingHistory } =
-                    await getPlayerStats(id);
-                const updatedPlayerData = { ...player, playerStats, ratingHistory };
-                selectedPlayersData.value.set(playerIndex, updatedPlayerData);
-                cardsFlipped.value.set(playerIndex, false);
-            } finally {
-                pendingPlayers.value.delete(playerIndex);
-            }
-        },
-        {
-            loading: `Adding ${playerName} to ${slotLabel(playerIndex)}...`,
-            success: `Added ${playerName} to ${slotLabel(playerIndex)}`,
-            error: `Failed to add ${playerName} to ${slotLabel(playerIndex)}`,
-        }
-    );
+    // in - loadPlayerIntoSlot marks the slot pending so the card shows the
+    // same wait in place.
+    toast.promise(loadPlayerIntoSlot(playerIndex, player), {
+        loading: `Adding ${playerName} to ${slotLabel(playerIndex)}...`,
+        success: `Added ${playerName} to ${slotLabel(playerIndex)}`,
+        error: `Failed to add ${playerName} to ${slotLabel(playerIndex)}`,
+    });
 };
 
 const deletePlayer = (index: number) => {
@@ -269,27 +284,76 @@ const resetTeam = () => {
 };
 
 const saveTeam = () => {
-    // Sort by slot - Map iteration is insertion order, which would save a
-    // reordered roster in the order the players happened to be added.
-    const players = Array.from(selectedPlayersData.value.entries())
-        .sort(([a], [b]) => a - b)
-        .map(([, p]) => p.fullName);
+    const payload = serializeTeam({
+        teamName: teamName.value,
+        teamDescription: teamDescription.value || "Custom NBA Team",
+        teamCity: teamCity.value,
+        teamCountry: teamCountry.value,
+        teamLogo: teamLogo.value,
+        selectedPlayersData: selectedPlayersData.value,
+        teamCoach: teamCoach.value,
+        teamArena: teamArena.value,
+        teamGM: teamGM.value,
+    });
 
-    const newTeam: CreateTeamPayload = {
-        description: teamDescription.value || "Custom NBA Team",
-        name: teamName.value,
-        players,
-    };
+    const existingUUID = loadedTeamUUID.value;
 
     toast.promise(
-        teamApi.createTeam(newTeam),
+        async () => {
+            const saved = existingUUID
+                ? await userTeamsStore.update({ ...payload, teamUUID: existingUUID })
+                : await userTeamsStore.save(payload);
+            loadedTeamUUID.value = saved.teamUUID;
+            // Puts the team's uuid in the URL after the first save so a
+            // refresh still knows to update this team rather than create
+            // a duplicate on the next save.
+            if (!existingUUID) {
+                router.replace({ query: { ...route.query, team: saved.teamUUID } });
+            }
+        },
         {
-            loading: 'Saving team...',
-            success: 'Team saved successfully!',
-            error: 'Failed to save team',
+            loading: existingUUID ? 'Saving team...' : 'Creating team...',
+            success: existingUUID ? 'Team saved!' : 'Team created!',
+            error: existingUUID ? 'Failed to save team' : 'Failed to create team',
         }
     );
 };
+
+// Loading an existing team via ?team=<uuid> (e.g. from /teams). Metadata
+// restores synchronously; each roster slot then streams its career stats in
+// through loadPlayerIntoSlot, same as adding a player fresh.
+onMounted(async () => {
+    const teamUUID = route.query.team;
+    if (typeof teamUUID !== "string" || !teamUUID) return;
+
+    try {
+        const response = await teamApi.getTeam(teamUUID);
+        if (!response.success) {
+            toast.error(response.error || "Failed to load team");
+            return;
+        }
+
+        const hydrated = hydrateTeam(response.data);
+        loadedTeamUUID.value = response.data.teamUUID;
+        teamName.value = hydrated.teamName;
+        teamDescription.value = hydrated.teamDescription;
+        teamCity.value = hydrated.teamCity;
+        teamCountry.value = hydrated.teamCountry;
+        teamLogo.value = hydrated.teamLogo;
+        teamCoach.value = hydrated.teamCoach;
+        teamArena.value = hydrated.teamArena;
+        teamGM.value = hydrated.teamGM;
+
+        await Promise.all(
+            Array.from(hydrated.players.entries()).map(([slot, player]) =>
+                loadPlayerIntoSlot(slot, player),
+            ),
+        );
+    } catch (err) {
+        console.error("Error loading team:", err);
+        toast.error("Failed to load team");
+    }
+});
 </script>
 
 <template>

--- a/src/views/TeamBuilder.vue
+++ b/src/views/TeamBuilder.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, computed, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { toast } from 'vue-sonner';
 import PageTitle from "@/components/PageTitle.vue";
@@ -266,7 +266,11 @@ watch(showPlayerComparison, (open) => {
     if (!open) selectedPlayersForComparison.value.clear();
 });
 
-const resetTeam = () => {
+// Shared by the user-facing "Clear Team" button and route-driven resets
+// (navigating from a loaded team to a bare /teambuilder). Resetting
+// loadedTeamUUID here matters: without it, Save after a clear would still
+// update the previously loaded team instead of creating a new one.
+const clearBuilderState = () => {
     cancelPickup();
     selectedPlayersData.value.clear();
     cardsFlipped.value.clear();
@@ -279,7 +283,11 @@ const resetTeam = () => {
     teamCity.value = "";
     teamCountry.value = "";
     teamLogo.value = "";
+    loadedTeamUUID.value = null;
+};
 
+const resetTeam = () => {
+    clearBuilderState();
     toast.success('Team cleared successfully');
 };
 
@@ -322,10 +330,7 @@ const saveTeam = () => {
 // Loading an existing team via ?team=<uuid> (e.g. from /teams). Metadata
 // restores synchronously; each roster slot then streams its career stats in
 // through loadPlayerIntoSlot, same as adding a player fresh.
-onMounted(async () => {
-    const teamUUID = route.query.team;
-    if (typeof teamUUID !== "string" || !teamUUID) return;
-
+const loadTeamFromRoute = async (teamUUID: string) => {
     try {
         const response = await teamApi.getTeam(teamUUID);
         if (!response.success) {
@@ -353,7 +358,24 @@ onMounted(async () => {
         console.error("Error loading team:", err);
         toast.error("Failed to load team");
     }
-});
+};
+
+// Watches route.query.team rather than onMounted alone: navigating between
+// /teambuilder?team=A and a bare /teambuilder (e.g. the nav bar's "Team
+// Builder" link) matches the same route record, so Vue Router reuses this
+// component instance and onMounted never fires again. Without this watcher
+// the builder kept showing team A - and Save would silently overwrite it.
+watch(
+    () => route.query.team,
+    (teamUUID) => {
+        if (typeof teamUUID === "string" && teamUUID) {
+            loadTeamFromRoute(teamUUID);
+        } else {
+            clearBuilderState();
+        }
+    },
+    { immediate: true },
+);
 </script>
 
 <template>

--- a/src/views/Teams.vue
+++ b/src/views/Teams.vue
@@ -107,7 +107,7 @@ onMounted(() => {
                         <div class="team-meta">
                             <Badge variant="secondary" class="player-count-badge">
                                 <Users class="h-3 w-3 mr-1" />
-                                {{ team.playerCount }} {{ team.playerCount === 1 ? 'player' : 'players' }}
+                                {{ team.playerCount ?? 0 }} {{ team.playerCount === 1 ? 'player' : 'players' }}
                             </Badge>
                             <span class="updated-at">
                                 Updated {{ formatUpdatedAt(team.updatedAt) }}

--- a/src/views/Teams.vue
+++ b/src/views/Teams.vue
@@ -1,17 +1,83 @@
 <script setup lang="ts">
+import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
+import { toast } from "vue-sonner";
 import PageTitle from "@/components/PageTitle.vue";
 import { Button } from "@/components/ui/button";
-import { Shield, Plus } from "lucide-vue-next";
+import { Badge } from "@/components/ui/badge";
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
+import ConfirmDialog from "@/components/ui/confirm-dialog/ConfirmDialog.vue";
+import { Shield, Plus, Users, Trash2 } from "lucide-vue-next";
+import { useUserTeamsStore } from "@/stores/userTeams";
+import type { TeamSummary } from "@/models/api";
 
 const router = useRouter();
+const userTeamsStore = useUserTeamsStore();
+
+const teamToDelete = ref<TeamSummary | null>(null);
+const showDeleteDialog = ref(false);
+const deleting = ref(false);
+
+const formatUpdatedAt = (updatedAt: number) =>
+    new Date(updatedAt).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+
+const openTeam = (teamUUID: string) => {
+    router.push({ path: "/teambuilder", query: { team: teamUUID } });
+};
+
+const confirmDelete = (team: TeamSummary) => {
+    teamToDelete.value = team;
+    showDeleteDialog.value = true;
+};
+
+const handleDelete = async () => {
+    if (!teamToDelete.value) return;
+
+    deleting.value = true;
+    try {
+        await userTeamsStore.remove(teamToDelete.value.teamUUID);
+        toast.success(`Deleted ${teamToDelete.value.title}`);
+        showDeleteDialog.value = false;
+        teamToDelete.value = null;
+    } catch (err) {
+        toast.error(
+            err instanceof Error ? err.message : "Failed to delete team",
+        );
+    } finally {
+        deleting.value = false;
+    }
+};
+
+onMounted(() => {
+    userTeamsStore.fetch();
+});
 </script>
 
 <template>
     <main class="teams-page">
         <PageTitle />
         <div class="teams-container">
-            <div class="empty-state">
+            <div v-if="userTeamsStore.loading" class="status-state">
+                <p class="status-copy">Loading your teams...</p>
+            </div>
+
+            <div v-else-if="userTeamsStore.error" class="status-state">
+                <p class="status-copy error-copy">{{ userTeamsStore.error }}</p>
+                <Button variant="outline" @click="userTeamsStore.fetch()">
+                    Try again
+                </Button>
+            </div>
+
+            <div v-else-if="userTeamsStore.teams.length === 0" class="empty-state">
                 <div class="empty-state-icon">
                     <Shield class="h-10 w-10 text-primary" />
                 </div>
@@ -24,7 +90,59 @@ const router = useRouter();
                     Build a Team
                 </Button>
             </div>
+
+            <div v-else class="teams-grid">
+                <Card
+                    v-for="team in userTeamsStore.teams"
+                    :key="team.teamUUID"
+                    class="team-card"
+                >
+                    <CardHeader>
+                        <CardTitle class="team-card-title">{{ team.title }}</CardTitle>
+                    </CardHeader>
+                    <CardContent class="team-card-content">
+                        <p v-if="team.description" class="team-description">
+                            {{ team.description }}
+                        </p>
+                        <div class="team-meta">
+                            <Badge variant="secondary" class="player-count-badge">
+                                <Users class="h-3 w-3 mr-1" />
+                                {{ team.playerCount }} {{ team.playerCount === 1 ? 'player' : 'players' }}
+                            </Badge>
+                            <span class="updated-at">
+                                Updated {{ formatUpdatedAt(team.updatedAt) }}
+                            </span>
+                        </div>
+                        <div class="team-actions">
+                            <Button
+                                class="open-button"
+                                @click="openTeam(team.teamUUID)"
+                            >
+                                Open
+                            </Button>
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                aria-label="Delete team"
+                                @click="confirmDelete(team)"
+                            >
+                                <Trash2 class="h-4 w-4" />
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
         </div>
+
+        <ConfirmDialog
+            v-model:open="showDeleteDialog"
+            title="Delete team?"
+            :description="`Are you sure you want to delete ${teamToDelete?.title}? This action cannot be undone.`"
+            confirm-text="Delete"
+            variant="destructive"
+            :loading="deleting"
+            @confirm="handleDelete"
+        />
     </main>
 </template>
 
@@ -33,6 +151,29 @@ const router = useRouter();
     display: grid;
     justify-items: center;
     padding: 0 4rem;
+}
+
+.teams-container {
+    width: 100%;
+    max-width: 75rem;
+}
+
+.status-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 4rem 1.5rem;
+    text-align: center;
+}
+
+.status-copy {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.error-copy {
+    color: hsl(var(--destructive));
 }
 
 .empty-state {
@@ -61,5 +202,83 @@ const router = useRouter();
     color: hsl(var(--muted-foreground));
     margin: 0.25rem 0 1.5rem;
     max-width: 24rem;
+}
+
+.teams-grid {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    gap: 1.25rem;
+    padding: 1rem 0 3rem;
+}
+
+@media (min-width: 640px) {
+    .teams-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 1024px) {
+    .teams-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+.team-card {
+    border-radius: 0.5rem;
+    border: 0.125rem solid;
+    border-color: hsla(var(--primary), 0.5);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.team-card:hover {
+    border-color: hsl(var(--primary));
+    box-shadow: 0 0 0.5rem hsla(var(--primary), 0.3);
+}
+
+.team-card-title {
+    font-size: 1.125rem;
+}
+
+.team-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.team-description {
+    font-size: 0.875rem;
+    color: hsl(var(--muted-foreground));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.team-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.player-count-badge {
+    display: inline-flex;
+    align-items: center;
+}
+
+.updated-at {
+    font-size: 0.75rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.team-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.open-button {
+    flex: 1;
 }
 </style>

--- a/tests/composables/useTeamPersistence.test.ts
+++ b/tests/composables/useTeamPersistence.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import { serializeTeam, hydrateTeam } from "@/composables/useTeamPersistence";
+import type { SavedTeam } from "@/models/api";
+
+const apiPlayer = (overrides: Record<string, any> = {}) => ({
+    id: "jamesle01",
+    first_name: "LeBron",
+    last_name: "James",
+    fullName: "LeBron James",
+    position: "SF",
+    team: { full_name: "Los Angeles Lakers", abbreviation: "LAL" },
+    height_feet: 6,
+    height_inches: 9,
+    weight_pounds: 250,
+    active: true,
+    rating: 96,
+    ratingSource: "current",
+    // UI-only fields that shouldn't survive serialization
+    heightAndWeight: "6' 9\", 250lbs",
+    playerStats: [{ season: 2025, pts: 27 }],
+    ratingHistory: [{ gameVersion: "2K25", overall: 96 }],
+    ...overrides,
+});
+
+const customPlayer = (overrides: Record<string, any> = {}) => ({
+    playerUUID: "uuid-1",
+    name: "My Custom Guy",
+    fullName: "My Custom Guy",
+    position: "PG",
+    heightFeet: 6,
+    heightInches: 2,
+    weightPounds: 190,
+    overallRating: 80,
+    isCustom: true,
+    heightAndWeight: "6' 2\", 190lbs",
+    ...overrides,
+});
+
+describe("serializeTeam", () => {
+    it("sorts the roster by slot regardless of insertion order", () => {
+        const selectedPlayersData = new Map<number, any>([
+            [5, apiPlayer({ fullName: "Fifth Slot" })],
+            [1, apiPlayer({ fullName: "First Slot" })],
+        ]);
+
+        const payload = serializeTeam({
+            teamName: "Test Team",
+            teamDescription: "",
+            teamCity: "",
+            teamCountry: "",
+            teamLogo: "",
+            selectedPlayersData,
+            teamCoach: null,
+            teamArena: null,
+            teamGM: null,
+        });
+
+        expect(payload.roster.map((r) => r.slot)).toEqual([1, 5]);
+        expect(payload.roster.map((r) => r.player.fullName)).toEqual([
+            "First Slot",
+            "Fifth Slot",
+        ]);
+    });
+
+    it("strips derived/UI-only fields off each player", () => {
+        const selectedPlayersData = new Map<number, any>([[1, apiPlayer()]]);
+
+        const payload = serializeTeam({
+            teamName: "Test Team",
+            teamDescription: "",
+            teamCity: "",
+            teamCountry: "",
+            teamLogo: "",
+            selectedPlayersData,
+            teamCoach: null,
+            teamArena: null,
+            teamGM: null,
+        });
+
+        const snapshot = payload.roster[0].player as any;
+        expect(snapshot).not.toHaveProperty("playerStats");
+        expect(snapshot).not.toHaveProperty("ratingHistory");
+        expect(snapshot).not.toHaveProperty("heightAndWeight");
+        expect(snapshot.id).toBe("jamesle01");
+    });
+
+    it("serializes a custom player without an id/team the same way", () => {
+        const selectedPlayersData = new Map<number, any>([[8, customPlayer()]]);
+
+        const payload = serializeTeam({
+            teamName: "Test Team",
+            teamDescription: "",
+            teamCity: "",
+            teamCountry: "",
+            teamLogo: "",
+            selectedPlayersData,
+            teamCoach: null,
+            teamArena: null,
+            teamGM: null,
+        });
+
+        expect(payload.roster[0].player.fullName).toBe("My Custom Guy");
+        expect(payload.roster[0].player.isCustom).toBe(true);
+    });
+
+    it("maps coach/GM/arena refs, including custom UUIDs", () => {
+        const payload = serializeTeam({
+            teamName: "Test Team",
+            teamDescription: "",
+            teamCity: "",
+            teamCountry: "",
+            teamLogo: "",
+            selectedPlayersData: new Map(),
+            teamCoach: { name: "Steve Kerr", isCustom: false },
+            teamArena: { name: "Chase Center", imgLink: "https://example.com/chase.jpg" },
+            teamGM: { name: "My GM", isCustom: true, gmUUID: "gm-1" },
+        });
+
+        expect(payload.coach).toEqual({ name: "Steve Kerr", isCustom: false, uuid: undefined });
+        expect(payload.gm).toEqual({ name: "My GM", isCustom: true, uuid: "gm-1" });
+        expect(payload.arena).toEqual({
+            name: "Chase Center",
+            imgLink: "https://example.com/chase.jpg",
+        });
+    });
+
+    it("tolerates a null coach, GM, and arena", () => {
+        const payload = serializeTeam({
+            teamName: "Test Team",
+            teamDescription: "",
+            teamCity: "",
+            teamCountry: "",
+            teamLogo: "",
+            selectedPlayersData: new Map(),
+            teamCoach: null,
+            teamArena: null,
+            teamGM: null,
+        });
+
+        expect(payload.coach).toBeNull();
+        expect(payload.gm).toBeNull();
+        expect(payload.arena).toBeNull();
+        expect(payload.roster).toEqual([]);
+    });
+});
+
+// A snapshot as it actually comes back from the API - already stripped of
+// playerStats/ratingHistory/heightAndWeight, unlike the working `apiPlayer()`
+// fixture above.
+const snapshotPlayer = (overrides: Record<string, any> = {}) => {
+    const {
+        heightAndWeight: _heightAndWeight,
+        playerStats: _playerStats,
+        ratingHistory: _ratingHistory,
+        ...snapshot
+    } = apiPlayer(overrides);
+    return snapshot;
+};
+
+describe("hydrateTeam", () => {
+    const baseSaved: SavedTeam = {
+        teamUUID: "t1",
+        userUUID: "u1",
+        username: "someone",
+        title: "My Team",
+        description: "A description",
+        city: "Miami",
+        country: "USA",
+        logoUrl: "https://example.com/logo.png",
+        playerCount: 1,
+        roster: [{ slot: 1, player: snapshotPlayer() as any }],
+        coach: { name: "Steve Kerr", isCustom: false },
+        gm: { name: "My GM", isCustom: true, uuid: "gm-1" },
+        arena: { name: "Chase Center", imgLink: "https://example.com/chase.jpg" },
+        favorited: false,
+        label: "",
+        lastViewed: 1,
+        createdAt: 1,
+        updatedAt: 1,
+    };
+
+    it("round-trips a full team through serialize -> hydrate", () => {
+        const hydrated = hydrateTeam(baseSaved);
+
+        expect(hydrated.teamName).toBe("My Team");
+        expect(hydrated.teamDescription).toBe("A description");
+        expect(hydrated.teamCity).toBe("Miami");
+        expect(hydrated.teamCountry).toBe("USA");
+        expect(hydrated.teamLogo).toBe("https://example.com/logo.png");
+        expect(hydrated.players.get(1)?.fullName).toBe("LeBron James");
+        expect(hydrated.teamCoach).toEqual({ name: "Steve Kerr", isCustom: false });
+        expect(hydrated.teamGM).toEqual({ name: "My GM", isCustom: true, uuid: "gm-1" });
+        expect(hydrated.teamArena).toEqual({
+            name: "Chase Center",
+            imgLink: "https://example.com/chase.jpg",
+        });
+
+        // Re-serializing the hydrated state reproduces the roster slot/name pairing.
+        const reserialized = serializeTeam({
+            teamName: hydrated.teamName,
+            teamDescription: hydrated.teamDescription,
+            teamCity: hydrated.teamCity,
+            teamCountry: hydrated.teamCountry,
+            teamLogo: hydrated.teamLogo,
+            selectedPlayersData: hydrated.players,
+            teamCoach: hydrated.teamCoach,
+            teamArena: hydrated.teamArena,
+            teamGM: hydrated.teamGM,
+        });
+        expect(reserialized.roster).toEqual([
+            { slot: 1, player: hydrated.players.get(1) },
+        ]);
+    });
+
+    it("survives a null coach, null arena, null GM, and an empty roster", () => {
+        const hydrated = hydrateTeam({
+            ...baseSaved,
+            roster: [],
+            coach: null,
+            gm: null,
+            arena: null,
+        });
+
+        expect(hydrated.players.size).toBe(0);
+        expect(hydrated.teamCoach).toBeNull();
+        expect(hydrated.teamGM).toBeNull();
+        expect(hydrated.teamArena).toBeNull();
+    });
+});

--- a/tests/network/api.test.ts
+++ b/tests/network/api.test.ts
@@ -43,6 +43,58 @@ describe("teamApi.createTeam", () => {
     });
 });
 
+describe("teamApi.listTeams", () => {
+    it("GETs /api/teams/list and returns response.data", async () => {
+        const body = { success: true, data: { teams: [] } };
+        mockInstance.get.mockResolvedValue({ data: body });
+
+        const result = await teamApi.listTeams();
+
+        expect(mockInstance.get).toHaveBeenCalledWith("/api/teams/list");
+        expect(result).toEqual(body);
+    });
+});
+
+describe("teamApi.getTeam", () => {
+    it("GETs the uuid-scoped path", async () => {
+        const body = { success: true, data: { teamUUID: "t1" } };
+        mockInstance.get.mockResolvedValue({ data: body });
+
+        const result = await teamApi.getTeam("t1");
+
+        expect(mockInstance.get).toHaveBeenCalledWith("/api/teams/get/t1");
+        expect(result).toEqual(body);
+    });
+});
+
+describe("teamApi.updateTeam", () => {
+    it("PUTs to /api/teams/update with the payload", async () => {
+        const payload = { teamUUID: "t1", title: "Renamed" } as any;
+        mockInstance.put.mockResolvedValue({ data: { success: true } });
+
+        const result = await teamApi.updateTeam(payload);
+
+        expect(mockInstance.put).toHaveBeenCalledWith(
+            "/api/teams/update",
+            payload,
+        );
+        expect(result).toEqual({ success: true });
+    });
+});
+
+describe("teamApi.deleteTeam", () => {
+    it("DELETEs the uuid-scoped path", async () => {
+        mockInstance.delete.mockResolvedValue({ data: { success: true } });
+
+        const result = await teamApi.deleteTeam("t1");
+
+        expect(mockInstance.delete).toHaveBeenCalledWith(
+            "/api/teams/delete/t1",
+        );
+        expect(result).toEqual({ success: true });
+    });
+});
+
 describe("dataApi.getPlayers", () => {
     it("forwards the query params and returns response.data", async () => {
         const body = { data: [{ id: "jamesle01" }], nextCursor: null };

--- a/tests/stores/userTeams.test.ts
+++ b/tests/stores/userTeams.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.mock("@/network/api", () => ({
+    teamApi: {
+        listTeams: vi.fn(),
+        createTeam: vi.fn(),
+        updateTeam: vi.fn(),
+        deleteTeam: vi.fn(),
+    },
+}));
+
+import { useUserTeamsStore } from "@/stores/userTeams";
+import { teamApi } from "@/network/api";
+
+const sampleTeams = [
+    { teamUUID: "t1", title: "Team One", playerCount: 5 },
+    { teamUUID: "t2", title: "Team Two", playerCount: 3 },
+];
+
+beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+});
+
+describe("useUserTeamsStore.fetch", () => {
+    it("populates teams and clears loading on success", async () => {
+        vi.mocked(teamApi.listTeams).mockResolvedValue({
+            success: true,
+            data: { teams: sampleTeams },
+        } as any);
+
+        const store = useUserTeamsStore();
+        await store.fetch();
+
+        expect(store.teams).toEqual(sampleTeams);
+        expect(store.loading).toBe(false);
+        expect(store.error).toBeNull();
+    });
+
+    it("sets error from an unsuccessful response", async () => {
+        vi.mocked(teamApi.listTeams).mockResolvedValue({
+            success: false,
+            error: "nope",
+        } as any);
+
+        const store = useUserTeamsStore();
+        await store.fetch();
+
+        expect(store.error).toBe("nope");
+        expect(store.loading).toBe(false);
+    });
+
+    it("sets error on a thrown exception", async () => {
+        vi.mocked(teamApi.listTeams).mockRejectedValue(new Error("boom"));
+
+        const store = useUserTeamsStore();
+        await store.fetch();
+
+        expect(store.error).toBe("boom");
+        expect(store.loading).toBe(false);
+    });
+});
+
+describe("useUserTeamsStore.save", () => {
+    it("returns the created team on success", async () => {
+        const created = { teamUUID: "t1" };
+        vi.mocked(teamApi.createTeam).mockResolvedValue({
+            success: true,
+            data: created,
+        } as any);
+
+        const store = useUserTeamsStore();
+        const result = await store.save({} as any);
+
+        expect(result).toEqual(created);
+    });
+
+    it("throws on an unsuccessful response", async () => {
+        vi.mocked(teamApi.createTeam).mockResolvedValue({
+            success: false,
+            error: "invalid",
+        } as any);
+
+        const store = useUserTeamsStore();
+        await expect(store.save({} as any)).rejects.toThrow("invalid");
+    });
+});
+
+describe("useUserTeamsStore.update", () => {
+    it("returns the updated team on success", async () => {
+        const updated = { teamUUID: "t1", title: "Renamed" };
+        vi.mocked(teamApi.updateTeam).mockResolvedValue({
+            success: true,
+            data: updated,
+        } as any);
+
+        const store = useUserTeamsStore();
+        const result = await store.update({} as any);
+
+        expect(result).toEqual(updated);
+    });
+
+    it("throws on an unsuccessful response", async () => {
+        vi.mocked(teamApi.updateTeam).mockResolvedValue({
+            success: false,
+            error: "invalid",
+        } as any);
+
+        const store = useUserTeamsStore();
+        await expect(store.update({} as any)).rejects.toThrow("invalid");
+    });
+});
+
+describe("useUserTeamsStore.remove", () => {
+    it("removes the team from state on success", async () => {
+        vi.mocked(teamApi.deleteTeam).mockResolvedValue({
+            success: true,
+        } as any);
+
+        const store = useUserTeamsStore();
+        store.teams = sampleTeams as any;
+        await store.remove("t1");
+
+        expect(store.teams.map((t) => t.teamUUID)).toEqual(["t2"]);
+    });
+
+    it("leaves state untouched and throws on an unsuccessful response", async () => {
+        vi.mocked(teamApi.deleteTeam).mockResolvedValue({
+            success: false,
+            error: "nope",
+        } as any);
+
+        const store = useUserTeamsStore();
+        store.teams = sampleTeams as any;
+
+        await expect(store.remove("t1")).rejects.toThrow("nope");
+        expect(store.teams).toEqual(sampleTeams);
+    });
+});


### PR DESCRIPTION
TeamBuilder.vue's saveTeam() sent only {name, description, players: string[]}
- coach, GM, arena, city, country, and logo were collected by the UI and
silently dropped, and players were saved as display names, not ids.

Adds useTeamPersistence (serialize/hydrate the builder's live refs against
the new snapshot payload) and a userTeams store, separate from the existing
teams store which owns the 30 NBA franchises' logos fetched by every visitor.
TeamBuilder now updates a loaded team in place instead of creating a
duplicate on every save, and hydrates from ?team=<uuid> - career stats stay
lazy, fetched per slot the same way adding a player does today.

Teams.vue was a hardcoded "No teams yet" empty state with no fetch and no
props. It now lists the user's saved teams with open/delete actions.

Requires yusufaf/team-builder-cdk#8 (backend routes), already deployed to
team-builder-development-stack.

https://claude.ai/code/session_01NBxH3st7JPqNoCgWLgW9ka