### PR TITLE
fix(cdk): return full file name and awaited signed URL on upload completion

### DIFF
--- a/apps/cdk/service/lambdas/completeMultipartUpload/src/completeMultipartUpload.ts
+++ b/apps/cdk/service/lambdas/completeMultipartUpload/src/completeMultipartUpload.ts
@@ -46,7 +46,7 @@ export const handler: Handler = async (
 
         // Getting file metadata
         const splitKey = key.split("/");
-        const [fileName] = splitKey[splitKey.length - 1];
+        const fileName = splitKey[splitKey.length - 1];
         const headObjectCommand = new HeadObjectCommand({
             Bucket: mainBucket,
             Key: key,
@@ -57,7 +57,7 @@ export const handler: Handler = async (
             Bucket: mainBucket,
             Key: key,
         });
-        const signedURL = getSignedUrl(s3Client, getObjectCommand, {
+        const signedURL = await getSignedUrl(s3Client, getObjectCommand, {
             expiresIn: 86400, // One day in seconds
         });
 

--- a/apps/cdk/test/lambdas/completeMultipartUpload.test.ts
+++ b/apps/cdk/test/lambdas/completeMultipartUpload.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const send = vi.fn();
+const getSignedUrl = vi.fn();
+
+vi.mock("@aws-sdk/client-s3", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@aws-sdk/client-s3")>();
+	return {
+		...actual,
+		S3Client: class {
+			send = send;
+		},
+	};
+});
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+	getSignedUrl: (...args: any[]) => getSignedUrl(...args),
+}));
+
+process.env.mainBucket = "test-bucket";
+
+const { handler } = await import(
+	"lambdas/completeMultipartUpload/src/completeMultipartUpload"
+);
+
+const uploadEvent = (key: string) => ({
+	body: JSON.stringify({
+		key,
+		uploadId: "upload-1",
+		parts: [{ ETag: "etag-1", PartNumber: 1 }],
+	}),
+});
+
+const invoke = (key: string) =>
+	handler(uploadEvent(key) as any, {} as any, {} as any) as Promise<any>;
+
+beforeEach(() => {
+	send.mockReset();
+	getSignedUrl.mockReset();
+	getSignedUrl.mockResolvedValue("https://signed.example/photo.png");
+});
+
+describe("completeMultipartUpload", () => {
+	it("returns the full file name and a resolved signed URL", async () => {
+		send.mockResolvedValueOnce({});
+		send.mockResolvedValueOnce({ ContentLength: 12345 });
+
+		const result = await invoke("uploads/user-1/photo.png");
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({
+			name: "photo.png",
+			key: "uploads/user-1/photo.png",
+			size: 12345,
+			signedURL: "https://signed.example/photo.png",
+		});
+	});
+
+	it("completes the upload with the requested key, upload id and parts", async () => {
+		send.mockResolvedValueOnce({});
+		send.mockResolvedValueOnce({ ContentLength: 1 });
+
+		await invoke("uploads/user-1/photo.png");
+
+		const completeInput = send.mock.calls[0][0].input;
+		expect(completeInput).toMatchObject({
+			Bucket: "test-bucket",
+			Key: "uploads/user-1/photo.png",
+			UploadId: "upload-1",
+			MultipartUpload: { Parts: [{ ETag: "etag-1", PartNumber: 1 }] },
+		});
+	});
+
+	it("falls back to a zero size when S3 reports no content length", async () => {
+		send.mockResolvedValueOnce({});
+		send.mockResolvedValueOnce({});
+
+		const result = await invoke("photo.png");
+
+		expect(JSON.parse(result.body).size).toBe(0);
+	});
+
+	it("500s when completing the upload fails", async () => {
+		send.mockRejectedValueOnce(new Error("NoSuchUpload"));
+
+		const result = await invoke("uploads/user-1/photo.png");
+
+		expect(result.statusCode).toBe(500);
+		expect(JSON.parse(result.body)).toEqual({ message: "Error" });
+	});
+});


### PR DESCRIPTION
Fixes both defects on the success path of `completeMultipartUpload`, so a successful multipart completion no longer returns a malformed body.

- `const [fileName] = splitKey[splitKey.length - 1]` array-destructured a string, binding only its first character — `photo.png` came back as `"p"`.
- `getSignedUrl` was never awaited, so `JSON.stringify` serialized the pending promise as `{}`.

Adds `apps/cdk/test/lambdas/completeMultipartUpload.test.ts`, which the handler previously had no coverage from. The first test fails on `main` with exactly the two symptoms from the issue:

```
- "name": "photo.png",                          + "name": "p",
- "signedURL": "https://signed.example/photo.png"  + "signedURL": {},
```

Tests cover the 200 response body shape, the `CompleteMultipartUploadCommand` input (bucket, key, upload id, parts), the fallback to size `0` when S3 reports no `ContentLength`, and the 500 error path.

Verified with `pnpm --filter cdk test` (103 passed, up from 99), `pnpm --filter cdk build`, and `pnpm --filter cdk lint` (0 errors).

Closes #45

https://claude.ai/code/session_01QjNvJjZYjKWvS3Yu7XUmPm
