### PR TITLE
feat(web): browser notifications for followed game score changes

### DIFF
--- a/apps/web/src/components/Scores/ManageNotifications.vue
+++ b/apps/web/src/components/Scores/ManageNotifications.vue
@@ -1,9 +1,34 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useGameNotifications } from "@/composables/useGameNotifications";
+import { X } from "lucide-vue-next";
 
 /* 2-Way Bound Props */
 const notificationsMenuOpen = defineModel<boolean>("notificationsMenuOpen");
+
+const {
+    followedGames,
+    notificationPermission,
+    notificationsSupported,
+    requestPermission,
+    unfollowGame,
+} = useGameNotifications();
+
+const followedGamesList = computed(() => Object.values(followedGames.value));
+
+const permissionBadge = computed(() => {
+    switch (notificationPermission.value) {
+        case "granted":
+            return { label: "Enabled", variant: "default" as const };
+        case "denied":
+            return { label: "Blocked", variant: "destructive" as const };
+        default:
+            return { label: "Not enabled", variant: "secondary" as const };
+    }
+});
 </script>
 
 <template>
@@ -14,21 +39,54 @@ const notificationsMenuOpen = defineModel<boolean>("notificationsMenuOpen");
             </DialogHeader>
             <div class="content-area">
                 <p class="description-text">
-                    Configure your notification preferences for game alerts and team updates.
+                    Get a browser notification when the score changes for games
+                    you're following. Click the bell on a game's scorecard to
+                    follow it.
                 </p>
-                <div class="coming-soon-badge">
-                    <span class="badge-text">Coming Soon</span>
-                    <p class="badge-description">
-                        Team-specific notifications and real-time game alerts
+
+                <div class="permission-row">
+                    <div class="permission-status">
+                        <span>Browser notifications:</span>
+                        <Badge :variant="permissionBadge.variant">{{ permissionBadge.label }}</Badge>
+                    </div>
+                    <Button
+                        v-if="notificationPermission === 'default'"
+                        size="sm"
+                        @click="requestPermission"
+                    >
+                        Enable Notifications
+                    </Button>
+                </div>
+                <p v-if="!notificationsSupported" class="unsupported-text">
+                    This browser doesn't support notifications.
+                </p>
+                <p v-else-if="notificationPermission === 'denied'" class="unsupported-text">
+                    Notifications are blocked. Update your browser's site
+                    permissions to allow them.
+                </p>
+
+                <div class="followed-games">
+                    <template v-if="followedGamesList.length">
+                        <div
+                            v-for="game in followedGamesList"
+                            :key="game.uid"
+                            class="followed-game-row"
+                        >
+                            <span>{{ game.label }}</span>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                title="Stop notifying me about this game"
+                                @click="unfollowGame(game.uid)"
+                            >
+                                <X class="h-4 w-4" />
+                            </Button>
+                        </div>
+                    </template>
+                    <p v-else class="empty-text">
+                        You're not following any games yet.
                     </p>
                 </div>
-                <!-- Favorited Teams: -->
-                <!-- <template v-for="n in Array(5)" :key="n">
-                    <div class="flex items-center justify-between">
-                        <Label>Team notification</Label>
-                        <Switch />
-                    </div>
-                </template> -->
             </div>
             <DialogFooter>
                 <Button @click="notificationsMenuOpen = false">
@@ -52,30 +110,44 @@ const notificationsMenuOpen = defineModel<boolean>("notificationsMenuOpen");
     margin-bottom: 1.5rem;
 }
 
-.coming-soon-badge {
-    background-color: hsl(var(--warning) / 0.1);
-    background-image: linear-gradient(to bottom right, hsl(var(--warning) / 0.14), hsl(var(--warning) / 0.08));
-    border: 0.125rem solid hsl(var(--warning) / 0.35);
-    border-radius: 0.875rem;
-    padding: 1.5rem 1.75rem;
-    box-shadow: 0 0.25rem 0.75rem hsl(var(--shadow-color) / 0.3);
+.permission-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
 }
 
