### PR TITLE
feat(web): persist Scores filter preferences to localStorage

### DIFF
--- a/apps/web/src/composables/useScoresPreferences.ts
+++ b/apps/web/src/composables/useScoresPreferences.ts
@@ -1,0 +1,42 @@
+import { useStorage } from '@vueuse/core';
+import { VIEWS } from '@/constants/constants';
+
+export interface ScoresPreferences {
+  conferenceFilter: string;
+  selectedView: string;
+  useShortNames: boolean;
+  hideScores: boolean;
+  hideFinishedGames: boolean;
+}
+
+const DEFAULT_PREFERENCES: ScoresPreferences = {
+  conferenceFilter: 'ALL',
+  selectedView: VIEWS.DEFAULT,
+  useShortNames: true,
+  hideScores: false,
+  hideFinishedGames: false,
+};
+
+export const useScoresPreferences = () => {
+  const preferences = useStorage<ScoresPreferences>(
+    'nba-scores-preferences',
+    // A factory, not the object itself — useStorage assigns this value
+    // directly as the ref's initial contents when storage is empty, so a
+    // shared object literal here would let one instance's mutations leak
+    // into every other instance's "default".
+    () => ({ ...DEFAULT_PREFERENCES }),
+    undefined,
+    // Without this, anyone with preferences already in localStorage gets
+    // `undefined` for every key added after they first saved them.
+    { mergeDefaults: true }
+  );
+
+  const resetPreferences = () => {
+    preferences.value = { ...DEFAULT_PREFERENCES };
+  };
+
+  return {
+    preferences,
+    resetPreferences,
+  };
+};

--- a/apps/web/src/views/Scores.vue
+++ b/apps/web/src/views/Scores.vue
@@ -15,6 +15,7 @@ import PageShell from "@/layouts/PageShell.vue";
 import GameReplaysWarning from "@/components/Scores/GameReplaysWarning.vue";
 import ManageNotifications from "@/components/Scores/ManageNotifications.vue";
 import { useGameNotifications } from "@/composables/useGameNotifications";
+import { useScoresPreferences } from "@/composables/useScoresPreferences";
 import OptionsMenu from "@/components/Scores/OptionsMenu.vue";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -93,11 +94,24 @@ const games = ref<any[]>([]);
 const gameTeams = ref<any[]>([]);
 
 const showReplayConfirm = ref<boolean>(false);
-const hideScores = ref<boolean>(false);
-const hideFinishedGames = ref<boolean>(false);
 
-const selectedView = ref<string>("Default");
-const conferenceFilter = ref<string>("ALL");
+const { preferences: scoresPreferences } = useScoresPreferences();
+const hideScores = computed({
+    get: () => scoresPreferences.value.hideScores,
+    set: (value) => { scoresPreferences.value.hideScores = value; },
+});
+const hideFinishedGames = computed({
+    get: () => scoresPreferences.value.hideFinishedGames,
+    set: (value) => { scoresPreferences.value.hideFinishedGames = value; },
+});
+const selectedView = computed({
+    get: () => scoresPreferences.value.selectedView,
+    set: (value) => { scoresPreferences.value.selectedView = value; },
+});
+const conferenceFilter = computed({
+    get: () => scoresPreferences.value.conferenceFilter,
+    set: (value) => { scoresPreferences.value.conferenceFilter = value; },
+});
 
 const handleConferenceFilterChange = (value: string | undefined) => {
     // Prevent deselection - keep current value if user clicks the selected item
@@ -107,7 +121,10 @@ const handleConferenceFilterChange = (value: string | undefined) => {
     conferenceFilter.value = value;
 };
 
-const useShortNames = ref<boolean>(true);
+const useShortNames = computed({
+    get: () => scoresPreferences.value.useShortNames,
+    set: (value) => { scoresPreferences.value.useShortNames = value; },
+});
 const notificationsMenuOpen = ref<boolean>(false);
 
 const { notifyScoreChanges } = useGameNotifications();

--- a/apps/web/tests/composables/useScoresPreferences.test.ts
+++ b/apps/web/tests/composables/useScoresPreferences.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { nextTick } from 'vue';
+import { useScoresPreferences } from '@/composables/useScoresPreferences';
+
+describe('useScoresPreferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('provides default preferences', () => {
+    const { preferences } = useScoresPreferences();
+    expect(preferences.value.conferenceFilter).toBe('ALL');
+    expect(preferences.value.selectedView).toBe('Default');
+    expect(preferences.value.useShortNames).toBe(true);
+    expect(preferences.value.hideScores).toBe(false);
+    expect(preferences.value.hideFinishedGames).toBe(false);
+  });
+
+  it('allows updating preferences', () => {
+    const { preferences } = useScoresPreferences();
+    preferences.value.conferenceFilter = 'EAST';
+    expect(preferences.value.conferenceFilter).toBe('EAST');
+  });
+
+  it('persists preferences across composable instances', async () => {
+    const first = useScoresPreferences();
+    first.preferences.value.conferenceFilter = 'WEST';
+    first.preferences.value.hideScores = true;
+    await nextTick();
+
+    const second = useScoresPreferences();
+    expect(second.preferences.value.conferenceFilter).toBe('WEST');
+    expect(second.preferences.value.hideScores).toBe(true);
+  });
+
+  it('resets preferences back to defaults', () => {
+    const { preferences, resetPreferences } = useScoresPreferences();
+    preferences.value.conferenceFilter = 'CROSS';
+    preferences.value.selectedView = 'List';
+    preferences.value.useShortNames = false;
+    preferences.value.hideScores = true;
+    preferences.value.hideFinishedGames = true;
+
+    resetPreferences();
+
+    expect(preferences.value.conferenceFilter).toBe('ALL');
+    expect(preferences.value.selectedView).toBe('Default');
+    expect(preferences.value.useShortNames).toBe(true);
+    expect(preferences.value.hideScores).toBe(false);
+    expect(preferences.value.hideFinishedGames).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #27

Adds `useScoresPreferences`, a `useStorage`-backed composable (same pattern as `usePlayerStatsPreferences`), and wires it into `Scores.vue` in place of the 5 plain refs for `conferenceFilter`, `selectedView`, `useShortNames`, `hideScores`, and `hideFinishedGames`. These now persist across reloads.

`selectedDate` intentionally stays session-only (always defaults to today) so returning users don't land on a stale past date.

## Testing
- `vue-tsc --noEmit`: clean
- `pnpm --filter web check:styles`: 146 files, no problems
- `pnpm --filter web test`: 91/91 passing (adds 4 new tests for the composable)
- `pnpm --filter web test:visual`: 20/20 passing, no pixel diffs