### PR TITLE
fix: derive S3 file-lambda owner from authorizer sub, not the request body

### DIFF
--- a/apps/cdk/service/lambdas/completeMultipartUpload/src/completeMultipartUpload.ts
+++ b/apps/cdk/service/lambdas/completeMultipartUpload/src/completeMultipartUpload.ts
@@ -12,7 +12,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { AuthorizerContext } from "models/auth";
-import { parseRequestBody } from "utilities/request-body";
+import { isOwnedKey, parseRequestBody } from "utilities/request-body";
 
 const { mainBucket = "" } = process.env;
 
@@ -45,6 +45,16 @@ export const handler: Handler = async (
             };
         }
         const { key, uploadId, parts } = parsed.body;
+
+        const sub = event.requestContext?.authorizer?.lambda?.sub;
+        if (!isOwnedKey(key, sub)) {
+            return {
+                statusCode: 403,
+                body: JSON.stringify({
+                    message: "Forbidden",
+                }),
+            };
+        }
 
         const completeMultipartUploadCommand =
             new CompleteMultipartUploadCommand({

--- a/apps/cdk/service/lambdas/deleteFile/src/deleteFile.ts
+++ b/apps/cdk/service/lambdas/deleteFile/src/deleteFile.ts
@@ -5,7 +5,7 @@ import {
 } from "aws-lambda";
 import { S3Client, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { AuthorizerContext } from "models/auth";
-import { parseRequestBody } from "utilities/request-body";
+import { isOwnedKey, parseRequestBody } from "utilities/request-body";
 
 const { mainBucket = "" } = process.env;
 
@@ -34,6 +34,16 @@ export const handler: Handler = async (
             };
         }
         const { key } = parsed.body;
+
+        const sub = event.requestContext?.authorizer?.lambda?.sub;
+        if (!isOwnedKey(key, sub)) {
+            return {
+                statusCode: 403,
+                body: JSON.stringify({
+                    message: "Forbidden",
+                }),
+            };
+        }
 
         const deleteCommand = new DeleteObjectCommand({
             Bucket: mainBucket,

--- a/apps/cdk/service/lambdas/getMultipartSignedUploadUrls/src/getMultipartSignedUploadUrls.ts
+++ b/apps/cdk/service/lambdas/getMultipartSignedUploadUrls/src/getMultipartSignedUploadUrls.ts
@@ -9,7 +9,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { AuthorizerContext } from "models/auth";
-import { parseRequestBody } from "utilities/request-body";
+import { isOwnedKey, parseRequestBody } from "utilities/request-body";
 
 // S3's hard limit on parts in a single multipart upload. Signing beyond it
 // can only produce URLs the upload will reject, and a large numParts would
@@ -47,6 +47,16 @@ export const handler: Handler = async (
             };
         }
         const { key, uploadId, numParts } = parsed.body;
+
+        const sub = event.requestContext?.authorizer?.lambda?.sub;
+        if (!isOwnedKey(key, sub)) {
+            return {
+                statusCode: 403,
+                body: JSON.stringify({
+                    message: "Forbidden",
+                }),
+            };
+        }
 
         if (
             !Number.isInteger(numParts) ||

--- a/apps/cdk/service/lambdas/initiateMultipartUpload/src/initiateMultipartUpload.ts
+++ b/apps/cdk/service/lambdas/initiateMultipartUpload/src/initiateMultipartUpload.ts
@@ -42,6 +42,18 @@ export const handler: Handler = async (
         }
         const { contentType, fileName, studysetUUID } = parsed.body;
 
+        // A "/" in either field would shift the owner segment the key-taking
+        // handlers expect at index 1, locking the caller out of their own
+        // upload (isOwnedKey in utilities/request-body.ts).
+        if (studysetUUID.includes("/") || fileName.includes("/")) {
+            return {
+                statusCode: 400,
+                body: JSON.stringify({
+                    message: "studysetUUID and fileName must not contain '/'",
+                }),
+            };
+        }
+
         // The owner segment comes from the caller's verified sub, not the
         // request body, so a caller can't create an upload under someone
         // else's prefix by naming a different userUUID.

--- a/apps/cdk/service/lambdas/initiateMultipartUpload/src/initiateMultipartUpload.ts
+++ b/apps/cdk/service/lambdas/initiateMultipartUpload/src/initiateMultipartUpload.ts
@@ -14,7 +14,6 @@ const s3Client = new S3Client();
 type RequestBody = {
     studysetUUID: string;
     uploadType: string;
-    userUUID: string;
     fileName: string;
     contentType: string;
 };
@@ -27,11 +26,10 @@ export const handler: Handler = async (
 
     try {
         // contentType is not required: S3 falls back to a default and the
-        // object is still usable, unlike the three fields the key is built
-        // from, which would otherwise produce "undefined/undefined/undefined".
+        // object is still usable, unlike the two fields the key is built
+        // from, which would otherwise produce "undefined/undefined".
         const parsed = parseRequestBody<RequestBody>(event.body, {
             studysetUUID: "string",
-            userUUID: "string",
             fileName: "string",
         });
         if (!parsed.valid) {
@@ -42,9 +40,22 @@ export const handler: Handler = async (
                 }),
             };
         }
-        const { contentType, fileName, studysetUUID, userUUID } = parsed.body;
+        const { contentType, fileName, studysetUUID } = parsed.body;
 
-        const key = `${studysetUUID}/${userUUID}/${fileName}`;
+        // The owner segment comes from the caller's verified sub, not the
+        // request body, so a caller can't create an upload under someone
+        // else's prefix by naming a different userUUID.
+        const sub = event.requestContext?.authorizer?.lambda?.sub;
+        if (!sub) {
+            return {
+                statusCode: 403,
+                body: JSON.stringify({
+                    message: "Forbidden",
+                }),
+            };
+        }
+
+        const key = `${studysetUUID}/${sub}/${fileName}`;
 
         const multipartCommand = new CreateMultipartUploadCommand({
             Bucket: mainBucket,

--- a/apps/cdk/test/lambdas/completeMultipartUpload.test.ts
+++ b/apps/cdk/test/lambdas/completeMultipartUpload.test.ts
@@ -23,19 +23,24 @@ const { handler } = await import(
 	"lambdas/completeMultipartUpload/src/completeMultipartUpload"
 );
 
-const uploadEvent = (key: string) => ({
+const uploadEvent = (key: string, sub: string | undefined = "user-1") => ({
 	body: JSON.stringify({
 		key,
 		uploadId: "upload-1",
 		parts: [{ ETag: "etag-1", PartNumber: 1 }],
 	}),
+	requestContext: { authorizer: { lambda: { sub } } },
 });
 
-const invoke = (key: string) =>
-	handler(uploadEvent(key) as any, {} as any, {} as any) as Promise<any>;
+const invoke = (key: string, sub?: string) =>
+	handler(uploadEvent(key, sub) as any, {} as any, {} as any) as Promise<any>;
 
-const invokeWithBody = (body?: string) =>
-	handler({ body } as any, {} as any, {} as any) as Promise<any>;
+const invokeWithBody = (body?: string, sub: string | undefined = "user-1") =>
+	handler(
+		{ body, requestContext: { authorizer: { lambda: { sub } } } } as any,
+		{} as any,
+		{} as any,
+	) as Promise<any>;
 
 beforeEach(() => {
 	send.mockReset();
@@ -78,7 +83,7 @@ describe("completeMultipartUpload", () => {
 		send.mockResolvedValueOnce({});
 		send.mockResolvedValueOnce({});
 
-		const result = await invoke("photo.png");
+		const result = await invoke("uploads/user-1/photo.png");
 
 		expect(JSON.parse(result.body).size).toBe(0);
 	});
@@ -119,6 +124,14 @@ describe("completeMultipartUpload", () => {
 		expect(JSON.parse(result.body).message).toBe(
 			"Missing or invalid field(s): key, parts",
 		);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("403s when the key belongs to a different user", async () => {
+		const result = await invoke("uploads/user-2/photo.png");
+
+		expect(result.statusCode).toBe(403);
+		expect(JSON.parse(result.body)).toEqual({ message: "Forbidden" });
 		expect(send).not.toHaveBeenCalled();
 	});
 

--- a/apps/cdk/test/lambdas/deleteFile.test.ts
+++ b/apps/cdk/test/lambdas/deleteFile.test.ts
@@ -16,8 +16,12 @@ process.env.mainBucket = "test-bucket";
 
 const { handler } = await import("lambdas/deleteFile/src/deleteFile");
 
-const invokeWithBody = (body?: string) =>
-	handler({ body } as any, {} as any, {} as any) as Promise<any>;
+const invokeWithBody = (body?: string, sub: string | undefined = "user-1") =>
+	handler(
+		{ body, requestContext: { authorizer: { lambda: { sub } } } } as any,
+		{} as any,
+		{} as any,
+	) as Promise<any>;
 
 beforeEach(() => {
 	send.mockReset();
@@ -62,6 +66,30 @@ describe("deleteFile", () => {
 		expect(JSON.parse(result.body).message).toBe(
 			"Missing or invalid field(s): key",
 		);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("403s when the key belongs to a different user", async () => {
+		const result = await invokeWithBody(
+			JSON.stringify({ key: "uploads/user-2/photo.png" }),
+		);
+
+		expect(result.statusCode).toBe(403);
+		expect(JSON.parse(result.body)).toEqual({ message: "Forbidden" });
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("403s when the caller has no sub", async () => {
+		const result = await handler(
+			{
+				body: JSON.stringify({ key: "uploads/user-1/photo.png" }),
+				requestContext: { authorizer: { lambda: {} } },
+			} as any,
+			{} as any,
+			{} as any,
+		) as any;
+
+		expect(result.statusCode).toBe(403);
 		expect(send).not.toHaveBeenCalled();
 	});
 

--- a/apps/cdk/test/lambdas/getMultipartSignedUploadUrls.test.ts
+++ b/apps/cdk/test/lambdas/getMultipartSignedUploadUrls.test.ts
@@ -23,8 +23,12 @@ const { handler } = await import(
 	"lambdas/getMultipartSignedUploadUrls/src/getMultipartSignedUploadUrls"
 );
 
-const invokeWithBody = (body?: string) =>
-	handler({ body } as any, {} as any, {} as any) as Promise<any>;
+const invokeWithBody = (body?: string, sub: string | undefined = "user-1") =>
+	handler(
+		{ body, requestContext: { authorizer: { lambda: { sub } } } } as any,
+		{} as any,
+		{} as any,
+	) as Promise<any>;
 
 beforeEach(() => {
 	send.mockReset();
@@ -100,6 +104,20 @@ describe("getMultipartSignedUploadUrls", () => {
 		expect(JSON.parse(result.body).message).toBe(
 			"numParts must be an integer between 1 and 10000",
 		);
+		expect(getSignedUrl).not.toHaveBeenCalled();
+	});
+
+	it("403s when the key belongs to a different user", async () => {
+		const result = await invokeWithBody(
+			JSON.stringify({
+				key: "uploads/user-2/photo.png",
+				uploadId: "upload-1",
+				numParts: 1,
+			}),
+		);
+
+		expect(result.statusCode).toBe(403);
+		expect(JSON.parse(result.body)).toEqual({ message: "Forbidden" });
 		expect(getSignedUrl).not.toHaveBeenCalled();
 	});
 

--- a/apps/cdk/test/lambdas/initiateMultipartUpload.test.ts
+++ b/apps/cdk/test/lambdas/initiateMultipartUpload.test.ts
@@ -18,8 +18,12 @@ const { handler } = await import(
 	"lambdas/initiateMultipartUpload/src/initiateMultipartUpload"
 );
 
-const invokeWithBody = (body?: string) =>
-	handler({ body } as any, {} as any, {} as any) as Promise<any>;
+const invokeWithBody = (body?: string, sub: string | undefined = "user-1") =>
+	handler(
+		{ body, requestContext: { authorizer: { lambda: { sub } } } } as any,
+		{} as any,
+		{} as any,
+	) as Promise<any>;
 
 beforeEach(() => {
 	send.mockReset();
@@ -67,8 +71,40 @@ describe("initiateMultipartUpload", () => {
 
 		expect(result.statusCode).toBe(400);
 		expect(JSON.parse(result.body).message).toBe(
-			"Missing or invalid field(s): studysetUUID, userUUID, fileName",
+			"Missing or invalid field(s): studysetUUID, fileName",
 		);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("builds the key from the caller's sub, not a client-supplied userUUID", async () => {
+		send.mockResolvedValueOnce({ UploadId: "upload-1" });
+
+		const result = await invokeWithBody(
+			JSON.stringify({
+				studysetUUID: "studyset-1",
+				userUUID: "someone-elses-uuid",
+				fileName: "photo.png",
+			}),
+			"user-1",
+		);
+
+		expect(JSON.parse(result.body).key).toBe("studyset-1/user-1/photo.png");
+	});
+
+	it("403s when the caller has no sub", async () => {
+		const result = await handler(
+			{
+				body: JSON.stringify({
+					studysetUUID: "studyset-1",
+					fileName: "photo.png",
+				}),
+				requestContext: { authorizer: { lambda: {} } },
+			} as any,
+			{} as any,
+			{} as any,
+		) as any;
+
+		expect(result.statusCode).toBe(403);
 		expect(send).not.toHaveBeenCalled();
 	});
 

--- a/apps/cdk/test/lambdas/initiateMultipartUpload.test.ts
+++ b/apps/cdk/test/lambdas/initiateMultipartUpload.test.ts
@@ -91,6 +91,30 @@ describe("initiateMultipartUpload", () => {
 		expect(JSON.parse(result.body).key).toBe("studyset-1/user-1/photo.png");
 	});
 
+	it("400s when studysetUUID contains a slash, which would shift the owner segment", async () => {
+		const result = await invokeWithBody(
+			JSON.stringify({
+				studysetUUID: "a/b",
+				fileName: "photo.png",
+			}),
+		);
+
+		expect(result.statusCode).toBe(400);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when fileName contains a slash, which would shift the owner segment", async () => {
+		const result = await invokeWithBody(
+			JSON.stringify({
+				studysetUUID: "studyset-1",
+				fileName: "a/b.png",
+			}),
+		);
+
+		expect(result.statusCode).toBe(400);
+		expect(send).not.toHaveBeenCalled();
+	});
+
 	it("403s when the caller has no sub", async () => {
 		const result = await handler(
 			{

--- a/apps/cdk/test/utilities/request-body.test.ts
+++ b/apps/cdk/test/utilities/request-body.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseRequestBody } from "utilities/request-body";
+import { isOwnedKey, parseRequestBody } from "utilities/request-body";
 
 type Body = {
 	key: string;
@@ -87,5 +87,23 @@ describe("parseRequestBody", () => {
 			valid: false,
 			error: "Missing or invalid field(s): numParts",
 		});
+	});
+});
+
+describe("isOwnedKey", () => {
+	it("is true when the key's owner segment matches the caller's sub", () => {
+		expect(isOwnedKey("studyset-1/user-1/photo.png", "user-1")).toBe(true);
+	});
+
+	it("is false when the key's owner segment belongs to someone else", () => {
+		expect(isOwnedKey("studyset-1/user-1/photo.png", "user-2")).toBe(false);
+	});
+
+	it("is false when the key has no owner segment", () => {
+		expect(isOwnedKey("photo.png", "user-1")).toBe(false);
+	});
+
+	it("is false when there is no caller sub", () => {
+		expect(isOwnedKey("studyset-1/user-1/photo.png", undefined)).toBe(false);
 	});
 });

--- a/apps/cdk/utilities/request-body.ts
+++ b/apps/cdk/utilities/request-body.ts
@@ -48,3 +48,10 @@ export const parseRequestBody = <T>(
 
 	return { valid: true, body: parsed as T };
 };
+
+// The S3 key-taking handlers build keys as {prefix}/{ownerSub}/{fileName}.
+// The owner segment must match the caller's sub (from the Lambda authorizer
+// context) or a caller could act on another user's objects by naming their
+// key, since the key itself carries no secret.
+export const isOwnedKey = (key: string, sub: string | undefined): boolean =>
+	sub !== undefined && key.split("/")[1] === sub;


### PR DESCRIPTION
## Summary
Fixes #53. The S3 file Lambdas trusted the caller-supplied key (or the pieces it's built from) without checking it against the caller's identity, so any authenticated user could delete, sign uploads for, or complete uploads against another user's objects — and could create uploads under someone else's prefix.

## Fix
- Added `isOwnedKey(key, sub)` next to `parseRequestBody` in `utilities/request-body.ts` — checks the key's owner segment (`{prefix}/{ownerSub}/{fileName}`) against `event.requestContext.authorizer.lambda.sub`.
- `deleteFile`, `getMultipartSignedUploadUrls`, `completeMultipartUpload`: 403 when the key's owner segment doesn't match the caller's sub.
- `initiateMultipartUpload`: builds the key's owner segment from `sub` instead of trusting a client-supplied `userUUID`; 403 if there's no sub.

## Testing
- `pnpm --filter cdk test` — 145 passed, including new ownership tests per handler and for `isOwnedKey` itself.
- `pnpm --filter cdk build` (tsc) clean.
- `pnpm --filter cdk lint` — 0 errors (pre-existing `any` warnings only, none from touched files beyond existing test conventions).
- Full pre-commit hook (web type-check, check:styles, both packages' test suites) passed.

https://claude.ai/code/session_01N96ZpD1vHb2m4WEA36C9sz