-.badge-text {
-    display: inline-block;
+.permission-status {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    font-weight: 500;
+}
+
+.unsupported-text {
     font-size: 0.875rem;
-    font-weight: 800;
-    color: hsl(var(--warning));
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    margin-bottom: 0.625rem;
+    color: hsl(var(--foreground) / 0.65);
+    margin-bottom: 1rem;
 }
 
-.badge-description {
-    font-size: 0.9375rem;
-    color: hsl(var(--foreground) / 0.75);
-    margin: 0;
-    line-height: 1.6;
+.followed-games {
+    border-top: 0.0625rem solid hsl(var(--border));
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 
+.followed-game-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.empty-text {
+    font-size: 0.875rem;
+    color: hsl(var(--foreground) / 0.65);
+}
 </style>

--- a/apps/web/src/components/Scores/ScoreCard.vue
+++ b/apps/web/src/components/Scores/ScoreCard.vue
@@ -1,15 +1,13 @@
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { computed } from "vue";
 import { useRouter } from "vue-router";
-import { toast } from "vue-sonner";
 import {
     HOME,
     AWAY,
     GAME_STATUS,
     ZERO_CLOCK,
-    NOTIFICATION_GRANTED,
-    NOTIFICATION_DENIED,
 } from "@/constants/constants";
+import { useGameNotifications } from "@/composables/useGameNotifications";
 import LineScore from "./LineScore.vue";
 import TeamDetailsTooltip from "./TeamDetailsTooltip.vue";
 import type { CustomizationState } from "@/models/types";
@@ -31,18 +29,8 @@ const props = defineProps<{
 }>();
 
 
-/* Refs */
-const notificationPermission = ref<string>("");
-const gameNotificationsMap = ref<any>(new Map());
-
-/* Watchers */
-watch(notificationPermission, (newPermission) => {
-    if (newPermission === NOTIFICATION_GRANTED) {
-        return;
-    } else if (newPermission === NOTIFICATION_DENIED) {
-        return;
-    }
-});
+const { isFollowed, toggleFollow } = useGameNotifications();
+const isGameFollowed = computed(() => isFollowed(props.game.uid));
 
 /* Computed Refs */
 const fullGameName = computed(() => props.game.name);
@@ -204,51 +192,9 @@ const leaderData = computed(() => {
     return teamLeadersData.reverse();
 });
 
-const toggleGameNotification = (id: string): void => {
-    askNotificationPermission(id);
+const toggleGameNotification = (): void => {
+    toggleFollow(props.game);
 };
-
-const checkNotificationPromise = (): boolean => {
-    try {
-        Notification.requestPermission().then();
-    } catch (e) {
-        return false;
-    }
-    return true;
-};
-
-const askNotificationPermission = (id: string): void => {
-    /* Early return if browser permission has already been granted */
-    if (notificationPermission.value === NOTIFICATION_GRANTED) {
-        // const notification = new Notification("Hi there!");
-        return;
-    } else if (notificationPermission.value === NOTIFICATION_DENIED) {
-        /* Send toast instructing what user needs to change, return early because browser won't ask again */
-        toast.error(
-            "Please update your browser permissions to allow us to send you notifications"
-        );
-        return;
-    }
-
-    const handlePermission = (permission: string) => {
-        notificationPermission.value = permission;
-    };
-
-    // Let's check if the browser supports notifications
-    if (!("Notification" in window)) {
-        console.error("This browser does not support notifications.");
-    } else if (checkNotificationPromise()) {
-        Notification.requestPermission().then((permission) => {
-            handlePermission(permission);
-        });
-    } else {
-        Notification.requestPermission((permission) => {
-            handlePermission(permission);
-        });
-    }
-};
-
-/* TODO: Browser notifications link: https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API */
 </script>
 
 <template>
@@ -265,16 +211,15 @@ const askNotificationPermission = (id: string): void => {
         <Card class="score-card border-0 cursor-pointer hover:shadow-lg transition-all hover:scale-[1.02]" @click="() => router.push(`/game/${game.id}`)">
         <CardHeader class="card-header">
             <h6>{{ gameNameToDisplay }}</h6>
-            <!-- Toggled styling here ==> notifications vs notifications active -->
-            <!-- v-if="!isGameDone" -->
             <Button
-                @click.stop="toggleGameNotification(game.uid)"
+                @click.stop="toggleGameNotification"
                 class="notification-bell"
+                :class="{ following: isGameFollowed }"
                 variant="ghost"
                 size="icon"
-                title="Notify me about the game"
+                :title="isGameFollowed ? 'Stop notifying me about this game' : 'Notify me about this game'"
             >
-                <Bell class="h-5 w-5" />
+                <Bell class="h-5 w-5" :fill="isGameFollowed ? 'currentColor' : 'none'" />
             </Button>
         </CardHeader>
         <Separator />
@@ -445,6 +390,10 @@ const askNotificationPermission = (id: string): void => {
     margin-left: auto;
     animation: ring 4s 0.7s ease-in-out;
     transform-origin: 50% 0.0625rem;
+}
+
+.notification-bell.following {
+    color: hsl(var(--primary));
 }
 
 @keyframes ring {

--- a/apps/web/src/composables/useGameNotifications.ts
+++ b/apps/web/src/composables/useGameNotifications.ts
@@ -1,5 +1,6 @@
 import { ref, type Ref } from "vue";
 import { useStorage } from "@vueuse/core";
+import { toast } from "vue-sonner";
 import type { ESPNEvent } from "@/models/types";
 
 export interface FollowedGame {
@@ -25,12 +26,15 @@ const extractScores = (event: ESPNEvent): Omit<FollowedGame, "uid"> => {
   };
 };
 
+// Module-level so every component sharing this composable sees the same
+// permission state — unlike followedGames, a plain ref() has no cross-instance
+// sync of its own (useStorage gets that for free via a same-page storage event).
+const notificationPermission: Ref<NotificationPermission> = ref(
+  isNotificationsSupported() ? Notification.permission : "denied",
+);
+
 export const useGameNotifications = () => {
   const followedGames = useStorage<Record<string, FollowedGame>>(STORAGE_KEY, {});
-
-  const notificationPermission: Ref<NotificationPermission> = ref(
-    isNotificationsSupported() ? Notification.permission : "denied",
-  );
 
   const requestPermission = async (): Promise<NotificationPermission> => {
     if (!isNotificationsSupported()) {
@@ -53,11 +57,19 @@ export const useGameNotifications = () => {
   };
 
   const followGame = async (event: ESPNEvent): Promise<void> => {
-    await requestPermission();
+    const permission = await requestPermission();
     followedGames.value = {
       ...followedGames.value,
       [event.uid]: { uid: event.uid, ...extractScores(event) },
     };
+
+    if (permission !== "granted") {
+      toast.error(
+        isNotificationsSupported()
+          ? "Please update your browser permissions to allow us to send you notifications"
+          : "This browser doesn't support notifications",
+      );
+    }
   };
 
   const toggleFollow = async (event: ESPNEvent): Promise<void> => {
@@ -72,6 +84,8 @@ export const useGameNotifications = () => {
     if (notificationPermission.value !== "granted") {
       return;
     }
+
+    let updatedGames: Record<string, FollowedGame> | null = null;
 
     for (const event of events) {
       const followed = followedGames.value[event.uid];
@@ -89,10 +103,12 @@ export const useGameNotifications = () => {
         tag: event.uid,
       });
 
-      followedGames.value = {
-        ...followedGames.value,
-        [event.uid]: { uid: event.uid, ...scores },
-      };
+      updatedGames ??= { ...followedGames.value };
+      updatedGames[event.uid] = { uid: event.uid, ...scores };
+    }
+
+    if (updatedGames) {
+      followedGames.value = updatedGames;
     }
   };
 

--- a/apps/web/src/composables/useGameNotifications.ts
+++ b/apps/web/src/composables/useGameNotifications.ts
@@ -1,0 +1,109 @@
+import { ref, type Ref } from "vue";
+import { useStorage } from "@vueuse/core";
+import type { ESPNEvent } from "@/models/types";
+
+export interface FollowedGame {
+  uid: string;
+  label: string;
+  awayScore: string;
+  homeScore: string;
+}
+
+const STORAGE_KEY = "nba-followed-games";
+
+const isNotificationsSupported = (): boolean =>
+  typeof window !== "undefined" && "Notification" in window;
+
+const extractScores = (event: ESPNEvent): Omit<FollowedGame, "uid"> => {
+  const competitors = event.competitions?.[0]?.competitors ?? [];
+  const away = competitors.find((c) => c.homeAway === "away");
+  const home = competitors.find((c) => c.homeAway === "home");
+  return {
+    awayScore: away?.score ?? "",
+    homeScore: home?.score ?? "",
+    label: `${away?.team.shortDisplayName ?? "Away"} @ ${home?.team.shortDisplayName ?? "Home"}`,
+  };
+};
+
+export const useGameNotifications = () => {
+  const followedGames = useStorage<Record<string, FollowedGame>>(STORAGE_KEY, {});
+
+  const notificationPermission: Ref<NotificationPermission> = ref(
+    isNotificationsSupported() ? Notification.permission : "denied",
+  );
+
+  const requestPermission = async (): Promise<NotificationPermission> => {
+    if (!isNotificationsSupported()) {
+      return "denied";
+    }
+    if (notificationPermission.value !== "default") {
+      return notificationPermission.value;
+    }
+    const permission = await Notification.requestPermission();
+    notificationPermission.value = permission;
+    return permission;
+  };
+
+  const isFollowed = (uid: string): boolean => uid in followedGames.value;
+
+  const unfollowGame = (uid: string): void => {
+    const next = { ...followedGames.value };
+    delete next[uid];
+    followedGames.value = next;
+  };
+
+  const followGame = async (event: ESPNEvent): Promise<void> => {
+    await requestPermission();
+    followedGames.value = {
+      ...followedGames.value,
+      [event.uid]: { uid: event.uid, ...extractScores(event) },
+    };
+  };
+
+  const toggleFollow = async (event: ESPNEvent): Promise<void> => {
+    if (isFollowed(event.uid)) {
+      unfollowGame(event.uid);
+    } else {
+      await followGame(event);
+    }
+  };
+
+  const notifyScoreChanges = (events: ESPNEvent[]): void => {
+    if (notificationPermission.value !== "granted") {
+      return;
+    }
+
+    for (const event of events) {
+      const followed = followedGames.value[event.uid];
+      if (!followed) {
+        continue;
+      }
+
+      const scores = extractScores(event);
+      if (scores.awayScore === followed.awayScore && scores.homeScore === followed.homeScore) {
+        continue;
+      }
+
+      new Notification(scores.label, {
+        body: `${scores.awayScore} - ${scores.homeScore}`,
+        tag: event.uid,
+      });
+
+      followedGames.value = {
+        ...followedGames.value,
+        [event.uid]: { uid: event.uid, ...scores },
+      };
+    }
+  };
+
+  return {
+    followedGames,
+    notificationPermission,
+    notificationsSupported: isNotificationsSupported(),
+    requestPermission,
+    isFollowed,
+    toggleFollow,
+    unfollowGame,
+    notifyScoreChanges,
+  };
+};

--- a/apps/web/src/views/Scores.vue
+++ b/apps/web/src/views/Scores.vue
@@ -14,6 +14,7 @@ import PageTitle from "@/components/PageTitle.vue";
 import PageShell from "@/layouts/PageShell.vue";
 import GameReplaysWarning from "@/components/Scores/GameReplaysWarning.vue";
 import ManageNotifications from "@/components/Scores/ManageNotifications.vue";
+import { useGameNotifications } from "@/composables/useGameNotifications";
 import OptionsMenu from "@/components/Scores/OptionsMenu.vue";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -109,14 +110,7 @@ const handleConferenceFilterChange = (value: string | undefined) => {
 const useShortNames = ref<boolean>(true);
 const notificationsMenuOpen = ref<boolean>(false);
 
-/* TODO: Set in localStorage?  */
-const gamesWithNotifications = ref<Map<any, any>>(new Map());
-
-/* TODO/IDEA:
-- Notifications for score updates like Google?
-- Discord through javascript somehow?
-
-*/
+const { notifyScoreChanges } = useGameNotifications();
 
 const fetchCurrentScores = async (forDate?: Date) => {
     try {
@@ -131,6 +125,8 @@ const fetchCurrentScores = async (forDate?: Date) => {
 
         const data: ESPNScoreboardResponse = await response.json();
         const { events } = data;
+
+        notifyScoreChanges(events ?? []);
 
         scoreData.value = data;
         numGames.value = events?.length || 0;

--- a/apps/web/tests/composables/useGameNotifications.test.ts
+++ b/apps/web/tests/composables/useGameNotifications.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useGameNotifications } from "@/composables/useGameNotifications";
+import type { ESPNEvent } from "@/models/types";
+
+const makeEvent = (overrides: {
+    uid: string;
+    awayScore: string;
+    homeScore: string;
+}): ESPNEvent =>
+    ({
+        uid: overrides.uid,
+        competitions: [
+            {
+                competitors: [
+                    {
+                        homeAway: "away",
+                        score: overrides.awayScore,
+                        team: { shortDisplayName: "Away Team" },
+                    },
+                    {
+                        homeAway: "home",
+                        score: overrides.homeScore,
+                        team: { shortDisplayName: "Home Team" },
+                    },
+                ],
+            },
+        ],
+    }) as unknown as ESPNEvent;
+
+describe("useGameNotifications", () => {
+    let notificationCtor: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        localStorage.clear();
+        notificationCtor = vi.fn();
+        vi.stubGlobal(
+            "Notification",
+            Object.assign(notificationCtor, {
+                permission: "default" as NotificationPermission,
+                requestPermission: vi.fn().mockResolvedValue("granted"),
+            }),
+        );
+    });
+
+    it("is not followed before toggling", () => {
+        const { isFollowed } = useGameNotifications();
+        expect(isFollowed("game-1")).toBe(false);
+    });
+
+    it("follows a game and requests permission", async () => {
+        const { toggleFollow, isFollowed } = useGameNotifications();
+        const event = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+
+        await toggleFollow(event);
+
+        expect(isFollowed("game-1")).toBe(true);
+        expect(Notification.requestPermission).toHaveBeenCalled();
+    });
+
+    it("unfollows an already-followed game", async () => {
+        const { toggleFollow, isFollowed } = useGameNotifications();
+        const event = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+
+        await toggleFollow(event);
+        await toggleFollow(event);
+
+        expect(isFollowed("game-1")).toBe(false);
+    });
+
+    it("fires a notification when a followed game's score changes", async () => {
+        const { toggleFollow, notifyScoreChanges } = useGameNotifications();
+        const initial = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+        await toggleFollow(initial);
+
+        const updated = makeEvent({ uid: "game-1", awayScore: "13", homeScore: "12" });
+        notifyScoreChanges([updated]);
+
+        expect(notificationCtor).toHaveBeenCalledTimes(1);
+        expect(notificationCtor).toHaveBeenCalledWith(
+            "Away Team @ Home Team",
+            expect.objectContaining({ body: "13 - 12" }),
+        );
+    });
+
+    it("does not fire a notification when the score is unchanged", async () => {
+        const { toggleFollow, notifyScoreChanges } = useGameNotifications();
+        const initial = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+        await toggleFollow(initial);
+
+        notifyScoreChanges([initial]);
+
+        expect(notificationCtor).not.toHaveBeenCalled();
+    });
+
+    it("does not fire a notification for games that are not followed", () => {
+        const { notifyScoreChanges } = useGameNotifications();
+        const event = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+
+        notifyScoreChanges([event]);
+
+        expect(notificationCtor).not.toHaveBeenCalled();
+    });
+
+    it("does not fire a notification without granted permission", async () => {
+        (Notification as any).permission = "default";
+        (Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue("denied");
+
+        const { toggleFollow, notifyScoreChanges } = useGameNotifications();
+        const initial = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+        await toggleFollow(initial);
+
+        const updated = makeEvent({ uid: "game-1", awayScore: "13", homeScore: "12" });
+        notifyScoreChanges([updated]);
+
+        expect(notificationCtor).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/tests/composables/useGameNotifications.test.ts
+++ b/apps/web/tests/composables/useGameNotifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useGameNotifications } from "@/composables/useGameNotifications";
 import type { ESPNEvent } from "@/models/types";
+
+vi.mock("vue-sonner", () => ({ toast: { error: vi.fn() } }));
 
 const makeEvent = (overrides: {
     uid: string;
@@ -29,9 +30,11 @@ const makeEvent = (overrides: {
 
 describe("useGameNotifications", () => {
     let notificationCtor: ReturnType<typeof vi.fn>;
+    let useGameNotifications: typeof import("@/composables/useGameNotifications").useGameNotifications;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         localStorage.clear();
+        vi.resetModules();
         notificationCtor = vi.fn();
         vi.stubGlobal(
             "Notification",
@@ -40,6 +43,7 @@ describe("useGameNotifications", () => {
                 requestPermission: vi.fn().mockResolvedValue("granted"),
             }),
         );
+        ({ useGameNotifications } = await import("@/composables/useGameNotifications"));
     });
 
     it("is not followed before toggling", () => {
@@ -99,6 +103,46 @@ describe("useGameNotifications", () => {
         notifyScoreChanges([event]);
 
         expect(notificationCtor).not.toHaveBeenCalled();
+    });
+
+    it("shares granted permission across separate composable instances", async () => {
+        const componentA = useGameNotifications();
+        const componentB = useGameNotifications();
+        const event = makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" });
+
+        await componentA.toggleFollow(event);
+
+        expect(componentB.notificationPermission.value).toBe("granted");
+
+        const updated = makeEvent({ uid: "game-1", awayScore: "13", homeScore: "12" });
+        componentB.notifyScoreChanges([updated]);
+
+        expect(notificationCtor).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns the user when they follow a game but permission is denied", async () => {
+        const { toast } = await import("vue-sonner");
+        (Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue("denied");
+
+        const { toggleFollow } = useGameNotifications();
+        await toggleFollow(makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" }));
+
+        expect(toast.error).toHaveBeenCalledWith(
+            expect.stringContaining("browser permissions"),
+        );
+    });
+
+    it("warns the user when they follow a game on an unsupported browser", async () => {
+        vi.unstubAllGlobals();
+        const { toast } = await import("vue-sonner");
+
+        const { toggleFollow, isFollowed } = useGameNotifications();
+        await toggleFollow(makeEvent({ uid: "game-1", awayScore: "10", homeScore: "12" }));
+
+        expect(isFollowed("game-1")).toBe(true);
+        expect(toast.error).toHaveBeenCalledWith(
+            expect.stringContaining("doesn't support notifications"),
+        );
     });
 
     it("does not fire a notification without granted permission", async () => {


### PR DESCRIPTION
## Summary
Wires up `ManageNotifications.vue` and the per-game bell in `ScoreCard.vue` to request browser notification permission and fire a notification when a followed game's score changes.

- New `useGameNotifications` composable: localStorage-backed followed-games store, permission handling, score-diff notify.
- `ScoreCard.vue`: bell toggles follow via the composable; removes the old duplicated per-card permission logic.
- `ManageNotifications.vue`: replaces the "Coming Soon" placeholder with permission status + Enable button + followed-games list (unfollow per row).
- `Scores.vue`: poll loop calls `notifyScoreChanges` each fetch; drops the unused `gamesWithNotifications` map.

Closes #26

## Testing
- `pnpm --filter web test` (84 passing, including 7 new composable tests)
- `pnpm --filter web type-check`
- `pnpm --filter web check:styles`
- Manually verified in-browser with a mocked ESPN fixture: follow/unfollow, localStorage persistence, permission badge, cross-component reactivity.