### PR TITLE
fix: point Umami tracker at analytics.yusufaf.dev

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,9 +5,8 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NBA Team Builder</title>
-    <!-- Umami analytics — self-hosted, cookieless. See C:\Projects\umami-flyio.
-         Host is umami-af.fly.dev until analytics.yusufaf.dev's cert is set up. -->
-    <script defer src="https://umami-af.fly.dev/s.js" data-website-id="e61804bb-ee89-4519-8636-beeb54e3dc7f"></script>
+    <!-- Umami analytics — self-hosted, cookieless. See C:\Projects\umami-flyio. -->
+    <script defer src="https://analytics.yusufaf.dev/s.js" data-website-id="e61804bb-ee89-4519-8636-beeb54e3dc7f"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Custom domain cert is verified and live. Swap from the temporary umami-af.fly.dev.

https://claude.ai/code/session_01QhkM8KvBJLTksPR22Vkb96