### PR TITLE
fix(web): use a factory for usePlayerStatsPreferences defaults

### DIFF
--- a/apps/web/src/composables/usePlayerStatsPreferences.ts
+++ b/apps/web/src/composables/usePlayerStatsPreferences.ts
@@ -18,7 +18,11 @@ const DEFAULT_PREFERENCES: PlayerStatsPreferences = {
 export const usePlayerStatsPreferences = () => {
   const preferences = useStorage<PlayerStatsPreferences>(
     'nba-player-stats-preferences',
-    DEFAULT_PREFERENCES,
+    // A factory, not the object itself — useStorage assigns this value
+    // directly as the ref's initial contents when storage is empty, so a
+    // shared object literal here would let one instance's mutations leak
+    // into every other instance's "default".
+    () => ({ ...DEFAULT_PREFERENCES }),
     undefined,
     // Without this, anyone with preferences already in localStorage gets
     // `undefined` for every key added after they first saved them.

--- a/apps/web/tests/composables/usePlayerStatsPreferences.test.ts
+++ b/apps/web/tests/composables/usePlayerStatsPreferences.test.ts
@@ -1,12 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { usePlayerStatsPreferences } from '@/composables/usePlayerStatsPreferences';
 
 describe('usePlayerStatsPreferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('provides default preferences', () => {
     const { preferences } = usePlayerStatsPreferences();
     expect(preferences.value.seasonFormat).toBe('YYYY-YY');
     expect(preferences.value.statMode).toBe('per_game');
     expect(preferences.value.showCareerSummary).toBe(true);
+    expect(preferences.value.highlightCareerHighs).toBe(true);
   });
 
   it('allows updating preferences', () => {
@@ -20,11 +25,25 @@ describe('usePlayerStatsPreferences', () => {
     preferences.value.seasonFormat = 'YYYY+1';
     preferences.value.statMode = 'totals';
     preferences.value.showCareerSummary = false;
+    preferences.value.highlightCareerHighs = false;
 
     resetPreferences();
 
     expect(preferences.value.seasonFormat).toBe('YYYY-YY');
     expect(preferences.value.statMode).toBe('per_game');
     expect(preferences.value.showCareerSummary).toBe(true);
+    expect(preferences.value.highlightCareerHighs).toBe(true);
+  });
+
+  it("does not leak one instance's mutations into another's defaults", () => {
+    const first = usePlayerStatsPreferences();
+    first.preferences.value.statMode = 'totals';
+    first.preferences.value.showCareerSummary = false;
+
+    localStorage.clear();
+
+    const second = usePlayerStatsPreferences();
+    expect(second.preferences.value.statMode).toBe('per_game');
+    expect(second.preferences.value.showCareerSummary).toBe(true);
   });
 });


### PR DESCRIPTION
usePlayerStatsPreferences.ts passed the module-level DEFAULT_PREFERENCES object literal straight to useStorage's defaults argument. When localStorage is empty, useStorage assigns that exact object as the ref's raw value, and Vue's ref() wraps it in a reactive proxy rather than cloning it — so mutating preferences.value.someKey mutates the shared DEFAULT_PREFERENCES singleton. Every later usePlayerStatsPreferences() call made against empty storage (or resetPreferences()) then inherits the already-mutated defaults.

useScoresPreferences.ts already avoids this with a factory function (`() => ({...DEFAULT_PREFERENCES})`). This applies the same fix here.

## Changes
- `usePlayerStatsPreferences.ts`: pass a factory instead of the object literal.
- Test suite: add `beforeEach(() => localStorage.clear())` (the existing "resets preferences back to defaults" case only passed by accident, since nothing cleared storage between cases), add a cross-instance leak regression test, and cover the previously-unasserted `highlightCareerHighs` field.

Confirmed the new/changed tests fail on the old code and pass after the fix.

Closes #38

https://claude.ai/code/session_01N96ZpD1vHb2m4WEA36C9sz