### PR TITLE
feat: add self-hosted Umami analytics

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NBA Team Builder</title>
+    <!-- Umami analytics — self-hosted, cookieless. See C:\Projects\umami-flyio.
+         Host is umami-af.fly.dev until analytics.yusufaf.dev's cert is set up. -->
+    <script defer src="https://umami-af.fly.dev/s.js" data-website-id="e61804bb-ee89-4519-8636-beeb54e3dc7f"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Cookieless, self-hosted Umami tracker. Served from `analytics.yusufaf.dev` (temporarily `umami-af.fly.dev` until the custom domain cert is set up). See [yusufaf/umami-flyio](https://github.com/yusufaf/umami-flyio).

https://claude.ai/code/session_01QhkM8KvBJLTksPR22Vkb96