### PR TITLE
fix: guard QuarterScores against a missing competitor

### DIFF
--- a/apps/web/src/components/BoxScore/QuarterScores.vue
+++ b/apps/web/src/components/BoxScore/QuarterScores.vue
@@ -1,5 +1,5 @@
 <template>
-    <Card v-if="hasLineScores">
+    <Card v-if="awayTeam && homeTeam && hasLineScores">
         <CardContent class="p-3 overflow-x-auto">
             <Table>
                 <TableHeader>
@@ -91,11 +91,12 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const awayTeam = computed(() => props.competitors.find(c => c.homeAway === 'away')!);
-const homeTeam = computed(() => props.competitors.find(c => c.homeAway === 'home')!);
+const awayTeam = computed(() => props.competitors.find(c => c.homeAway === 'away'));
+const homeTeam = computed(() => props.competitors.find(c => c.homeAway === 'home'));
 
 // Check if we have any line scores to display
 const hasLineScores = computed(() => {
+    if (!awayTeam.value || !homeTeam.value) return false;
     const awayScores = awayTeam.value.linescores?.length || 0;
     const homeScores = homeTeam.value.linescores?.length || 0;
     return awayScores > 0 || homeScores > 0;
@@ -104,8 +105,8 @@ const hasLineScores = computed(() => {
 // Build period labels (Q1, Q2, Q3, Q4, OT, OT2, etc.)
 const periods = computed(() => {
     const maxPeriods = Math.max(
-        awayTeam.value.linescores?.length || 0,
-        homeTeam.value.linescores?.length || 0
+        awayTeam.value?.linescores?.length || 0,
+        homeTeam.value?.linescores?.length || 0
     );
 
     return Array.from({ length: maxPeriods }, (_, i) => {
@@ -127,7 +128,7 @@ const periods = computed(() => {
 // Build score maps for easy lookup
 const awayPeriodScores = computed(() => {
     const scores: Record<number, number> = {};
-    awayTeam.value.linescores?.forEach((ls, index) => {
+    awayTeam.value?.linescores?.forEach((ls, index) => {
         scores[index + 1] = ls.value;
     });
     return scores;
@@ -135,7 +136,7 @@ const awayPeriodScores = computed(() => {
 
 const homePeriodScores = computed(() => {
     const scores: Record<number, number> = {};
-    homeTeam.value.linescores?.forEach((ls, index) => {
+    homeTeam.value?.linescores?.forEach((ls, index) => {
         scores[index + 1] = ls.value;
     });
     return scores;

--- a/apps/web/tests/components/QuarterScores.test.ts
+++ b/apps/web/tests/components/QuarterScores.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import QuarterScores from "@/components/BoxScore/QuarterScores.vue";
+import type { ESPNCompetitor } from "@/models/types";
+
+const competitor = (
+    homeAway: "home" | "away",
+    linescores: { value: number }[] = [{ value: 25 }, { value: 30 }],
+): ESPNCompetitor =>
+    ({
+        homeAway,
+        winner: false,
+        score: "55",
+        team: { abbreviation: homeAway === "home" ? "HOM" : "AWY" },
+        linescores,
+    }) as ESPNCompetitor;
+
+describe("QuarterScores", () => {
+    it("renders the table when both teams are present with line scores", () => {
+        const wrapper = mount(QuarterScores, {
+            props: { competitors: [competitor("away"), competitor("home")] },
+        });
+
+        expect(wrapper.find("table").exists()).toBe(true);
+    });
+
+    it("renders nothing, and does not throw, when the home competitor is missing", () => {
+        expect(() =>
+            mount(QuarterScores, {
+                props: { competitors: [competitor("away")] },
+            }),
+        ).not.toThrow();
+
+        const wrapper = mount(QuarterScores, {
+            props: { competitors: [competitor("away")] },
+        });
+        expect(wrapper.find("table").exists()).toBe(false);
+    });
+
+    it("renders nothing, and does not throw, for an empty competitors array", () => {
+        expect(() =>
+            mount(QuarterScores, { props: { competitors: [] } }),
+        ).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #46. Same crash pattern PR #44 fixed in `GameHeader.vue`: `Array.prototype.find` returns `undefined` when nothing matches, the `!` asserts that away, and `hasLineScores` then dereferences `.linescores` with no optional chaining — so a competitors array missing either team throws during render and blanks the box-score page. The parent guard in `BoxScore.vue` doesn't prevent it (an empty array is truthy).

## Fix
- Drop the `!` assertions on `awayTeam`/`homeTeam`.
- `hasLineScores` and the period-score computeds are now null-safe.
- Template guards on `awayTeam && homeTeam && hasLineScores` (same pattern as `GameHeader.vue`, which lets `vue-tsc` narrow the types in the template).

Grepped `apps/web` for the remaining `?.` immediately followed by `!` — `QuarterScores.vue` was the only other instance of this pattern (one unrelated hit in vendored `components/ui/command/CommandItem.vue`, different pattern, not touched).

## Testing
- Added `tests/components/QuarterScores.test.ts` — reproduces the crash on a missing competitor/empty array before the fix, passes after.
- `pnpm --filter web test` — 95 passed.
- `pnpm --filter web type-check` (vue-tsc) clean.
- `pnpm --filter web lint` — 0 errors.
- `pnpm --filter web check:styles` — clean.

https://claude.ai/code/session_01N96ZpD1vHb2m4WEA36C9sz