### PR TITLE
Fix presigned URL expiry, response type drift, and signature canvas stroke bug

### DIFF
--- a/apps/cdk/service/lambdas/completeMultipartUpload/src/completeMultipartUpload.ts
+++ b/apps/cdk/service/lambdas/completeMultipartUpload/src/completeMultipartUpload.ts
@@ -81,7 +81,7 @@ export const handler: Handler = async (
             Key: key,
         });
         const signedURL = await getSignedUrl(s3Client, getObjectCommand, {
-            expiresIn: 86400, // One day in seconds
+            expiresIn: 3600, // One hour in seconds
         });
 
         return {

--- a/apps/web/src/components/TeamBuilder/TeamCustomizationDialog.vue
+++ b/apps/web/src/components/TeamBuilder/TeamCustomizationDialog.vue
@@ -74,8 +74,10 @@ const handleFileChange = (event: Event) => {
     }
 };
 
-const startDrawing = () => {
+const startDrawing = (e: MouseEvent) => {
     isDrawing.value = true;
+    currentX.value = e.offsetX;
+    currentY.value = e.offsetY;
 };
 
 const stopDrawing = () => {

--- a/apps/web/src/models/api.ts
+++ b/apps/web/src/models/api.ts
@@ -37,8 +37,10 @@ export interface CompleteMultipartUploadPayload {
 }
 
 export interface CompleteMultipartUploadResponse {
-    location: string;
+    name: string;
     key: string;
+    size: number;
+    signedURL: string;
 }
 
 export interface DeleteFilePayload {


### PR DESCRIPTION
Three small independent fixes flagged in code review of #48/#45:

- **#49** — `completeMultipartUpload` presigned its download URL for 24h (`expiresIn: 86400`), but a Lambda execution role's temporary credentials don't live that long, so the URL can 403 with `ExpiredToken` inside the window the API advertises. Shrunk to 3600s, matching the sibling `getMultipartSignedUploadUrls` handler (only other `getSignedUrl` caller in the codebase).
- **#51** — `CompleteMultipartUploadResponse` in `apps/web/src/models/api.ts` described `{ location, key }`, but the handler actually returns `{ name, key, size, signedURL }`. Latent (no caller yet), now matches.
- **#47** — Signature/jersey-drawing canvas in `TeamCustomizationDialog.vue` joined every stroke after the first to its predecessor with a spurious straight line, because `startDrawing` never seeded `currentX`/`currentY` on mousedown. Restored the event param (dropped by #44 to silence an unused-var lint error) and used it to seed the start point. Verified visually — two separate strokes on the jersey canvas no longer connect.

Fixes #49, #51, #47

Each commit is independently reviewable/revertable. Full `pnpm -r test` and `pnpm --filter web type-check` pass (also enforced by the husky pre-commit hook on each commit here).