### PR TITLE
fix: bump fast-uri override to 3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "qs": "6.15.3",
       "path-to-regexp": "8.4.2",
       "lodash-es": "4.18.1",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.6",
       "nanoid": "3.3.18",
       "hono": "4.12.31",
       "express-rate-limit": "8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   qs: 6.15.3
   path-to-regexp: 8.4.2
   lodash-es: 4.18.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   nanoid: 3.3.18
   hono: 4.12.31
   express-rate-limit: 8.6.0
@@ -2194,8 +2194,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-xml-builder@1.3.1:
     resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
@@ -5338,7 +5338,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5979,7 +5979,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-xml-builder@1.3.1:
     dependencies:


### PR DESCRIPTION
Bumps the pinned `fast-uri` pnpm override from 3.1.5 to 3.1.6.

Closes 4 open Dependabot alerts, all high severity:
- GHSA-5jgf-p345-68v8 (host confusion via skipped IDN canonicalization)
- GHSA-jqff-g426-hqxp (host confusion via percent-encoded scheme normalization)
- GHSA-fph4-wmhf-6fwf (SSRF via repeated hostname percent-decoding)
- GHSA-f65p-4m7j-42xc (SSRF via malformed IPv6 normalization)

3.1.5 looked patched at a glance (later than the 2.4.5 fix version quoted in the advisories) but each advisory's vulnerable range for the 3.x line is actually `< 3.1.6` — 3.1.5 was still in range. Bumping the override to 3.1.6 resolves all four.

`fast-uri` is a transitive dev dependency (via `ajv`), pinned only through the root `pnpm.overrides`. No app code touches it directly.

Verified: `pnpm install`, `pnpm --filter web lint`, `pnpm --filter cdk lint`, and the pre-commit hook's test suite (92/92 passing) all green.

https://claude.ai/code/session_01N96ZpD1vHb2m4WEA36C9sz