### PR TITLE
fix: unbreak all-time logo picker fullscreen view

### DIFF
--- a/src/components/TeamBuilder/HistoricalLogoPicker.vue
+++ b/src/components/TeamBuilder/HistoricalLogoPicker.vue
@@ -22,7 +22,7 @@ const selectedDecade = ref<string>('All');
 const selectedLeague = ref<string>('All');
 // Modeled so the Team Customization dialog can tell the fullscreen overlay
 // apart from its own click-outside handling - see the dialog's
-// `onInteractOutside` for why that matters.
+// `onDialogInteractOutside` for why that matters.
 const expanded = defineModel<boolean>('expanded', { default: false });
 const searchField = ref<HTMLElement | null>(null);
 

--- a/src/components/TeamBuilder/HistoricalLogoPicker.vue
+++ b/src/components/TeamBuilder/HistoricalLogoPicker.vue
@@ -20,7 +20,10 @@ const teamLogo = defineModel<string>('teamLogo');
 const search = ref<string>('');
 const selectedDecade = ref<string>('All');
 const selectedLeague = ref<string>('All');
-const expanded = ref<boolean>(false);
+// Modeled so the Team Customization dialog can tell the fullscreen overlay
+// apart from its own click-outside handling - see the dialog's
+// `onInteractOutside` for why that matters.
+const expanded = defineModel<boolean>('expanded', { default: false });
 const searchField = ref<HTMLElement | null>(null);
 
 const DECADES = [
@@ -228,6 +231,12 @@ onBeforeUnmount(() => {
     gap: 0.875rem;
     background: hsl(0 0% 7% / 0.98);
     backdrop-filter: blur(0.75rem);
+    /* This overlay teleports past the dialog's own DOM subtree, so it isn't one
+       of reka-ui's registered dismissable layers. A modal Dialog sets
+       body { pointer-events: none } and only re-enables pointer-events on
+       layers it knows about - without this override every click and scroll
+       here is inert, since it inherits "none" from the body. */
+    pointer-events: auto;
 }
 
 .picker-header {

--- a/src/components/TeamBuilder/TeamCustomizationDialog.vue
+++ b/src/components/TeamBuilder/TeamCustomizationDialog.vue
@@ -33,6 +33,21 @@ const teamCountry = defineModel<string>('teamCountry');
 const teamLogo = defineModel<string>('teamLogo');
 const selectedFile = ref<File | null>(null);
 
+/**
+ * The all-time logo picker's fullscreen overlay teleports to <body>, outside
+ * this DialogContent's own DOM subtree, so reka-ui's dismissable-layer logic
+ * sees every click inside it as a click "outside" the dialog and closes it
+ * instantly. Track the picker's expanded state and swallow those outside
+ * interactions while it's up.
+ */
+const historicalLogoPickerExpanded = ref(false);
+
+const onDialogInteractOutside = (event: Event) => {
+    if (historicalLogoPickerExpanded.value) {
+        event.preventDefault();
+    }
+};
+
 /* Canvas Props */
 const drawingCanvas = ref<HTMLCanvasElement | null>(null);
 const isDrawing = ref<boolean>(false);
@@ -109,7 +124,10 @@ onMounted(() => {
 
 <template>
     <Dialog v-model:open="showTeamCustomizationDialog">
-        <DialogContent class="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogContent
+            class="max-w-2xl max-h-[90vh] overflow-y-auto"
+            @interact-outside="onDialogInteractOutside"
+        >
             <DialogHeader>
                 <DialogTitle>Team Customization</DialogTitle>
             </DialogHeader>
@@ -200,7 +218,10 @@ onMounted(() => {
                             </div>
                         </TabsContent>
                         <TabsContent value="all-time" class="mt-4">
-                            <HistoricalLogoPicker v-model:teamLogo="teamLogo" />
+                            <HistoricalLogoPicker
+                                v-model:teamLogo="teamLogo"
+                                v-model:expanded="historicalLogoPickerExpanded"
+                            />
                         </TabsContent>
                     </Tabs>
                 </div>


### PR DESCRIPTION
Modal Dialog sets `body{pointer-events:none}` and only re-enables it on layers it tracks. The fullscreen picker teleports to `<body>`, outside that tracking, so clicks passed through inert to the dialog overlay behind it, which read as an outside click and closed the dialog.

Fix:
- `pointer-events: auto` on the expanded picker
- `defineModel('expanded')` + `@interact-outside` guard on the parent dialog so it stops treating picker clicks as outside clicks

Verified live: expand, click tile (selects, stays open), scroll works, X collapses, and normal outside-click still closes the dialog with picker collapsed. `type-check` and `check:styles` pass.