### PR TITLE
Fix real-run bugs in refresh-historical-jerseys, point at real CDN

### DIFF
--- a/apps/cdk/scripts/lib/historicalJerseys.ts
+++ b/apps/cdk/scripts/lib/historicalJerseys.ts
@@ -332,9 +332,15 @@ export const formatJerseyYears = (startYear: number, endYear: number) => {
 
 /**
  * Assembles one gallery item plus its page context into a dataset row, or
- * null (with a problem recorded) when no season span could be parsed from
- * either its description or its title - the one case that should never
- * happen on a real page and signals the upstream layout changed.
+ * null when it can't be. A blank title (bballjerseys.com's aba-sounds
+ * gallery carries exactly one such item, seemingly a stray deleted-but-not-
+ * really entry rather than anything reflecting a real jersey) has no season
+ * span by construction and is silently skipped - it's a permanent data-
+ * quality quirk in the source, not a signal anything upstream changed. Any
+ * *titled* item with no parseable span, by contrast, means the site's season
+ * label or year-range format changed underneath us, and records a problem
+ * so the caller's all-or-nothing write refuses instead of shipping a
+ * silently-wrong dataset.
  */
 export const buildParsedJersey = (
 	item: RawGalleryItem,
@@ -345,7 +351,9 @@ export const buildParsedJersey = (
 ): ParsedJersey | null => {
 	const span = parseSeasonSpan(item, seasonEndYearNow);
 	if (!span) {
-		problems.push(`${slug}: "${item.title}" has no parseable season span`);
+		if (item.title.trim()) {
+			problems.push(`${slug}: "${item.title}" has no parseable season span`);
+		}
 		return null;
 	}
 

--- a/apps/cdk/scripts/refresh-historical-jerseys.ts
+++ b/apps/cdk/scripts/refresh-historical-jerseys.ts
@@ -72,9 +72,12 @@ const MAX_YEAR = new Date().getFullYear() + 2;
 
 // "jersey" (the CDN URL) is deliberately excluded - it only exists after a
 // real upload, not under --check - mirroring how refresh-historical-logos.ts
-// excludes "logo" from its own required-fields list.
+// excludes "logo" from its own required-fields list. "franchiseName" is also
+// excluded: buildParsedJersey leaves it "" by design for a handful of
+// defunct-page teams with no historicalLogos.json entry of their own (see
+// resolveFranchise's doc comment) - requiring it here would contradict that
+// and refuse to write every real run.
 const REQUIRED_FIELDS: (keyof ParsedJersey)[] = [
-	"franchiseName",
 	"name",
 	"league",
 	"slot",
@@ -83,15 +86,21 @@ const REQUIRED_FIELDS: (keyof ParsedJersey)[] = [
 	"years",
 ];
 
-const fetchWithRetry = async (url: string, headers: Record<string, string>) => {
+const fetchWithRetry = async (
+	url: string,
+	headers: Record<string, string>,
+	retryStatuses: number[] = [429],
+) => {
 	for (let attempt = 0; attempt < RETRY_LIMIT; attempt++) {
 		const response = await fetch(url, { headers });
-		if (response.status !== 429) {
+		if (!retryStatuses.includes(response.status)) {
 			return response;
 		}
 		await sleep(IMAGE_SPACING_MS * 5 * (attempt + 1));
 	}
-	throw new Error(`${url} kept returning 429 after ${RETRY_LIMIT} retries`);
+	throw new Error(
+		`${url} kept returning ${retryStatuses.join("/")} after ${RETRY_LIMIT} retries`,
+	);
 };
 
 const fetchInstanceToken = async (): Promise<string> => {
@@ -140,33 +149,59 @@ const loadFranchiseNames = (): Record<string, string> => {
 const isAvif = (bytes: Uint8Array) =>
 	bytes.length > 12 && String.fromCharCode(bytes[4], bytes[5], bytes[6], bytes[7]) === "ftyp";
 
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47];
+const isPng = (bytes: Uint8Array) =>
+	bytes.length > PNG_MAGIC.length && PNG_MAGIC.every((byte, i) => bytes[i] === byte);
+
+export interface FetchedImage {
+	bytes: Uint8Array;
+	format: "avif" | "png";
+}
+
 /**
  * Downloads one jersey at a fixed 400px width, forcing Wix's AVIF encoder via
  * the Accept header - without it the same URL serves a ~3-8x heavier PNG.
+ * Wix occasionally 400s this endpoint transiently (confirmed by hand: the
+ * exact same URL succeeds seconds later) and, less often, honors the
+ * `enc_avif` request but serves plain PNG bytes anyway while still claiming
+ * `Content-Type: image/avif` - both are retried/detected rather than treated
+ * as failures, but a persistently-failing or unrecognized response still
+ * records a problem and returns null rather than aborting the whole run.
  */
 const fetchJerseyImage = async (
 	mediaUrl: string,
 	label: string,
 	problems: string[],
-): Promise<Uint8Array | null> => {
+): Promise<FetchedImage | null> => {
 	const basename = mediaUrl.split("/").pop();
 	const transformUrl = `${mediaUrl}/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/${basename}`;
 
-	const response = await fetchWithRetry(transformUrl, {
-		"User-Agent": USER_AGENT,
-		Accept: "image/avif",
-	});
+	let response: Response;
+	try {
+		response = await fetchWithRetry(
+			transformUrl,
+			{ "User-Agent": USER_AGENT, Accept: "image/avif" },
+			[429, 400],
+		);
+	} catch (err) {
+		problems.push(`${label}: ${err instanceof Error ? err.message : err}`);
+		return null;
+	}
 	if (!response.ok) {
 		problems.push(`${label}: image request returned ${response.status}`);
 		return null;
 	}
 
 	const bytes = new Uint8Array(await response.arrayBuffer());
-	if (bytes.length < 200 || !isAvif(bytes)) {
-		problems.push(`${label}: response did not look like an AVIF image`);
+	if (bytes.length < 200) {
+		problems.push(`${label}: image response was too small to be real`);
 		return null;
 	}
-	return bytes;
+	if (isAvif(bytes)) return { bytes, format: "avif" };
+	if (isPng(bytes)) return { bytes, format: "png" };
+
+	problems.push(`${label}: response did not look like an AVIF or PNG image`);
+	return null;
 };
 
 /** Wix media ids are globally unique per asset - reused as the S3 key. */
@@ -290,21 +325,22 @@ const main = async () => {
 		// Fetched (and validated) in both modes - this is --check's actual
 		// value, confirming Wix's image pipeline still behaves as expected -
 		// but only uploaded and kept when actually writing output.
-		const bytes = await fetchJerseyImage(row.mediaUrl, row.name, problems);
+		const image = await fetchJerseyImage(row.mediaUrl, row.name, problems);
 		await sleep(IMAGE_SPACING_MS);
-		if (!bytes) continue;
+		if (!image) continue;
 
 		let jerseyUrl = "";
 		if (upload) {
+			const objectKey = `jerseys/historical/${key}.${image.format}`;
 			await upload.s3Client.send(
 				new PutObjectCommand({
 					Bucket: upload.bucketName,
-					Key: `jerseys/historical/${key}.avif`,
-					Body: bytes,
-					ContentType: "image/avif",
+					Key: objectKey,
+					Body: image.bytes,
+					ContentType: `image/${image.format}`,
 				}),
 			);
-			jerseyUrl = `https://${upload.distributionDomain}/jerseys/historical/${key}.avif`;
+			jerseyUrl = `https://${upload.distributionDomain}/${objectKey}`;
 		}
 
 		const { mediaUrl: _mediaUrl, ...cleanRow } = row;

--- a/apps/cdk/test/scripts/historicalJerseys.test.ts
+++ b/apps/cdk/test/scripts/historicalJerseys.test.ts
@@ -294,4 +294,14 @@ describe("buildParsedJersey", () => {
 		expect(buildParsedJersey(item, "knicks", franchiseNames, problems)).toBeNull();
 		expect(problems).toEqual(['knicks: "New York Knicks Jersey" has no parseable season span']);
 	});
+
+	it("silently skips a blank-titled item instead of recording a problem", () => {
+		// bballjerseys.com's aba-sounds gallery carries exactly one of these -
+		// a permanent data-quality quirk in the source, not a layout change.
+		const item: RawGalleryItem = { mediaUrl: "x", title: "", description: "" };
+		const problems: string[] = [];
+
+		expect(buildParsedJersey(item, "aba-sounds", franchiseNames, problems)).toBeNull();
+		expect(problems).toEqual([]);
+	});
 });

--- a/apps/web/src/assets/data/historicalJerseys.json
+++ b/apps/web/src/assets/data/historicalJerseys.json
@@ -13,7 +13,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d7be6e06a283493ea15be25ca7e6bd3a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d7be6e06a283493ea15be25ca7e6bd3a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d7be6e06a283493ea15be25ca7e6bd3a.avif"
     },
     {
         "franchise": "MEM",
@@ -27,7 +27,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8736937f8aaf465d80e2401b9b464e95~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8736937f8aaf465d80e2401b9b464e95~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8736937f8aaf465d80e2401b9b464e95.avif"
     },
     {
         "franchise": "MEM",
@@ -41,7 +41,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2beb5b0c7c8e4b29988639eeffe8c2b0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2beb5b0c7c8e4b29988639eeffe8c2b0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2beb5b0c7c8e4b29988639eeffe8c2b0.avif"
     },
     {
         "franchise": "MEM",
@@ -55,7 +55,7 @@
         "seasons": [
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ef131bb49e634f3a9774cd1e6c40699d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ef131bb49e634f3a9774cd1e6c40699d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ef131bb49e634f3a9774cd1e6c40699d.avif"
     },
     {
         "franchise": "MEM",
@@ -69,7 +69,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c508cd93248f40a6bb7794247ee1808d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c508cd93248f40a6bb7794247ee1808d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c508cd93248f40a6bb7794247ee1808d.avif"
     },
     {
         "franchise": "MEM",
@@ -84,7 +84,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c317473b47184c0284fcbc8bd5092812~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c317473b47184c0284fcbc8bd5092812~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c317473b47184c0284fcbc8bd5092812.avif"
     },
     {
         "franchise": "MEM",
@@ -103,7 +103,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cec3f8ebd0e944b69a6f6efd252b9a90~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cec3f8ebd0e944b69a6f6efd252b9a90~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cec3f8ebd0e944b69a6f6efd252b9a90.avif"
     },
     {
         "franchise": "MEM",
@@ -120,7 +120,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b990b0d4a7c048b9bb90808be4bbda46~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b990b0d4a7c048b9bb90808be4bbda46~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b990b0d4a7c048b9bb90808be4bbda46.avif"
     },
     {
         "franchise": "MEM",
@@ -136,7 +136,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_20c0d2ab23904afab34b1b3e7e506f5f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_20c0d2ab23904afab34b1b3e7e506f5f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_20c0d2ab23904afab34b1b3e7e506f5f.avif"
     },
     {
         "franchise": "MEM",
@@ -150,7 +150,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e82d43cc7f5a462c859bbf9cdc31db92~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e82d43cc7f5a462c859bbf9cdc31db92~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e82d43cc7f5a462c859bbf9cdc31db92.avif"
     },
     {
         "franchise": "MEM",
@@ -167,7 +167,7 @@
             "2020-21",
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_af5fd62d626f4cfeb8e40a039bbb717a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_af5fd62d626f4cfeb8e40a039bbb717a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_af5fd62d626f4cfeb8e40a039bbb717a.avif"
     },
     {
         "franchise": "MEM",
@@ -181,7 +181,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_12264e3a39964c9d9cf55ae6ac047d7a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_12264e3a39964c9d9cf55ae6ac047d7a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_12264e3a39964c9d9cf55ae6ac047d7a.avif"
     },
     {
         "franchise": "MEM",
@@ -195,7 +195,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_55f21f342d1746f5b793e61d6604f225~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_55f21f342d1746f5b793e61d6604f225~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_55f21f342d1746f5b793e61d6604f225.avif"
     },
     {
         "franchise": "MEM",
@@ -210,7 +210,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_815e2ab5b01a4f50b275d4de17a279f6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_815e2ab5b01a4f50b275d4de17a279f6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_815e2ab5b01a4f50b275d4de17a279f6.avif"
     },
     {
         "franchise": "MEM",
@@ -224,7 +224,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_57e5d896749d4baa9ff78750f86d1885~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_57e5d896749d4baa9ff78750f86d1885~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_57e5d896749d4baa9ff78750f86d1885.avif"
     },
     {
         "franchise": "MEM",
@@ -238,7 +238,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a5e882b7f5ba451db4df8732a3749e3d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a5e882b7f5ba451db4df8732a3749e3d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a5e882b7f5ba451db4df8732a3749e3d.avif"
     },
     {
         "franchise": "MEM",
@@ -255,7 +255,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_739d34723bcb41a6ac80452aa8040179~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_739d34723bcb41a6ac80452aa8040179~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_739d34723bcb41a6ac80452aa8040179.avif"
     },
     {
         "franchise": "MEM",
@@ -271,7 +271,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ce2df41a4fbf4a2d885eced34e8535e9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ce2df41a4fbf4a2d885eced34e8535e9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ce2df41a4fbf4a2d885eced34e8535e9.avif"
     },
     {
         "franchise": "MEM",
@@ -285,7 +285,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b29fb7096a5e4c62bf09d2a39474fb60~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b29fb7096a5e4c62bf09d2a39474fb60~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b29fb7096a5e4c62bf09d2a39474fb60.avif"
     },
     {
         "franchise": "MEM",
@@ -300,7 +300,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7afe6e9a28334443a5e99214a11c7cf0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7afe6e9a28334443a5e99214a11c7cf0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7afe6e9a28334443a5e99214a11c7cf0.avif"
     },
     {
         "franchise": "MEM",
@@ -314,7 +314,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0be2f7bca1f144cb93445cbc7b454bb6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0be2f7bca1f144cb93445cbc7b454bb6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0be2f7bca1f144cb93445cbc7b454bb6.avif"
     },
     {
         "franchise": "MEM",
@@ -328,7 +328,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0e974864360b4806afb804a1c287bc80~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0e974864360b4806afb804a1c287bc80~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0e974864360b4806afb804a1c287bc80.avif"
     },
     {
         "franchise": "MEM",
@@ -342,7 +342,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a3ef4116c3df49d484b7c744a344d18f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a3ef4116c3df49d484b7c744a344d18f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a3ef4116c3df49d484b7c744a344d18f.avif"
     },
     {
         "franchise": "MEM",
@@ -356,246 +356,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f1cea24b6c684a378e5e62482cb9421f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f1cea24b6c684a378e5e62482cb9421f~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 1994-2000",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 1995,
-        "endYear": 1999,
-        "years": "1994-95 – 1998-99",
-        "seasons": [
-            "1994-95",
-            "1995-96",
-            "1997-98",
-            "1998-99"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe130fbf5e324df78788a761be6fe6e9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe130fbf5e324df78788a761be6fe6e9~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 1996-1997",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 1997,
-        "endYear": 1997,
-        "years": "1996-97",
-        "seasons": [
-            "1996-97"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_424275bf817847afae5983e55974255d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_424275bf817847afae5983e55974255d~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 1994-2000",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2000,
-        "endYear": 2000,
-        "years": "1999-00",
-        "seasons": [
-            "1999-00"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5e580243208a4d0cbd5e61fe2680355c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5e580243208a4d0cbd5e61fe2680355c~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 2003-2006",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2004,
-        "endYear": 2006,
-        "years": "2003-04 – 2005-06",
-        "seasons": [
-            "2003-04",
-            "2004-05",
-            "2005-06"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a78299d9eaad488f92705bf03a0f08d6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a78299d9eaad488f92705bf03a0f08d6~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 2006-2010",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2007,
-        "endYear": 2010,
-        "years": "2006-07 – 2009-10",
-        "seasons": [
-            "2006-07",
-            "2007-08",
-            "2008-09",
-            "2009-10"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_da715ce37e01478b8e502ec4e7a4364d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_da715ce37e01478b8e502ec4e7a4364d~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 2010-2013",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2010,
-        "endYear": 2013,
-        "years": "2009-10 – 2012-13",
-        "seasons": [
-            "2009-10",
-            "2010-11",
-            "2011-12",
-            "2012-13"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e431a2ff3bff4bc9937f5129d057fc68~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e431a2ff3bff4bc9937f5129d057fc68~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 2013-2014",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2014,
-        "endYear": 2014,
-        "years": "2013-14",
-        "seasons": [
-            "2013-14"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_85a929da96c14e4894d43d5e1d387a82~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_85a929da96c14e4894d43d5e1d387a82~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 2014-2015",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2015,
-        "endYear": 2015,
-        "years": "2014-15",
-        "seasons": [
-            "2014-15"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_982fec585a204ee8ace5917061d0d192~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_982fec585a204ee8ace5917061d0d192~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns PHX Rising Alternate Jersey 2014-2017",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2015,
-        "endYear": 2017,
-        "years": "2014-15 – 2016-17",
-        "seasons": [
-            "2014-15",
-            "2015-16",
-            "2016-17"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c2fbf260552d4c90b5878a15e46f1a25~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c2fbf260552d4c90b5878a15e46f1a25~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Alternate Jersey 2015-2017",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2016,
-        "endYear": 2017,
-        "years": "2015-16 – 2016-17",
-        "seasons": [
-            "2015-16",
-            "2016-17"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_09db20a1e4d64965b6de1ef2e60f9d23~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_09db20a1e4d64965b6de1ef2e60f9d23~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Statement Jersey 2017-2019",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2018,
-        "endYear": 2019,
-        "years": "2017-18 – 2018-19",
-        "seasons": [
-            "2017-18",
-            "2018-19"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_33c9f5a936714c7b98237529eddb8001~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_33c9f5a936714c7b98237529eddb8001~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Statement Jersey 2019-2020",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2020,
-        "endYear": 2020,
-        "years": "2019-20",
-        "seasons": [
-            "2019-20"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_08b181020abd4d6f96758164ee98dcdc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_08b181020abd4d6f96758164ee98dcdc~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Statement Jersey 2020-2022",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2021,
-        "endYear": 2021,
-        "years": "2020-21",
-        "seasons": [
-            "2020-21"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ffe0619d557e4d3f855499091d495152~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ffe0619d557e4d3f855499091d495152~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Statement Jersey 2021-2022",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2022,
-        "endYear": 2022,
-        "years": "2021-22",
-        "seasons": [
-            "2021-22"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_71c2aaf715fc481db20d1d319a19b158~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_71c2aaf715fc481db20d1d319a19b158~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Statement Jersey 2022-2023",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2023,
-        "endYear": 2023,
-        "years": "2022-23",
-        "seasons": [
-            "2022-23"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8c7d4594b7f14d569012749df1cd1180~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8c7d4594b7f14d569012749df1cd1180~mv2.png"
-    },
-    {
-        "franchise": "PHO",
-        "franchiseName": "Phoenix Suns",
-        "name": "Phoenix Suns Statement Jersey 2022-Present",
-        "league": "NBA",
-        "slot": "alternate",
-        "startYear": 2024,
-        "endYear": 2024,
-        "years": "2023-24",
-        "seasons": [
-            "2023-24"
-        ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e79e21e6f3c4439e9da7d799fd341968~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e79e21e6f3c4439e9da7d799fd341968~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f1cea24b6c684a378e5e62482cb9421f.avif"
     },
     {
         "franchise": "PHO",
@@ -610,7 +371,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5e8ba9fde2de4d83b22411dc20ddff0a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5e8ba9fde2de4d83b22411dc20ddff0a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5e8ba9fde2de4d83b22411dc20ddff0a.avif"
     },
     {
         "franchise": "PHO",
@@ -624,7 +385,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e6bf02023f1944bd9383fa174406d081~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e6bf02023f1944bd9383fa174406d081~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e6bf02023f1944bd9383fa174406d081.avif"
     },
     {
         "franchise": "PHO",
@@ -639,7 +400,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3ea1c5675c4f457cbfc782d1adf52134~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3ea1c5675c4f457cbfc782d1adf52134~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3ea1c5675c4f457cbfc782d1adf52134.avif"
     },
     {
         "franchise": "PHO",
@@ -664,7 +425,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b67244368277460db69f3c2f8bb498e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b67244368277460db69f3c2f8bb498e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b67244368277460db69f3c2f8bb498e0.avif"
     },
     {
         "franchise": "PHO",
@@ -678,7 +439,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4dec468152b4148840ced5e48e14721~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4dec468152b4148840ced5e48e14721~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4dec468152b4148840ced5e48e14721.avif"
     },
     {
         "franchise": "PHO",
@@ -697,7 +458,7 @@
             "1990-91",
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_799971667fda400ab98990489e7df3e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_799971667fda400ab98990489e7df3e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_799971667fda400ab98990489e7df3e0.avif"
     },
     {
         "franchise": "PHO",
@@ -712,7 +473,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bd6585c1f84f4a11af3bc667275baa68~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bd6585c1f84f4a11af3bc667275baa68~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bd6585c1f84f4a11af3bc667275baa68.avif"
     },
     {
         "franchise": "PHO",
@@ -729,7 +490,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88027a82de464b3281c6612103aaeb72~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88027a82de464b3281c6612103aaeb72~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88027a82de464b3281c6612103aaeb72.avif"
     },
     {
         "franchise": "PHO",
@@ -743,7 +504,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7c5c73b3636c4841a050e0b0a03a8bb7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7c5c73b3636c4841a050e0b0a03a8bb7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7c5c73b3636c4841a050e0b0a03a8bb7.avif"
     },
     {
         "franchise": "PHO",
@@ -757,7 +518,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_747ed89d73d24129a6e05f7302990db3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_747ed89d73d24129a6e05f7302990db3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_747ed89d73d24129a6e05f7302990db3.avif"
     },
     {
         "franchise": "PHO",
@@ -775,7 +536,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b9dc27ff89ae428fb409fb76342e8745~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b9dc27ff89ae428fb409fb76342e8745~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b9dc27ff89ae428fb409fb76342e8745.avif"
     },
     {
         "franchise": "PHO",
@@ -789,7 +550,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_93211fd61a8a45808bd8fbbcc409a534~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_93211fd61a8a45808bd8fbbcc409a534~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_93211fd61a8a45808bd8fbbcc409a534.avif"
     },
     {
         "franchise": "PHO",
@@ -806,7 +567,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dfd19fd4f09b48389444411e25fde442~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dfd19fd4f09b48389444411e25fde442~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dfd19fd4f09b48389444411e25fde442.avif"
     },
     {
         "franchise": "PHO",
@@ -822,7 +583,7 @@
             "2011-12",
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2293067773fb4a1a936231d89a474fb2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2293067773fb4a1a936231d89a474fb2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2293067773fb4a1a936231d89a474fb2.avif"
     },
     {
         "franchise": "PHO",
@@ -836,7 +597,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9b4c78189e8c4ffd8c5634331d209108~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9b4c78189e8c4ffd8c5634331d209108~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9b4c78189e8c4ffd8c5634331d209108.avif"
     },
     {
         "franchise": "PHO",
@@ -852,7 +613,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7febafd12c7c485fb2b34262f24945bf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7febafd12c7c485fb2b34262f24945bf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7febafd12c7c485fb2b34262f24945bf.avif"
     },
     {
         "franchise": "PHO",
@@ -869,7 +630,7 @@
             "2019-20",
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c28f2872b6f140ca87edb5bb19f07243~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c28f2872b6f140ca87edb5bb19f07243~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c28f2872b6f140ca87edb5bb19f07243.avif"
     },
     {
         "franchise": "PHO",
@@ -883,7 +644,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_43d4f6a7b01a48d185e373f8bc13ca4c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_43d4f6a7b01a48d185e373f8bc13ca4c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_43d4f6a7b01a48d185e373f8bc13ca4c.avif"
     },
     {
         "franchise": "PHO",
@@ -897,7 +658,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8f034f3e2de747e6b954def69a9baa2f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8f034f3e2de747e6b954def69a9baa2f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8f034f3e2de747e6b954def69a9baa2f.avif"
     },
     {
         "franchise": "PHO",
@@ -911,7 +672,246 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6be67cc16e0547ff975838ca5c03e662~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6be67cc16e0547ff975838ca5c03e662~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6be67cc16e0547ff975838ca5c03e662.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 1994-2000",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 1995,
+        "endYear": 1999,
+        "years": "1994-95 – 1998-99",
+        "seasons": [
+            "1994-95",
+            "1995-96",
+            "1997-98",
+            "1998-99"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe130fbf5e324df78788a761be6fe6e9.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 1996-1997",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 1997,
+        "endYear": 1997,
+        "years": "1996-97",
+        "seasons": [
+            "1996-97"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_424275bf817847afae5983e55974255d.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 1994-2000",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2000,
+        "endYear": 2000,
+        "years": "1999-00",
+        "seasons": [
+            "1999-00"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5e580243208a4d0cbd5e61fe2680355c.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 2003-2006",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2004,
+        "endYear": 2006,
+        "years": "2003-04 – 2005-06",
+        "seasons": [
+            "2003-04",
+            "2004-05",
+            "2005-06"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a78299d9eaad488f92705bf03a0f08d6.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 2006-2010",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2007,
+        "endYear": 2010,
+        "years": "2006-07 – 2009-10",
+        "seasons": [
+            "2006-07",
+            "2007-08",
+            "2008-09",
+            "2009-10"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_da715ce37e01478b8e502ec4e7a4364d.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 2010-2013",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2010,
+        "endYear": 2013,
+        "years": "2009-10 – 2012-13",
+        "seasons": [
+            "2009-10",
+            "2010-11",
+            "2011-12",
+            "2012-13"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e431a2ff3bff4bc9937f5129d057fc68.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 2013-2014",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2014,
+        "endYear": 2014,
+        "years": "2013-14",
+        "seasons": [
+            "2013-14"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_85a929da96c14e4894d43d5e1d387a82.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 2014-2015",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2015,
+        "endYear": 2015,
+        "years": "2014-15",
+        "seasons": [
+            "2014-15"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_982fec585a204ee8ace5917061d0d192.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns PHX Rising Alternate Jersey 2014-2017",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2015,
+        "endYear": 2017,
+        "years": "2014-15 – 2016-17",
+        "seasons": [
+            "2014-15",
+            "2015-16",
+            "2016-17"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c2fbf260552d4c90b5878a15e46f1a25.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Alternate Jersey 2015-2017",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2016,
+        "endYear": 2017,
+        "years": "2015-16 – 2016-17",
+        "seasons": [
+            "2015-16",
+            "2016-17"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_09db20a1e4d64965b6de1ef2e60f9d23.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Statement Jersey 2017-2019",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2018,
+        "endYear": 2019,
+        "years": "2017-18 – 2018-19",
+        "seasons": [
+            "2017-18",
+            "2018-19"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_33c9f5a936714c7b98237529eddb8001.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Statement Jersey 2019-2020",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2020,
+        "endYear": 2020,
+        "years": "2019-20",
+        "seasons": [
+            "2019-20"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_08b181020abd4d6f96758164ee98dcdc.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Statement Jersey 2020-2022",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2021,
+        "endYear": 2021,
+        "years": "2020-21",
+        "seasons": [
+            "2020-21"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ffe0619d557e4d3f855499091d495152.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Statement Jersey 2021-2022",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2022,
+        "endYear": 2022,
+        "years": "2021-22",
+        "seasons": [
+            "2021-22"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_71c2aaf715fc481db20d1d319a19b158.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Statement Jersey 2022-2023",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2023,
+        "endYear": 2023,
+        "years": "2022-23",
+        "seasons": [
+            "2022-23"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8c7d4594b7f14d569012749df1cd1180.avif"
+    },
+    {
+        "franchise": "PHO",
+        "franchiseName": "Phoenix Suns",
+        "name": "Phoenix Suns Statement Jersey 2022-Present",
+        "league": "NBA",
+        "slot": "alternate",
+        "startYear": 2024,
+        "endYear": 2024,
+        "years": "2023-24",
+        "seasons": [
+            "2023-24"
+        ],
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e79e21e6f3c4439e9da7d799fd341968.avif"
     },
     {
         "franchise": "OKC",
@@ -923,7 +923,7 @@
         "endYear": 2014,
         "years": "2008-09 – 2013-14",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_94edde1b24d64456b199e01248b2cdff~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_94edde1b24d64456b199e01248b2cdff~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_94edde1b24d64456b199e01248b2cdff.avif"
     },
     {
         "franchise": "OKC",
@@ -935,7 +935,7 @@
         "endYear": 2017,
         "years": "2014-15 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_d8519edbb72843e7b3e999d04d542e85~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d8519edbb72843e7b3e999d04d542e85~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d8519edbb72843e7b3e999d04d542e85.avif"
     },
     {
         "franchise": "OKC",
@@ -947,7 +947,7 @@
         "endYear": 2019,
         "years": "2017-18 – 2018-19",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_0adc52b7163549ceb126b31f8049f8ee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0adc52b7163549ceb126b31f8049f8ee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0adc52b7163549ceb126b31f8049f8ee.avif"
     },
     {
         "franchise": "OKC",
@@ -959,7 +959,7 @@
         "endYear": 2026,
         "years": "2019-20 – 2025-26",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_a675d55d8adc40cbacc7c7b15868b40e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a675d55d8adc40cbacc7c7b15868b40e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a675d55d8adc40cbacc7c7b15868b40e.avif"
     },
     {
         "franchise": "OKC",
@@ -971,7 +971,7 @@
         "endYear": 2017,
         "years": "2014-15 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_b9cef2f61df04277853dbf402d17dee3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b9cef2f61df04277853dbf402d17dee3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b9cef2f61df04277853dbf402d17dee3.avif"
     },
     {
         "franchise": "OKC",
@@ -983,7 +983,7 @@
         "endYear": 2019,
         "years": "2017-18 – 2018-19",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_c3cc10486eda47d682d3f7bed2cf6c42~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c3cc10486eda47d682d3f7bed2cf6c42~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c3cc10486eda47d682d3f7bed2cf6c42.avif"
     },
     {
         "franchise": "OKC",
@@ -995,7 +995,7 @@
         "endYear": 2026,
         "years": "2019-20 – 2025-26",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_0fbe7e5ff12f455497fa491d1df21a4c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0fbe7e5ff12f455497fa491d1df21a4c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0fbe7e5ff12f455497fa491d1df21a4c.avif"
     },
     {
         "franchise": "OKC",
@@ -1007,7 +1007,7 @@
         "endYear": 2014,
         "years": "2012-13 – 2013-14",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_9e62859f517f42c8b23780b49e412b74~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9e62859f517f42c8b23780b49e412b74~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9e62859f517f42c8b23780b49e412b74.avif"
     },
     {
         "franchise": "OKC",
@@ -1019,7 +1019,7 @@
         "endYear": 2016,
         "years": "2014-15 – 2015-16",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_7a76acd925814a8da38c03137063e076~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7a76acd925814a8da38c03137063e076~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7a76acd925814a8da38c03137063e076.avif"
     },
     {
         "franchise": "OKC",
@@ -1031,7 +1031,7 @@
         "endYear": 2017,
         "years": "2015-16 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_95f5adc78c4f4e04a9a7933157593d82~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_95f5adc78c4f4e04a9a7933157593d82~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_95f5adc78c4f4e04a9a7933157593d82.avif"
     },
     {
         "franchise": "OKC",
@@ -1043,7 +1043,7 @@
         "endYear": 2019,
         "years": "2017-18 – 2018-19",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_d480ee87ccac4be5bd6ea80711e1e1c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d480ee87ccac4be5bd6ea80711e1e1c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d480ee87ccac4be5bd6ea80711e1e1c4.avif"
     },
     {
         "franchise": "OKC",
@@ -1055,7 +1055,7 @@
         "endYear": 2020,
         "years": "2019-20",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_289b2e1a4aba4c54a5a278ae0b0815fe~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_289b2e1a4aba4c54a5a278ae0b0815fe~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_289b2e1a4aba4c54a5a278ae0b0815fe.avif"
     },
     {
         "franchise": "OKC",
@@ -1067,7 +1067,7 @@
         "endYear": 2026,
         "years": "2021-22 – 2025-26",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_0247fa02f6c84827813f2e3e372fbbd9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0247fa02f6c84827813f2e3e372fbbd9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0247fa02f6c84827813f2e3e372fbbd9.avif"
     },
     {
         "franchise": "NJN",
@@ -1079,7 +1079,7 @@
         "endYear": 1968,
         "years": "1967-68",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_f759f1201bef43379eced2dbc90fb649~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f759f1201bef43379eced2dbc90fb649~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f759f1201bef43379eced2dbc90fb649.avif"
     },
     {
         "franchise": "NJN",
@@ -1091,7 +1091,7 @@
         "endYear": 1969,
         "years": "1968-69",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_50cbb4796c6e4caa8a314f65bf771ac3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50cbb4796c6e4caa8a314f65bf771ac3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50cbb4796c6e4caa8a314f65bf771ac3.avif"
     },
     {
         "franchise": "NJN",
@@ -1103,7 +1103,7 @@
         "endYear": 1970,
         "years": "1969-70",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_ca0136135b8a446db9a63ad9acac8f9d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ca0136135b8a446db9a63ad9acac8f9d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ca0136135b8a446db9a63ad9acac8f9d.avif"
     },
     {
         "franchise": "NJN",
@@ -1115,7 +1115,7 @@
         "endYear": 1972,
         "years": "1970-71 – 1971-72",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_279e02d5b87240ce875d9208d37687a8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_279e02d5b87240ce875d9208d37687a8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_279e02d5b87240ce875d9208d37687a8.avif"
     },
     {
         "franchise": "NJN",
@@ -1127,7 +1127,7 @@
         "endYear": 1976,
         "years": "1972-73 – 1975-76",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_846d5e6aa6464c68ae3ba2fa4a07b068~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_846d5e6aa6464c68ae3ba2fa4a07b068~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_846d5e6aa6464c68ae3ba2fa4a07b068.avif"
     },
     {
         "franchise": "NJN",
@@ -1141,7 +1141,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0c1d071ac314e61a5d4482351e519a4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0c1d071ac314e61a5d4482351e519a4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0c1d071ac314e61a5d4482351e519a4.avif"
     },
     {
         "franchise": "NJN",
@@ -1155,7 +1155,7 @@
         "seasons": [
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0dd4d435412b4fecafba821038263f87~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0dd4d435412b4fecafba821038263f87~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0dd4d435412b4fecafba821038263f87.avif"
     },
     {
         "franchise": "NJN",
@@ -1169,7 +1169,7 @@
         "seasons": [
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9ce1dfc366114c9e8dfa29a9380f8485~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9ce1dfc366114c9e8dfa29a9380f8485~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9ce1dfc366114c9e8dfa29a9380f8485.avif"
     },
     {
         "franchise": "NJN",
@@ -1183,7 +1183,7 @@
         "seasons": [
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_abfe4ba5024f4d519e2f2d72c8980ab1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_abfe4ba5024f4d519e2f2d72c8980ab1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_abfe4ba5024f4d519e2f2d72c8980ab1.avif"
     },
     {
         "franchise": "NJN",
@@ -1197,7 +1197,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2ba0f42d2bc940b69a04ac71254a5a6b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2ba0f42d2bc940b69a04ac71254a5a6b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2ba0f42d2bc940b69a04ac71254a5a6b.avif"
     },
     {
         "franchise": "NJN",
@@ -1212,7 +1212,7 @@
             "1981-82",
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e13dabb6fed7434aa2e6dc470646e53a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e13dabb6fed7434aa2e6dc470646e53a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e13dabb6fed7434aa2e6dc470646e53a.avif"
     },
     {
         "franchise": "NJN",
@@ -1228,7 +1228,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0d332ad5eaa145d8ab73a4c6a08d6896~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0d332ad5eaa145d8ab73a4c6a08d6896~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0d332ad5eaa145d8ab73a4c6a08d6896.avif"
     },
     {
         "franchise": "NJN",
@@ -1245,7 +1245,7 @@
             "1988-89",
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_034ec93c8ebb4d0fa8bfb81aab37beea~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_034ec93c8ebb4d0fa8bfb81aab37beea~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_034ec93c8ebb4d0fa8bfb81aab37beea.avif"
     },
     {
         "franchise": "NJN",
@@ -1259,7 +1259,7 @@
         "seasons": [
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c7946357421140be99179faa5bc6899e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c7946357421140be99179faa5bc6899e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c7946357421140be99179faa5bc6899e.avif"
     },
     {
         "franchise": "NJN",
@@ -1274,7 +1274,7 @@
             "1991-92",
             "1992-93"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d4af266a50c14013a2dac76d5c5ba1fb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d4af266a50c14013a2dac76d5c5ba1fb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d4af266a50c14013a2dac76d5c5ba1fb.avif"
     },
     {
         "franchise": "NJN",
@@ -1288,7 +1288,7 @@
         "seasons": [
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a0a702b5e8204f339a6bde78fa43fce6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a0a702b5e8204f339a6bde78fa43fce6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a0a702b5e8204f339a6bde78fa43fce6.avif"
     },
     {
         "franchise": "NJN",
@@ -1303,7 +1303,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9af3a2e3765240b6a23788f7e91c105d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9af3a2e3765240b6a23788f7e91c105d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9af3a2e3765240b6a23788f7e91c105d.avif"
     },
     {
         "franchise": "NJN",
@@ -1317,7 +1317,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c2a80334304c48f189db6cc2b1414ee7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c2a80334304c48f189db6cc2b1414ee7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c2a80334304c48f189db6cc2b1414ee7.avif"
     },
     {
         "franchise": "NJN",
@@ -1332,7 +1332,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7b5bb39e39e24b39a402bfdb6eab1753~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7b5bb39e39e24b39a402bfdb6eab1753~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7b5bb39e39e24b39a402bfdb6eab1753.avif"
     },
     {
         "franchise": "NJN",
@@ -1351,7 +1351,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_578a2ce0d6cc401e920693590e84a9b4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_578a2ce0d6cc401e920693590e84a9b4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_578a2ce0d6cc401e920693590e84a9b4.avif"
     },
     {
         "franchise": "NJN",
@@ -1365,7 +1365,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9a2b09b0093b449aba504a42b70f6ce2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9a2b09b0093b449aba504a42b70f6ce2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9a2b09b0093b449aba504a42b70f6ce2.avif"
     },
     {
         "franchise": "NJN",
@@ -1381,7 +1381,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7b8ceb91919c4f17ba987f70bffc2557~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7b8ceb91919c4f17ba987f70bffc2557~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7b8ceb91919c4f17ba987f70bffc2557.avif"
     },
     {
         "franchise": "NJN",
@@ -1395,7 +1395,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6f0c13fbe9d64144a967bcf1781ae3d7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6f0c13fbe9d64144a967bcf1781ae3d7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6f0c13fbe9d64144a967bcf1781ae3d7.avif"
     },
     {
         "franchise": "NJN",
@@ -1410,7 +1410,7 @@
             "2010-11",
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f6834f5513bb4cc39a9a170242f04b76~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f6834f5513bb4cc39a9a170242f04b76~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f6834f5513bb4cc39a9a170242f04b76.avif"
     },
     {
         "franchise": "NJN",
@@ -1425,7 +1425,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7af801ad536a4a79b95b0d38eb973901~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7af801ad536a4a79b95b0d38eb973901~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7af801ad536a4a79b95b0d38eb973901.avif"
     },
     {
         "franchise": "NJN",
@@ -1441,7 +1441,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_66ee27297d3d43edb3cbaeac24affb8d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_66ee27297d3d43edb3cbaeac24affb8d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_66ee27297d3d43edb3cbaeac24affb8d.avif"
     },
     {
         "franchise": "NJN",
@@ -1459,7 +1459,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bce27aa1e96f431e9325314ec5d1648d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bce27aa1e96f431e9325314ec5d1648d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bce27aa1e96f431e9325314ec5d1648d.avif"
     },
     {
         "franchise": "NJN",
@@ -1473,7 +1473,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9cae3dac70124634abdd422c1487a864~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9cae3dac70124634abdd422c1487a864~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9cae3dac70124634abdd422c1487a864.avif"
     },
     {
         "franchise": "NJN",
@@ -1487,7 +1487,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_278dd469a242436a9b01e78957a87013~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_278dd469a242436a9b01e78957a87013~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_278dd469a242436a9b01e78957a87013.avif"
     },
     {
         "franchise": "NJN",
@@ -1501,7 +1501,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f098cb4c155c43bcbc96d00e41d7a832~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f098cb4c155c43bcbc96d00e41d7a832~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f098cb4c155c43bcbc96d00e41d7a832.avif"
     },
     {
         "franchise": "NJN",
@@ -1515,7 +1515,7 @@
         "seasons": [
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe464ea9fcb44f8d9bf4a8f4aa6a8014~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe464ea9fcb44f8d9bf4a8f4aa6a8014~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe464ea9fcb44f8d9bf4a8f4aa6a8014.avif"
     },
     {
         "franchise": "NJN",
@@ -1529,7 +1529,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8ee6600ffdb2471f8cbdf61c61ef3839~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8ee6600ffdb2471f8cbdf61c61ef3839~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8ee6600ffdb2471f8cbdf61c61ef3839.avif"
     },
     {
         "franchise": "NJN",
@@ -1543,7 +1543,7 @@
         "seasons": [
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c26ac51619b34b5d8fa6a4c309553786~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c26ac51619b34b5d8fa6a4c309553786~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c26ac51619b34b5d8fa6a4c309553786.avif"
     },
     {
         "franchise": "NJN",
@@ -1557,7 +1557,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_931028a8f7604c53846f59c40b089593~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_931028a8f7604c53846f59c40b089593~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_931028a8f7604c53846f59c40b089593.avif"
     },
     {
         "franchise": "NJN",
@@ -1573,7 +1573,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_006ab3f885f4409cbc5e23a7d733cc6c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_006ab3f885f4409cbc5e23a7d733cc6c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_006ab3f885f4409cbc5e23a7d733cc6c.avif"
     },
     {
         "franchise": "NJN",
@@ -1589,7 +1589,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_50756065f53c475b843a4f8968e1c80c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50756065f53c475b843a4f8968e1c80c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50756065f53c475b843a4f8968e1c80c.avif"
     },
     {
         "franchise": "NJN",
@@ -1604,7 +1604,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d3fcb954a88f4287856a795a4b8320cc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d3fcb954a88f4287856a795a4b8320cc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d3fcb954a88f4287856a795a4b8320cc.avif"
     },
     {
         "franchise": "NJN",
@@ -1618,7 +1618,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9e4b0e7e830d469d997ab3b3034dea52~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9e4b0e7e830d469d997ab3b3034dea52~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9e4b0e7e830d469d997ab3b3034dea52.avif"
     },
     {
         "franchise": "NJN",
@@ -1633,7 +1633,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_391630ded0954957b0d429743fc7d8d5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_391630ded0954957b0d429743fc7d8d5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_391630ded0954957b0d429743fc7d8d5.avif"
     },
     {
         "franchise": "NJN",
@@ -1647,7 +1647,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3e0ca27228f443369df74f074ee3f706~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3e0ca27228f443369df74f074ee3f706~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3e0ca27228f443369df74f074ee3f706.avif"
     },
     {
         "franchise": "NJN",
@@ -1661,7 +1661,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4bf1d8d0772f43bcb3dad2b0f3e46f77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4bf1d8d0772f43bcb3dad2b0f3e46f77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4bf1d8d0772f43bcb3dad2b0f3e46f77.avif"
     },
     {
         "franchise": "NJN",
@@ -1675,7 +1675,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5ad374476d9840ff9d2dd81e3abc9c42~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5ad374476d9840ff9d2dd81e3abc9c42~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5ad374476d9840ff9d2dd81e3abc9c42.avif"
     },
     {
         "franchise": "NJN",
@@ -1689,7 +1689,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_13e55472267349af9e4bf5917ae82a16~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_13e55472267349af9e4bf5917ae82a16~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_13e55472267349af9e4bf5917ae82a16.avif"
     },
     {
         "franchise": "NJN",
@@ -1703,7 +1703,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_54c81257484f4861aa22beb47a5661ad~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_54c81257484f4861aa22beb47a5661ad~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_54c81257484f4861aa22beb47a5661ad.avif"
     },
     {
         "franchise": "NJN",
@@ -1717,7 +1717,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_da0ce5c1a6404113ad1daca0768b369c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_da0ce5c1a6404113ad1daca0768b369c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_da0ce5c1a6404113ad1daca0768b369c.avif"
     },
     {
         "franchise": "DET",
@@ -1732,7 +1732,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9e492ef5dbdb4c5db2cf7b59e02c2b60~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9e492ef5dbdb4c5db2cf7b59e02c2b60~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9e492ef5dbdb4c5db2cf7b59e02c2b60.avif"
     },
     {
         "franchise": "DET",
@@ -1747,7 +1747,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0032fba94bee4fea85868787e073b417~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0032fba94bee4fea85868787e073b417~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0032fba94bee4fea85868787e073b417.avif"
     },
     {
         "franchise": "DET",
@@ -1764,7 +1764,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3e2b69a1b1d9410b8959e5439f7d4444~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3e2b69a1b1d9410b8959e5439f7d4444~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3e2b69a1b1d9410b8959e5439f7d4444.avif"
     },
     {
         "franchise": "DET",
@@ -1778,7 +1778,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_54b9cc0a8d3941e994d462088101b377~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_54b9cc0a8d3941e994d462088101b377~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_54b9cc0a8d3941e994d462088101b377.avif"
     },
     {
         "franchise": "DET",
@@ -1793,7 +1793,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d7582bf6fabe499693670d3549af18cf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d7582bf6fabe499693670d3549af18cf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d7582bf6fabe499693670d3549af18cf.avif"
     },
     {
         "franchise": "DET",
@@ -1809,7 +1809,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7ebfefaaa2554873aac86e8e41ac976d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7ebfefaaa2554873aac86e8e41ac976d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7ebfefaaa2554873aac86e8e41ac976d.avif"
     },
     {
         "franchise": "DET",
@@ -1823,7 +1823,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e4ca1540566c432db78e86f544868faf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e4ca1540566c432db78e86f544868faf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e4ca1540566c432db78e86f544868faf.avif"
     },
     {
         "franchise": "DET",
@@ -1837,7 +1837,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_66e60d922081414fbdf715705247a167~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_66e60d922081414fbdf715705247a167~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_66e60d922081414fbdf715705247a167.avif"
     },
     {
         "franchise": "DET",
@@ -1851,7 +1851,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4091434a98d640e0acb0db5a1fc34724~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4091434a98d640e0acb0db5a1fc34724~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4091434a98d640e0acb0db5a1fc34724.avif"
     },
     {
         "franchise": "DET",
@@ -1865,7 +1865,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_08f32183e2f04cdeb05c9a019bd2c784~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_08f32183e2f04cdeb05c9a019bd2c784~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_08f32183e2f04cdeb05c9a019bd2c784.avif"
     },
     {
         "franchise": "DET",
@@ -1879,7 +1879,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1358262e119c4c56b548fce44fd52032~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1358262e119c4c56b548fce44fd52032~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1358262e119c4c56b548fce44fd52032.avif"
     },
     {
         "franchise": "DET",
@@ -1894,7 +1894,7 @@
             "1949-50",
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c8f75651c1694c3c86dcccd293973c63~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c8f75651c1694c3c86dcccd293973c63~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c8f75651c1694c3c86dcccd293973c63.avif"
     },
     {
         "franchise": "DET",
@@ -1910,7 +1910,7 @@
             "1952-53",
             "1953-54"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_eff4c7027d984fc6af9091a48e415be8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_eff4c7027d984fc6af9091a48e415be8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_eff4c7027d984fc6af9091a48e415be8.avif"
     },
     {
         "franchise": "DET",
@@ -1924,7 +1924,7 @@
         "seasons": [
             "1954-55"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ea41587140164c13b65d2ae23d75a013~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ea41587140164c13b65d2ae23d75a013~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ea41587140164c13b65d2ae23d75a013.avif"
     },
     {
         "franchise": "DET",
@@ -1939,7 +1939,7 @@
             "1955-56",
             "1956-57"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a47637f5f4824f6ca4852e2f427606da~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a47637f5f4824f6ca4852e2f427606da~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a47637f5f4824f6ca4852e2f427606da.avif"
     },
     {
         "franchise": "DET",
@@ -1955,7 +1955,7 @@
             "1958-59",
             "1959-60"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_37e7bf6c771b40f0a041b7486a5c6b1c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_37e7bf6c771b40f0a041b7486a5c6b1c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_37e7bf6c771b40f0a041b7486a5c6b1c.avif"
     },
     {
         "franchise": "DET",
@@ -1970,7 +1970,7 @@
             "1960-61",
             "1961-62"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4ab66785789f491c873b4280057fb3be~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4ab66785789f491c873b4280057fb3be~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4ab66785789f491c873b4280057fb3be.avif"
     },
     {
         "franchise": "DET",
@@ -1984,7 +1984,7 @@
         "seasons": [
             "1962-63"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4f5b7483b6f444258b7a57262c73850a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4f5b7483b6f444258b7a57262c73850a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4f5b7483b6f444258b7a57262c73850a.avif"
     },
     {
         "franchise": "DET",
@@ -2000,7 +2000,7 @@
             "1964-65",
             "1965-66"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f42a1655fb344ac0895aea0160d12e56~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f42a1655fb344ac0895aea0160d12e56~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f42a1655fb344ac0895aea0160d12e56.avif"
     },
     {
         "franchise": "DET",
@@ -2015,7 +2015,7 @@
             "1966-67",
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e3a761677fbf4842b79e05351f6378c9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e3a761677fbf4842b79e05351f6378c9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e3a761677fbf4842b79e05351f6378c9.avif"
     },
     {
         "franchise": "DET",
@@ -2029,7 +2029,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aae7234cd5894f0b8ec885dadaa85b3f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aae7234cd5894f0b8ec885dadaa85b3f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aae7234cd5894f0b8ec885dadaa85b3f.avif"
     },
     {
         "franchise": "DET",
@@ -2045,7 +2045,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9eeaa8802c334a30a1e960f80fda750e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9eeaa8802c334a30a1e960f80fda750e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9eeaa8802c334a30a1e960f80fda750e.avif"
     },
     {
         "franchise": "DET",
@@ -2059,7 +2059,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2195e5645b114f269b73c643631ba06c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2195e5645b114f269b73c643631ba06c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2195e5645b114f269b73c643631ba06c.avif"
     },
     {
         "franchise": "DET",
@@ -2075,7 +2075,7 @@
             "1974-75",
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_644cb49475ce42ceb2f4421b1b0f3c77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_644cb49475ce42ceb2f4421b1b0f3c77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_644cb49475ce42ceb2f4421b1b0f3c77.avif"
     },
     {
         "franchise": "DET",
@@ -2090,7 +2090,7 @@
             "1976-77",
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2b9815df49564ee5abbc2ec0a7415ddd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2b9815df49564ee5abbc2ec0a7415ddd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2b9815df49564ee5abbc2ec0a7415ddd.avif"
     },
     {
         "franchise": "DET",
@@ -2105,7 +2105,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b82d47d2e3714e07a4a36c9ae4674c9a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b82d47d2e3714e07a4a36c9ae4674c9a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b82d47d2e3714e07a4a36c9ae4674c9a.avif"
     },
     {
         "franchise": "DET",
@@ -2119,7 +2119,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_74189ea0f26d4b6fb2ba91b7ddc285de~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_74189ea0f26d4b6fb2ba91b7ddc285de~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_74189ea0f26d4b6fb2ba91b7ddc285de.avif"
     },
     {
         "franchise": "DET",
@@ -2134,7 +2134,7 @@
             "1981-82",
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d70f11dad1e644058588494cc3349eda~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d70f11dad1e644058588494cc3349eda~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d70f11dad1e644058588494cc3349eda.avif"
     },
     {
         "franchise": "DET",
@@ -2150,7 +2150,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_824f53525d404231a2582254428e2c33~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_824f53525d404231a2582254428e2c33~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_824f53525d404231a2582254428e2c33.avif"
     },
     {
         "franchise": "DET",
@@ -2171,7 +2171,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8b6deb36e12c4847aef4a21a09824cd4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8b6deb36e12c4847aef4a21a09824cd4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8b6deb36e12c4847aef4a21a09824cd4.avif"
     },
     {
         "franchise": "DET",
@@ -2186,7 +2186,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e3589dd20cdd4cd3860233f6387c4129~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e3589dd20cdd4cd3860233f6387c4129~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e3589dd20cdd4cd3860233f6387c4129.avif"
     },
     {
         "franchise": "DET",
@@ -2200,7 +2200,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_79d70504166747fc94b9ac3f2921ae0c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_79d70504166747fc94b9ac3f2921ae0c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_79d70504166747fc94b9ac3f2921ae0c.avif"
     },
     {
         "franchise": "DET",
@@ -2215,7 +2215,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_59c435a2c0d544699cf7f43edf1ede48~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_59c435a2c0d544699cf7f43edf1ede48~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_59c435a2c0d544699cf7f43edf1ede48.avif"
     },
     {
         "franchise": "DET",
@@ -2230,7 +2230,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b1da7024edd3417baba46188cd83eb07~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b1da7024edd3417baba46188cd83eb07~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b1da7024edd3417baba46188cd83eb07.avif"
     },
     {
         "franchise": "DET",
@@ -2244,7 +2244,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_02f46e1e14ca4557b2da06ce3c07fe25~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_02f46e1e14ca4557b2da06ce3c07fe25~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_02f46e1e14ca4557b2da06ce3c07fe25.avif"
     },
     {
         "franchise": "DET",
@@ -2259,7 +2259,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0dc8bca9cb404c76b6f3bfc72c6f8cf4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0dc8bca9cb404c76b6f3bfc72c6f8cf4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0dc8bca9cb404c76b6f3bfc72c6f8cf4.avif"
     },
     {
         "franchise": "DET",
@@ -2273,7 +2273,7 @@
         "seasons": [
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d62910beb4e7429abc9b763b88607a45~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d62910beb4e7429abc9b763b88607a45~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d62910beb4e7429abc9b763b88607a45.avif"
     },
     {
         "franchise": "DET",
@@ -2295,7 +2295,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a34316b10f964a18bd56ca35c5fadbca~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a34316b10f964a18bd56ca35c5fadbca~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a34316b10f964a18bd56ca35c5fadbca.avif"
     },
     {
         "franchise": "DET",
@@ -2311,7 +2311,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6c40dac0e19f41dbb82cc902ac140880~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6c40dac0e19f41dbb82cc902ac140880~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6c40dac0e19f41dbb82cc902ac140880.avif"
     },
     {
         "franchise": "DET",
@@ -2328,7 +2328,7 @@
             "2019-20",
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6a4cd962316b4661b5e754b553723378~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6a4cd962316b4661b5e754b553723378~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6a4cd962316b4661b5e754b553723378.avif"
     },
     {
         "franchise": "DET",
@@ -2342,7 +2342,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d072bcf7edc34bf5b737e309cd22eb20~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d072bcf7edc34bf5b737e309cd22eb20~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d072bcf7edc34bf5b737e309cd22eb20.avif"
     },
     {
         "franchise": "DET",
@@ -2356,7 +2356,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_37743ea00a804fe29a90e9e22fad1896~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_37743ea00a804fe29a90e9e22fad1896~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_37743ea00a804fe29a90e9e22fad1896.avif"
     },
     {
         "franchise": "DET",
@@ -2370,7 +2370,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c064126c412b4a97aea050a8b55e370a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c064126c412b4a97aea050a8b55e370a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c064126c412b4a97aea050a8b55e370a.avif"
     },
     {
         "franchise": "ATL",
@@ -2384,7 +2384,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_023ae89903554e47b3e006b120c45eac~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_023ae89903554e47b3e006b120c45eac~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_023ae89903554e47b3e006b120c45eac.avif"
     },
     {
         "franchise": "ATL",
@@ -2398,7 +2398,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_014a35a1434347b58a005e1b05583908~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_014a35a1434347b58a005e1b05583908~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_014a35a1434347b58a005e1b05583908.avif"
     },
     {
         "franchise": "ATL",
@@ -2412,7 +2412,7 @@
         "seasons": [
             "1994-95"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f8545b8b83224dd7a36f170cc8162eb2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f8545b8b83224dd7a36f170cc8162eb2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f8545b8b83224dd7a36f170cc8162eb2.avif"
     },
     {
         "franchise": "ATL",
@@ -2428,7 +2428,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f5fa366a9de1459e855516f17d75d74b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f5fa366a9de1459e855516f17d75d74b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f5fa366a9de1459e855516f17d75d74b.avif"
     },
     {
         "franchise": "ATL",
@@ -2444,7 +2444,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e8ec671c3f784c1eacb99ebd87dbc8e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e8ec671c3f784c1eacb99ebd87dbc8e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e8ec671c3f784c1eacb99ebd87dbc8e0.avif"
     },
     {
         "franchise": "ATL",
@@ -2461,7 +2461,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ede5b77d8e8f4d489df78586d008ff3a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ede5b77d8e8f4d489df78586d008ff3a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ede5b77d8e8f4d489df78586d008ff3a.avif"
     },
     {
         "franchise": "ATL",
@@ -2475,7 +2475,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3f29e3065f984c0bb7d429550be627f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3f29e3065f984c0bb7d429550be627f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3f29e3065f984c0bb7d429550be627f8.avif"
     },
     {
         "franchise": "ATL",
@@ -2490,7 +2490,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_63924bd349b648b49a452d4938a02e6e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_63924bd349b648b49a452d4938a02e6e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_63924bd349b648b49a452d4938a02e6e.avif"
     },
     {
         "franchise": "ATL",
@@ -2505,7 +2505,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3ab3df01fc4245d1a249ad3ff9c2aab5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3ab3df01fc4245d1a249ad3ff9c2aab5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3ab3df01fc4245d1a249ad3ff9c2aab5.avif"
     },
     {
         "franchise": "ATL",
@@ -2521,7 +2521,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b7fee117026449ffa5c60866ce764e99~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b7fee117026449ffa5c60866ce764e99~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b7fee117026449ffa5c60866ce764e99.avif"
     },
     {
         "franchise": "ATL",
@@ -2536,7 +2536,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c733600a14804279afbb8059a2761c28~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c733600a14804279afbb8059a2761c28~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c733600a14804279afbb8059a2761c28.avif"
     },
     {
         "franchise": "ATL",
@@ -2550,7 +2550,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8cf6c3b5e908490fafcb6967772f06c3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8cf6c3b5e908490fafcb6967772f06c3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8cf6c3b5e908490fafcb6967772f06c3.avif"
     },
     {
         "franchise": "ATL",
@@ -2564,7 +2564,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4151374b906439b8e6a9288bb4d1d5f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4151374b906439b8e6a9288bb4d1d5f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4151374b906439b8e6a9288bb4d1d5f.avif"
     },
     {
         "franchise": "ATL",
@@ -2579,7 +2579,7 @@
             "1949-50",
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9c0d6bfe59654c26869affe16467e723~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9c0d6bfe59654c26869affe16467e723~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9c0d6bfe59654c26869affe16467e723.avif"
     },
     {
         "franchise": "ATL",
@@ -2593,7 +2593,7 @@
         "seasons": [
             "1951-52"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c462dacedb4d40d69d3699a9ad16ebd0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c462dacedb4d40d69d3699a9ad16ebd0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c462dacedb4d40d69d3699a9ad16ebd0.avif"
     },
     {
         "franchise": "ATL",
@@ -2608,7 +2608,7 @@
             "1952-53",
             "1953-54"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0cc982f2e7cf4441b33eb5575ef4cb77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0cc982f2e7cf4441b33eb5575ef4cb77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0cc982f2e7cf4441b33eb5575ef4cb77.avif"
     },
     {
         "franchise": "ATL",
@@ -2622,7 +2622,7 @@
         "seasons": [
             "1954-55"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_269b8f8b7ead407db3eaa61a5c9e5c31~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_269b8f8b7ead407db3eaa61a5c9e5c31~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_269b8f8b7ead407db3eaa61a5c9e5c31.avif"
     },
     {
         "franchise": "ATL",
@@ -2636,7 +2636,7 @@
         "seasons": [
             "1955-56"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ea352fc827974331aecb4c8d862c2b6b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ea352fc827974331aecb4c8d862c2b6b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ea352fc827974331aecb4c8d862c2b6b.avif"
     },
     {
         "franchise": "ATL",
@@ -2652,7 +2652,7 @@
             "1957-58",
             "1958-59"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9cab9b32b6444cf9a8ce0670ca2dc34c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9cab9b32b6444cf9a8ce0670ca2dc34c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9cab9b32b6444cf9a8ce0670ca2dc34c.avif"
     },
     {
         "franchise": "ATL",
@@ -2670,7 +2670,7 @@
             "1962-63",
             "1963-64"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c6e8965515854a9d9122f357742d7d72~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c6e8965515854a9d9122f357742d7d72~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c6e8965515854a9d9122f357742d7d72.avif"
     },
     {
         "franchise": "ATL",
@@ -2684,7 +2684,7 @@
         "seasons": [
             "1964-65"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_90f7b1460c714078b1e69bf94ccd5f22~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_90f7b1460c714078b1e69bf94ccd5f22~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_90f7b1460c714078b1e69bf94ccd5f22.avif"
     },
     {
         "franchise": "ATL",
@@ -2700,7 +2700,7 @@
             "1966-67",
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_85cc11c8616c4933a0121eea52f38088~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_85cc11c8616c4933a0121eea52f38088~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_85cc11c8616c4933a0121eea52f38088.avif"
     },
     {
         "franchise": "ATL",
@@ -2715,7 +2715,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c38131399e014a6ca106c29dc707026d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c38131399e014a6ca106c29dc707026d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c38131399e014a6ca106c29dc707026d.avif"
     },
     {
         "franchise": "ATL",
@@ -2729,7 +2729,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c2a7a3316519441aba0e342dc1db4438~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c2a7a3316519441aba0e342dc1db4438~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c2a7a3316519441aba0e342dc1db4438.avif"
     },
     {
         "franchise": "ATL",
@@ -2743,7 +2743,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_48cf7d5608f14141a89d731a38f37fee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_48cf7d5608f14141a89d731a38f37fee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_48cf7d5608f14141a89d731a38f37fee.avif"
     },
     {
         "franchise": "ATL",
@@ -2759,7 +2759,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_99926c9f44324c95bb712f8e59b9d1f5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_99926c9f44324c95bb712f8e59b9d1f5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_99926c9f44324c95bb712f8e59b9d1f5.avif"
     },
     {
         "franchise": "ATL",
@@ -2774,7 +2774,7 @@
             "1975-76",
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_50d070b5c1a141a883405ac3c593395b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50d070b5c1a141a883405ac3c593395b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50d070b5c1a141a883405ac3c593395b.avif"
     },
     {
         "franchise": "ATL",
@@ -2788,7 +2788,7 @@
         "seasons": [
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_380a14629c4546109b151ce673bbb3a3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_380a14629c4546109b151ce673bbb3a3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_380a14629c4546109b151ce673bbb3a3.avif"
     },
     {
         "franchise": "ATL",
@@ -2804,7 +2804,7 @@
             "1979-80",
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a0827b41b245482e90833a2ab3c24905~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a0827b41b245482e90833a2ab3c24905~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a0827b41b245482e90833a2ab3c24905.avif"
     },
     {
         "franchise": "ATL",
@@ -2818,7 +2818,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_35cc3d382ec94355888c2394d22446dd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_35cc3d382ec94355888c2394d22446dd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_35cc3d382ec94355888c2394d22446dd.avif"
     },
     {
         "franchise": "ATL",
@@ -2835,7 +2835,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_50559bd4aa964021b2a53cee9048dfe4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50559bd4aa964021b2a53cee9048dfe4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50559bd4aa964021b2a53cee9048dfe4.avif"
     },
     {
         "franchise": "ATL",
@@ -2854,7 +2854,7 @@
             "1990-91",
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c457f3ef51441be8501c2bb6713851d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c457f3ef51441be8501c2bb6713851d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c457f3ef51441be8501c2bb6713851d.avif"
     },
     {
         "franchise": "ATL",
@@ -2869,7 +2869,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fed143af81784a84806674f00e0b2ca5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fed143af81784a84806674f00e0b2ca5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fed143af81784a84806674f00e0b2ca5.avif"
     },
     {
         "franchise": "ATL",
@@ -2883,7 +2883,7 @@
         "seasons": [
             "1994-95"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d56a8785c0194e19b9bfeebda3b3e3ba~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d56a8785c0194e19b9bfeebda3b3e3ba~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d56a8785c0194e19b9bfeebda3b3e3ba.avif"
     },
     {
         "franchise": "ATL",
@@ -2899,7 +2899,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9858d8ff13494fc09fe5bc29b18a9f59~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9858d8ff13494fc09fe5bc29b18a9f59~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9858d8ff13494fc09fe5bc29b18a9f59.avif"
     },
     {
         "franchise": "ATL",
@@ -2913,7 +2913,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2447081919c14451bb9f73209b134412~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2447081919c14451bb9f73209b134412~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2447081919c14451bb9f73209b134412.avif"
     },
     {
         "franchise": "ATL",
@@ -2928,7 +2928,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8a45d870baaa4f2da88c10e94856d587~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8a45d870baaa4f2da88c10e94856d587~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8a45d870baaa4f2da88c10e94856d587.avif"
     },
     {
         "franchise": "ATL",
@@ -2942,7 +2942,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aee7366eff0842d7a86441b7e75cc8ea~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aee7366eff0842d7a86441b7e75cc8ea~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aee7366eff0842d7a86441b7e75cc8ea.avif"
     },
     {
         "franchise": "ATL",
@@ -2957,7 +2957,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_89ff3880ee9a4eac949cee6086fb8261~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_89ff3880ee9a4eac949cee6086fb8261~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_89ff3880ee9a4eac949cee6086fb8261.avif"
     },
     {
         "franchise": "ATL",
@@ -2973,7 +2973,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8e1ff8cd90634e558a2de29997cc0b3b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8e1ff8cd90634e558a2de29997cc0b3b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8e1ff8cd90634e558a2de29997cc0b3b.avif"
     },
     {
         "franchise": "ATL",
@@ -2989,7 +2989,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_87861ff0b1884d958a50650f2b29e25e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_87861ff0b1884d958a50650f2b29e25e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_87861ff0b1884d958a50650f2b29e25e.avif"
     },
     {
         "franchise": "ATL",
@@ -3006,7 +3006,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_072ec5412ad14fc69b63916669f7cc0b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_072ec5412ad14fc69b63916669f7cc0b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_072ec5412ad14fc69b63916669f7cc0b.avif"
     },
     {
         "franchise": "ATL",
@@ -3020,7 +3020,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aeae92d210974ec9ab486890d67cd8a3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aeae92d210974ec9ab486890d67cd8a3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aeae92d210974ec9ab486890d67cd8a3.avif"
     },
     {
         "franchise": "ATL",
@@ -3035,7 +3035,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_be441d15e85042cb8f92dc4c6ace9000~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_be441d15e85042cb8f92dc4c6ace9000~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_be441d15e85042cb8f92dc4c6ace9000.avif"
     },
     {
         "franchise": "ATL",
@@ -3051,7 +3051,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_33e6770404e34424bda893d5816002f6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_33e6770404e34424bda893d5816002f6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_33e6770404e34424bda893d5816002f6.avif"
     },
     {
         "franchise": "ATL",
@@ -3066,7 +3066,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0907d0e368ab445ea53e188ce9812d4b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0907d0e368ab445ea53e188ce9812d4b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0907d0e368ab445ea53e188ce9812d4b.avif"
     },
     {
         "franchise": "ATL",
@@ -3080,7 +3080,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_af67900ef21c4a8ab874af2c9b4dd08d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_af67900ef21c4a8ab874af2c9b4dd08d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_af67900ef21c4a8ab874af2c9b4dd08d.avif"
     },
     {
         "franchise": "ATL",
@@ -3094,7 +3094,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aad386d7d8d942a8998fff1d61a3acd9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aad386d7d8d942a8998fff1d61a3acd9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aad386d7d8d942a8998fff1d61a3acd9.avif"
     },
     {
         "franchise": "MIA",
@@ -3113,7 +3113,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_142381754aef42508255ef95817e3135~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_142381754aef42508255ef95817e3135~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_142381754aef42508255ef95817e3135.avif"
     },
     {
         "franchise": "MIA",
@@ -3130,7 +3130,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a879e2158e3946aca33797441ddb4e2a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a879e2158e3946aca33797441ddb4e2a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a879e2158e3946aca33797441ddb4e2a.avif"
     },
     {
         "franchise": "MIA",
@@ -3144,7 +3144,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5b2017eac60e4013bc09efbe539d89a6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5b2017eac60e4013bc09efbe539d89a6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5b2017eac60e4013bc09efbe539d89a6.avif"
     },
     {
         "franchise": "MIA",
@@ -3159,7 +3159,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_011273b07a5a4e84a50d28e8ebc47952~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_011273b07a5a4e84a50d28e8ebc47952~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_011273b07a5a4e84a50d28e8ebc47952.avif"
     },
     {
         "franchise": "MIA",
@@ -3176,7 +3176,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_20653604bef646ac9e5ae3f016859ac3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_20653604bef646ac9e5ae3f016859ac3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_20653604bef646ac9e5ae3f016859ac3.avif"
     },
     {
         "franchise": "MIA",
@@ -3190,7 +3190,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f9dafd742c1b44e29e88c6b7db1dfdef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f9dafd742c1b44e29e88c6b7db1dfdef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f9dafd742c1b44e29e88c6b7db1dfdef.avif"
     },
     {
         "franchise": "MIA",
@@ -3207,7 +3207,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_144b928f2e5e4f9ebe2cfab3fd4e29d7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_144b928f2e5e4f9ebe2cfab3fd4e29d7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_144b928f2e5e4f9ebe2cfab3fd4e29d7.avif"
     },
     {
         "franchise": "MIA",
@@ -3222,7 +3222,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_56b72d225afc4b378f37a816bf1487ed~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_56b72d225afc4b378f37a816bf1487ed~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_56b72d225afc4b378f37a816bf1487ed.avif"
     },
     {
         "franchise": "MIA",
@@ -3237,7 +3237,7 @@
             "2010-11",
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8967337f3c794bc28f487cab0a2bc499~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8967337f3c794bc28f487cab0a2bc499~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8967337f3c794bc28f487cab0a2bc499.avif"
     },
     {
         "franchise": "MIA",
@@ -3252,7 +3252,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dfedb37431294ce5b5496514d78b4400~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dfedb37431294ce5b5496514d78b4400~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dfedb37431294ce5b5496514d78b4400.avif"
     },
     {
         "franchise": "MIA",
@@ -3268,7 +3268,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5355176a7af24d9d960878e15a73f6d9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5355176a7af24d9d960878e15a73f6d9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5355176a7af24d9d960878e15a73f6d9.avif"
     },
     {
         "franchise": "MIA",
@@ -3286,7 +3286,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_61452c692ef742f3a01f2939fcc4791c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_61452c692ef742f3a01f2939fcc4791c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_61452c692ef742f3a01f2939fcc4791c.avif"
     },
     {
         "franchise": "MIA",
@@ -3300,7 +3300,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_956beb72a13c447ea93b0e830e7b946a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_956beb72a13c447ea93b0e830e7b946a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_956beb72a13c447ea93b0e830e7b946a.avif"
     },
     {
         "franchise": "MIA",
@@ -3314,7 +3314,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f8de16c9489b42c4877496d9697e9caf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f8de16c9489b42c4877496d9697e9caf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f8de16c9489b42c4877496d9697e9caf.avif"
     },
     {
         "franchise": "MIA",
@@ -3328,7 +3328,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f4e933d879d74479900528c628687c6f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f4e933d879d74479900528c628687c6f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f4e933d879d74479900528c628687c6f.avif"
     },
     {
         "franchise": "MIA",
@@ -3344,7 +3344,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c0166cd56bb4ff2a39d3b5f217b7b4a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c0166cd56bb4ff2a39d3b5f217b7b4a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c0166cd56bb4ff2a39d3b5f217b7b4a.avif"
     },
     {
         "franchise": "MIA",
@@ -3358,7 +3358,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88a07aa4a79e45e6b539b0048bf49814~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88a07aa4a79e45e6b539b0048bf49814~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88a07aa4a79e45e6b539b0048bf49814.avif"
     },
     {
         "franchise": "MIA",
@@ -3372,7 +3372,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_72d1878bc90143199ea7d21e08b43a23~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_72d1878bc90143199ea7d21e08b43a23~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_72d1878bc90143199ea7d21e08b43a23.avif"
     },
     {
         "franchise": "MIA",
@@ -3388,7 +3388,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_69f01829867940969cb5b5bd6f740058~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_69f01829867940969cb5b5bd6f740058~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_69f01829867940969cb5b5bd6f740058.avif"
     },
     {
         "franchise": "MIA",
@@ -3405,7 +3405,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6b335150a84346cb9c98a90649e55634~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6b335150a84346cb9c98a90649e55634~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6b335150a84346cb9c98a90649e55634.avif"
     },
     {
         "franchise": "MIA",
@@ -3420,7 +3420,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7276fa42ff634b40a107a11f4c029753~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7276fa42ff634b40a107a11f4c029753~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7276fa42ff634b40a107a11f4c029753.avif"
     },
     {
         "franchise": "MIA",
@@ -3437,7 +3437,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2a7f1e5bbad247e2b8eb7d5d1903b269~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2a7f1e5bbad247e2b8eb7d5d1903b269~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2a7f1e5bbad247e2b8eb7d5d1903b269.avif"
     },
     {
         "franchise": "MIA",
@@ -3451,7 +3451,7 @@
         "seasons": [
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_228df9dd5a7840639d200531d39f97ef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_228df9dd5a7840639d200531d39f97ef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_228df9dd5a7840639d200531d39f97ef.avif"
     },
     {
         "franchise": "MIA",
@@ -3465,7 +3465,7 @@
         "seasons": [
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3d205a4302a8442baf452cfcdf105d10~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3d205a4302a8442baf452cfcdf105d10~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3d205a4302a8442baf452cfcdf105d10.avif"
     },
     {
         "franchise": "MIA",
@@ -3479,7 +3479,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_18ecafca54194d968eaeb019837e5a05~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_18ecafca54194d968eaeb019837e5a05~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_18ecafca54194d968eaeb019837e5a05.avif"
     },
     {
         "franchise": "MIA",
@@ -3495,7 +3495,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_568a202e239c4c7bbd06b64e052d7c87~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_568a202e239c4c7bbd06b64e052d7c87~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_568a202e239c4c7bbd06b64e052d7c87.avif"
     },
     {
         "franchise": "MIA",
@@ -3509,7 +3509,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fb30b4f9c816441888df634d1364f4fd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fb30b4f9c816441888df634d1364f4fd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fb30b4f9c816441888df634d1364f4fd.avif"
     },
     {
         "franchise": "MIA",
@@ -3523,7 +3523,7 @@
         "seasons": [
             "2015-16"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1db0ab2cfe074aa3b96768837a411d37~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1db0ab2cfe074aa3b96768837a411d37~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1db0ab2cfe074aa3b96768837a411d37.avif"
     },
     {
         "franchise": "MIA",
@@ -3537,7 +3537,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_24bdeb5325bf4c6e821bf586fd5a42cf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_24bdeb5325bf4c6e821bf586fd5a42cf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_24bdeb5325bf4c6e821bf586fd5a42cf.avif"
     },
     {
         "franchise": "MIA",
@@ -3553,7 +3553,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2ee49c0754064f3394ad5ffd9fca869b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2ee49c0754064f3394ad5ffd9fca869b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2ee49c0754064f3394ad5ffd9fca869b.avif"
     },
     {
         "franchise": "MIA",
@@ -3568,7 +3568,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8c605b5aa2ac4f0bb9fba0a479ca0fef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8c605b5aa2ac4f0bb9fba0a479ca0fef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8c605b5aa2ac4f0bb9fba0a479ca0fef.avif"
     },
     {
         "franchise": "MIA",
@@ -3582,7 +3582,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b1b5219798f34319b3860a838d3298a4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b1b5219798f34319b3860a838d3298a4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b1b5219798f34319b3860a838d3298a4.avif"
     },
     {
         "franchise": "MIA",
@@ -3596,7 +3596,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ee818f84bb4d4955aaf831d438201f58~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ee818f84bb4d4955aaf831d438201f58~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ee818f84bb4d4955aaf831d438201f58.avif"
     },
     {
         "franchise": "CLE",
@@ -3610,7 +3610,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe6953ff78f145a4908b198c962e8a4d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe6953ff78f145a4908b198c962e8a4d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe6953ff78f145a4908b198c962e8a4d.avif"
     },
     {
         "franchise": "CLE",
@@ -3626,7 +3626,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4cf3187366a24851a3cdd667126b5e97~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4cf3187366a24851a3cdd667126b5e97~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4cf3187366a24851a3cdd667126b5e97.avif"
     },
     {
         "franchise": "CLE",
@@ -3645,7 +3645,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0470e02c3934cfdb0c354c229c17ad4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0470e02c3934cfdb0c354c229c17ad4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0470e02c3934cfdb0c354c229c17ad4.avif"
     },
     {
         "franchise": "CLE",
@@ -3659,7 +3659,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_16dfa93999444f8b9e96203b38360d6e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_16dfa93999444f8b9e96203b38360d6e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_16dfa93999444f8b9e96203b38360d6e.avif"
     },
     {
         "franchise": "CLE",
@@ -3674,7 +3674,7 @@
             "1981-82",
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_96f22c261a4144ab97bc0c3d45a6088a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_96f22c261a4144ab97bc0c3d45a6088a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_96f22c261a4144ab97bc0c3d45a6088a.avif"
     },
     {
         "franchise": "CLE",
@@ -3689,7 +3689,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5fdd7d285f0f41daaf141d1ac3e49503~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5fdd7d285f0f41daaf141d1ac3e49503~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5fdd7d285f0f41daaf141d1ac3e49503.avif"
     },
     {
         "franchise": "CLE",
@@ -3703,7 +3703,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ec220b8fc212499cb3358a0c4e1db8a3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ec220b8fc212499cb3358a0c4e1db8a3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ec220b8fc212499cb3358a0c4e1db8a3.avif"
     },
     {
         "franchise": "CLE",
@@ -3717,7 +3717,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cc1c02edd0f74c2e9384e886405a4c49~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cc1c02edd0f74c2e9384e886405a4c49~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cc1c02edd0f74c2e9384e886405a4c49.avif"
     },
     {
         "franchise": "CLE",
@@ -3731,7 +3731,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0525cdaa2ab14d63bbf006ce6bd5e212~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0525cdaa2ab14d63bbf006ce6bd5e212~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0525cdaa2ab14d63bbf006ce6bd5e212.avif"
     },
     {
         "franchise": "CLE",
@@ -3746,7 +3746,7 @@
             "1987-88",
             "1988-89"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_96cbe8877c6d4594852e41184a23503c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_96cbe8877c6d4594852e41184a23503c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_96cbe8877c6d4594852e41184a23503c.avif"
     },
     {
         "franchise": "CLE",
@@ -3764,7 +3764,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9b6df95c5cd64578bb5789a7ee715870~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9b6df95c5cd64578bb5789a7ee715870~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9b6df95c5cd64578bb5789a7ee715870.avif"
     },
     {
         "franchise": "CLE",
@@ -3779,7 +3779,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_726f486510d14d75b255102f913cca05~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_726f486510d14d75b255102f913cca05~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_726f486510d14d75b255102f913cca05.avif"
     },
     {
         "franchise": "CLE",
@@ -3793,7 +3793,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e13a2522d1f84b90a50330a6cadafc43~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e13a2522d1f84b90a50330a6cadafc43~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e13a2522d1f84b90a50330a6cadafc43.avif"
     },
     {
         "franchise": "CLE",
@@ -3808,7 +3808,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a3e0e352ebea416e9cca30f9e40259f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a3e0e352ebea416e9cca30f9e40259f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a3e0e352ebea416e9cca30f9e40259f8.avif"
     },
     {
         "franchise": "CLE",
@@ -3824,7 +3824,7 @@
             "2000-01",
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_981a99087e2f49de81d6aa7a90657b89~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_981a99087e2f49de81d6aa7a90657b89~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_981a99087e2f49de81d6aa7a90657b89.avif"
     },
     {
         "franchise": "CLE",
@@ -3838,7 +3838,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5653dc9d85e44ae5ad3214fd8ea9131a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5653dc9d85e44ae5ad3214fd8ea9131a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5653dc9d85e44ae5ad3214fd8ea9131a.avif"
     },
     {
         "franchise": "CLE",
@@ -3858,7 +3858,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_473832306d7b4564985896e07a057a4d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_473832306d7b4564985896e07a057a4d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_473832306d7b4564985896e07a057a4d.avif"
     },
     {
         "franchise": "CLE",
@@ -3875,7 +3875,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c660bb25ed0a42e7a0688403f02ed5be~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c660bb25ed0a42e7a0688403f02ed5be~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c660bb25ed0a42e7a0688403f02ed5be.avif"
     },
     {
         "franchise": "CLE",
@@ -3891,7 +3891,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5543bf383b0d4858af6815e2defdcf39~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5543bf383b0d4858af6815e2defdcf39~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5543bf383b0d4858af6815e2defdcf39.avif"
     },
     {
         "franchise": "CLE",
@@ -3908,7 +3908,7 @@
             "2019-20",
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_554c604dd60746abaff25021c6edf591~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_554c604dd60746abaff25021c6edf591~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_554c604dd60746abaff25021c6edf591.avif"
     },
     {
         "franchise": "CLE",
@@ -3922,7 +3922,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_be85b97f63b24a029d9a5b04e256b630~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_be85b97f63b24a029d9a5b04e256b630~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_be85b97f63b24a029d9a5b04e256b630.avif"
     },
     {
         "franchise": "CLE",
@@ -3936,7 +3936,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_285897cbeed9404990dc795afee5b0c9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_285897cbeed9404990dc795afee5b0c9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_285897cbeed9404990dc795afee5b0c9.avif"
     },
     {
         "franchise": "CLE",
@@ -3950,7 +3950,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8a0d12d4165c487688d149bac98c1049~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8a0d12d4165c487688d149bac98c1049~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8a0d12d4165c487688d149bac98c1049.avif"
     },
     {
         "franchise": "CLE",
@@ -3968,7 +3968,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5a6135f7ede243ea8aa702cb62837694~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5a6135f7ede243ea8aa702cb62837694~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5a6135f7ede243ea8aa702cb62837694.avif"
     },
     {
         "franchise": "CLE",
@@ -3983,7 +3983,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bc710ce51a6d435b84bfd9d9dd7c419c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bc710ce51a6d435b84bfd9d9dd7c419c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bc710ce51a6d435b84bfd9d9dd7c419c.avif"
     },
     {
         "franchise": "CLE",
@@ -3999,7 +3999,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b29ef2ffce6b42aca4f3ab6255633394~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b29ef2ffce6b42aca4f3ab6255633394~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b29ef2ffce6b42aca4f3ab6255633394.avif"
     },
     {
         "franchise": "CLE",
@@ -4015,7 +4015,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1acb5ff4655540a48ca6bee783a8fa12~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1acb5ff4655540a48ca6bee783a8fa12~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1acb5ff4655540a48ca6bee783a8fa12.avif"
     },
     {
         "franchise": "CLE",
@@ -4031,7 +4031,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_de979272a8de45c491b213a3e16feb21~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_de979272a8de45c491b213a3e16feb21~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_de979272a8de45c491b213a3e16feb21.avif"
     },
     {
         "franchise": "CLE",
@@ -4045,7 +4045,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_99894e77a619443b81925bd46abb5a77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_99894e77a619443b81925bd46abb5a77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_99894e77a619443b81925bd46abb5a77.avif"
     },
     {
         "franchise": "CLE",
@@ -4059,7 +4059,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b97decbc762941e2a47bd39aaa8ec743~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b97decbc762941e2a47bd39aaa8ec743~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b97decbc762941e2a47bd39aaa8ec743.avif"
     },
     {
         "franchise": "CLE",
@@ -4073,7 +4073,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b7d56777a5254cfb97b0d79fe8888e0c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b7d56777a5254cfb97b0d79fe8888e0c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b7d56777a5254cfb97b0d79fe8888e0c.avif"
     },
     {
         "franchise": "CLE",
@@ -4087,7 +4087,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8d6cb482e4d241c6b1caa50f8c1cee7f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8d6cb482e4d241c6b1caa50f8c1cee7f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8d6cb482e4d241c6b1caa50f8c1cee7f.avif"
     },
     {
         "franchise": "SDS",
@@ -4102,7 +4102,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2b2da934598441869932d016db599b2a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2b2da934598441869932d016db599b2a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2b2da934598441869932d016db599b2a.avif"
     },
     {
         "franchise": "SDS",
@@ -4116,7 +4116,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0f3481dff5814409b046fa3d06f024af~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0f3481dff5814409b046fa3d06f024af~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0f3481dff5814409b046fa3d06f024af.avif"
     },
     {
         "franchise": "SDS",
@@ -4130,7 +4130,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_12250ae1f3584501997e009dbb687abb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_12250ae1f3584501997e009dbb687abb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_12250ae1f3584501997e009dbb687abb.avif"
     },
     {
         "franchise": "SAS",
@@ -4145,7 +4145,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4b3ca1caab5c41d19ed760f55b7ac72c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4b3ca1caab5c41d19ed760f55b7ac72c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4b3ca1caab5c41d19ed760f55b7ac72c.avif"
     },
     {
         "franchise": "SAS",
@@ -4161,7 +4161,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4db4eb20f144436bbaf3424b09a8980a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4db4eb20f144436bbaf3424b09a8980a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4db4eb20f144436bbaf3424b09a8980a.avif"
     },
     {
         "franchise": "SAS",
@@ -4176,7 +4176,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e6b5417bcba3454b93d1e0365e31137b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e6b5417bcba3454b93d1e0365e31137b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e6b5417bcba3454b93d1e0365e31137b.avif"
     },
     {
         "franchise": "SAS",
@@ -4192,7 +4192,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_211232c467aa4345a310a6b6676028ff~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_211232c467aa4345a310a6b6676028ff~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_211232c467aa4345a310a6b6676028ff.avif"
     },
     {
         "franchise": "SAS",
@@ -4206,7 +4206,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fd3d10d7af424db19fa0f7b046ec5321~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fd3d10d7af424db19fa0f7b046ec5321~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fd3d10d7af424db19fa0f7b046ec5321.avif"
     },
     {
         "franchise": "SAS",
@@ -4220,7 +4220,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bdebd1db04b94b80863c4d352528e77d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bdebd1db04b94b80863c4d352528e77d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bdebd1db04b94b80863c4d352528e77d.avif"
     },
     {
         "franchise": "SAS",
@@ -4234,7 +4234,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_be371ce6f092487aaf2c9b55d1338c7c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_be371ce6f092487aaf2c9b55d1338c7c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_be371ce6f092487aaf2c9b55d1338c7c.avif"
     },
     {
         "franchise": "SAS",
@@ -4248,7 +4248,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_650f2d3e374b49b38054abbbcd6e83b2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_650f2d3e374b49b38054abbbcd6e83b2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_650f2d3e374b49b38054abbbcd6e83b2.avif"
     },
     {
         "franchise": "SAS",
@@ -4260,7 +4260,7 @@
         "endYear": 1969,
         "years": "1967-68 – 1968-69",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_3cf2faba38f540cebbae9919377fb359~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3cf2faba38f540cebbae9919377fb359~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3cf2faba38f540cebbae9919377fb359.avif"
     },
     {
         "franchise": "SAS",
@@ -4272,7 +4272,7 @@
         "endYear": 1970,
         "years": "1969-70",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_5c778f3404cb40fa9c3ead7af674d19a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5c778f3404cb40fa9c3ead7af674d19a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5c778f3404cb40fa9c3ead7af674d19a.avif"
     },
     {
         "franchise": "SAS",
@@ -4284,7 +4284,7 @@
         "endYear": 1971,
         "years": "1970-71",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_4396a0c0f4474b759192f6f13ba32b96~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4396a0c0f4474b759192f6f13ba32b96~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4396a0c0f4474b759192f6f13ba32b96.avif"
     },
     {
         "franchise": "SAS",
@@ -4296,7 +4296,7 @@
         "endYear": 1971,
         "years": "1970-71",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_8af4a4cdad194a18a88c392e5828f829~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8af4a4cdad194a18a88c392e5828f829~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8af4a4cdad194a18a88c392e5828f829.avif"
     },
     {
         "franchise": "SAS",
@@ -4308,7 +4308,7 @@
         "endYear": 1973,
         "years": "1971-72 – 1972-73",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_53b2341e9d324633a84e640704936ecc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_53b2341e9d324633a84e640704936ecc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_53b2341e9d324633a84e640704936ecc.avif"
     },
     {
         "franchise": "SAS",
@@ -4320,7 +4320,7 @@
         "endYear": 1974,
         "years": "1973-74",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_cd456e6791b54fd7aca00b3f5a950766~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cd456e6791b54fd7aca00b3f5a950766~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cd456e6791b54fd7aca00b3f5a950766.avif"
     },
     {
         "franchise": "SAS",
@@ -4332,7 +4332,7 @@
         "endYear": 1976,
         "years": "1974-75 – 1975-76",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_0328df711ed944e0b1831dc52c3de8ab~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0328df711ed944e0b1831dc52c3de8ab~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0328df711ed944e0b1831dc52c3de8ab.avif"
     },
     {
         "franchise": "SAS",
@@ -4346,7 +4346,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1693cf4714254934ab59293a64bf7676~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1693cf4714254934ab59293a64bf7676~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1693cf4714254934ab59293a64bf7676.avif"
     },
     {
         "franchise": "SAS",
@@ -4361,7 +4361,7 @@
             "1977-78",
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9545fbc3667a4bfba53f25c848009f06~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9545fbc3667a4bfba53f25c848009f06~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9545fbc3667a4bfba53f25c848009f06.avif"
     },
     {
         "franchise": "SAS",
@@ -4375,7 +4375,7 @@
         "seasons": [
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e1c8a4b05b1412ea77c1f83fb91bf7f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e1c8a4b05b1412ea77c1f83fb91bf7f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e1c8a4b05b1412ea77c1f83fb91bf7f.avif"
     },
     {
         "franchise": "SAS",
@@ -4389,7 +4389,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9fe4b2e58f444662ba770f467c46d82e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9fe4b2e58f444662ba770f467c46d82e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9fe4b2e58f444662ba770f467c46d82e.avif"
     },
     {
         "franchise": "SAS",
@@ -4403,7 +4403,7 @@
         "seasons": [
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_336c5a63b77243b68aa8a79ea08be268~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_336c5a63b77243b68aa8a79ea08be268~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_336c5a63b77243b68aa8a79ea08be268.avif"
     },
     {
         "franchise": "SAS",
@@ -4420,7 +4420,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c6059b06fd38414880f7ffea422489a4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c6059b06fd38414880f7ffea422489a4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c6059b06fd38414880f7ffea422489a4.avif"
     },
     {
         "franchise": "SAS",
@@ -4436,7 +4436,7 @@
             "1987-88",
             "1988-89"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2d8d2a2fc74c42058a5a1edd034ffbf9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2d8d2a2fc74c42058a5a1edd034ffbf9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2d8d2a2fc74c42058a5a1edd034ffbf9.avif"
     },
     {
         "franchise": "SAS",
@@ -4454,7 +4454,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_10d5a4ae8a524168b04c03602c684b29~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_10d5a4ae8a524168b04c03602c684b29~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_10d5a4ae8a524168b04c03602c684b29.avif"
     },
     {
         "franchise": "SAS",
@@ -4470,7 +4470,7 @@
             "1995-96",
             "1997-98"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_66b6f90e6bd143b8b602bc39b54cbb64~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_66b6f90e6bd143b8b602bc39b54cbb64~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_66b6f90e6bd143b8b602bc39b54cbb64.avif"
     },
     {
         "franchise": "SAS",
@@ -4484,7 +4484,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_07fe5e340248429e937d490c41ca5848~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_07fe5e340248429e937d490c41ca5848~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_07fe5e340248429e937d490c41ca5848.avif"
     },
     {
         "franchise": "SAS",
@@ -4498,7 +4498,7 @@
         "seasons": [
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e4f868ec31e8486c9fc63fa06a7d495d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e4f868ec31e8486c9fc63fa06a7d495d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e4f868ec31e8486c9fc63fa06a7d495d.avif"
     },
     {
         "franchise": "SAS",
@@ -4513,7 +4513,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2d7763678db74a4bb078c709834151b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2d7763678db74a4bb078c709834151b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2d7763678db74a4bb078c709834151b1.avif"
     },
     {
         "franchise": "SAS",
@@ -4527,7 +4527,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_295689d365bd4361bf3914051044ebff~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_295689d365bd4361bf3914051044ebff~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_295689d365bd4361bf3914051044ebff.avif"
     },
     {
         "franchise": "SAS",
@@ -4548,7 +4548,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_167ddcec202f4a37b28d6fdb0ac36928~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_167ddcec202f4a37b28d6fdb0ac36928~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_167ddcec202f4a37b28d6fdb0ac36928.avif"
     },
     {
         "franchise": "SAS",
@@ -4565,7 +4565,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2aebb1e2eded4056aa01369b3ed60b46~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2aebb1e2eded4056aa01369b3ed60b46~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2aebb1e2eded4056aa01369b3ed60b46.avif"
     },
     {
         "franchise": "SAS",
@@ -4581,7 +4581,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fea938f809f54563ba12109178bf4611~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fea938f809f54563ba12109178bf4611~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fea938f809f54563ba12109178bf4611.avif"
     },
     {
         "franchise": "SAS",
@@ -4596,7 +4596,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_714c3a27f919416e956a69d00f6312aa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_714c3a27f919416e956a69d00f6312aa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_714c3a27f919416e956a69d00f6312aa.avif"
     },
     {
         "franchise": "SAS",
@@ -4612,7 +4612,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3a2d4f01495c433eadf4f0fcef0f6c3b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3a2d4f01495c433eadf4f0fcef0f6c3b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3a2d4f01495c433eadf4f0fcef0f6c3b.avif"
     },
     {
         "franchise": "SAS",
@@ -4626,7 +4626,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e60b67fc98ed4cd5b7af72a44d9c9e99~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e60b67fc98ed4cd5b7af72a44d9c9e99~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e60b67fc98ed4cd5b7af72a44d9c9e99.avif"
     },
     {
         "franchise": "SAS",
@@ -4640,7 +4640,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_72a00e951e0c40acaf0656f4dc45262b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_72a00e951e0c40acaf0656f4dc45262b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_72a00e951e0c40acaf0656f4dc45262b.avif"
     },
     {
         "franchise": "SAC",
@@ -4655,7 +4655,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_98d252be091847a0ac91253cb2e3e1b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_98d252be091847a0ac91253cb2e3e1b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_98d252be091847a0ac91253cb2e3e1b1.avif"
     },
     {
         "franchise": "SAC",
@@ -4669,7 +4669,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dd1edcf45cc64c08a066dcab370a273d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dd1edcf45cc64c08a066dcab370a273d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dd1edcf45cc64c08a066dcab370a273d.avif"
     },
     {
         "franchise": "SAC",
@@ -4683,7 +4683,7 @@
         "seasons": [
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_696dc63ba71f475bbbc9e920cb894d55~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_696dc63ba71f475bbbc9e920cb894d55~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_696dc63ba71f475bbbc9e920cb894d55.avif"
     },
     {
         "franchise": "SAC",
@@ -4698,7 +4698,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a50c688483e343ffa577e93ac309dbae~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a50c688483e343ffa577e93ac309dbae~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a50c688483e343ffa577e93ac309dbae.avif"
     },
     {
         "franchise": "SAC",
@@ -4712,7 +4712,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e41ab86b14b34b299b53a6f8d84bbe98~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e41ab86b14b34b299b53a6f8d84bbe98~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e41ab86b14b34b299b53a6f8d84bbe98.avif"
     },
     {
         "franchise": "SAC",
@@ -4727,7 +4727,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9bc68c9d33664a22939f329d826a8804~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9bc68c9d33664a22939f329d826a8804~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9bc68c9d33664a22939f329d826a8804.avif"
     },
     {
         "franchise": "SAC",
@@ -4743,7 +4743,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2c64ff23695c4e3e95e36e575fd4fe0a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2c64ff23695c4e3e95e36e575fd4fe0a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2c64ff23695c4e3e95e36e575fd4fe0a.avif"
     },
     {
         "franchise": "SAC",
@@ -4758,7 +4758,7 @@
             "2014-15",
             "2015-16"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e65104a009be45d89ecd1d1c822afddc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e65104a009be45d89ecd1d1c822afddc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e65104a009be45d89ecd1d1c822afddc.avif"
     },
     {
         "franchise": "SAC",
@@ -4772,7 +4772,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3554bf097665474891ae108f62a17ea4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3554bf097665474891ae108f62a17ea4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3554bf097665474891ae108f62a17ea4.avif"
     },
     {
         "franchise": "SAC",
@@ -4786,7 +4786,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d247eb14abca47f5b61aa87f3fb0f498~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d247eb14abca47f5b61aa87f3fb0f498~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d247eb14abca47f5b61aa87f3fb0f498.avif"
     },
     {
         "franchise": "SAC",
@@ -4802,7 +4802,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f2397f19b40b43e5a90249bf2321f44d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f2397f19b40b43e5a90249bf2321f44d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f2397f19b40b43e5a90249bf2321f44d.avif"
     },
     {
         "franchise": "SAC",
@@ -4816,7 +4816,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_212ff3d4856442fead3fe25fb99e670c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_212ff3d4856442fead3fe25fb99e670c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_212ff3d4856442fead3fe25fb99e670c.avif"
     },
     {
         "franchise": "SAC",
@@ -4830,7 +4830,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b574924f014d415f839e95d10fe29087~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b574924f014d415f839e95d10fe29087~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b574924f014d415f839e95d10fe29087.avif"
     },
     {
         "franchise": "SAC",
@@ -4844,7 +4844,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f8d6a62826ee4db995d740d4254f82af~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f8d6a62826ee4db995d740d4254f82af~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f8d6a62826ee4db995d740d4254f82af.avif"
     },
     {
         "franchise": "SAC",
@@ -4858,7 +4858,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fa7a79424f0642a387a0e41170be9a18~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fa7a79424f0642a387a0e41170be9a18~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fa7a79424f0642a387a0e41170be9a18.avif"
     },
     {
         "franchise": "SAC",
@@ -4872,7 +4872,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_49d129542743417183fe84a0403579e1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_49d129542743417183fe84a0403579e1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_49d129542743417183fe84a0403579e1.avif"
     },
     {
         "franchise": "SAC",
@@ -4887,7 +4887,7 @@
             "1949-50",
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_80071aff92bb46409785969d775dd581~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_80071aff92bb46409785969d775dd581~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_80071aff92bb46409785969d775dd581.avif"
     },
     {
         "franchise": "SAC",
@@ -4904,7 +4904,7 @@
             "1953-54",
             "1954-55"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_843101e71b7048ecbc6e8b9b77552a67~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_843101e71b7048ecbc6e8b9b77552a67~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_843101e71b7048ecbc6e8b9b77552a67.avif"
     },
     {
         "franchise": "SAC",
@@ -4918,7 +4918,7 @@
         "seasons": [
             "1955-56"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_98cb8ac361ff487ea2e56d65b34ac931~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_98cb8ac361ff487ea2e56d65b34ac931~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_98cb8ac361ff487ea2e56d65b34ac931.avif"
     },
     {
         "franchise": "SAC",
@@ -4932,7 +4932,7 @@
         "seasons": [
             "1956-57"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_daf6243cec354422b37ffaead14617fc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_daf6243cec354422b37ffaead14617fc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_daf6243cec354422b37ffaead14617fc.avif"
     },
     {
         "franchise": "SAC",
@@ -4948,7 +4948,7 @@
             "1958-59",
             "1959-60"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8cf49ba308564fdaa62034e4b099ee2d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8cf49ba308564fdaa62034e4b099ee2d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8cf49ba308564fdaa62034e4b099ee2d.avif"
     },
     {
         "franchise": "SAC",
@@ -4964,7 +4964,7 @@
             "1961-62",
             "1962-63"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dce40a5cf44249a7b983420d05d62f61~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dce40a5cf44249a7b983420d05d62f61~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dce40a5cf44249a7b983420d05d62f61.avif"
     },
     {
         "franchise": "SAC",
@@ -4981,7 +4981,7 @@
             "1965-66",
             "1966-67"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8c97def4c72d4e5eb0c8f37bda0a87fb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8c97def4c72d4e5eb0c8f37bda0a87fb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8c97def4c72d4e5eb0c8f37bda0a87fb.avif"
     },
     {
         "franchise": "SAC",
@@ -4995,7 +4995,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7d4d3c949c1447eba9347061523e5a9d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7d4d3c949c1447eba9347061523e5a9d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7d4d3c949c1447eba9347061523e5a9d.avif"
     },
     {
         "franchise": "SAC",
@@ -5009,7 +5009,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fb1b05fa359a4275a48a4728e5b90949~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fb1b05fa359a4275a48a4728e5b90949~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fb1b05fa359a4275a48a4728e5b90949.avif"
     },
     {
         "franchise": "SAC",
@@ -5025,7 +5025,7 @@
             "1969-70",
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0ff3c3c3a8d74fb9be1a82e831c39f0f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0ff3c3c3a8d74fb9be1a82e831c39f0f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0ff3c3c3a8d74fb9be1a82e831c39f0f.avif"
     },
     {
         "franchise": "SAC",
@@ -5040,7 +5040,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_305a15cd47f64417ada83725ff951b0b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_305a15cd47f64417ada83725ff951b0b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_305a15cd47f64417ada83725ff951b0b.avif"
     },
     {
         "franchise": "SAC",
@@ -5054,7 +5054,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ed60f3bd6fdc4528836d3cd637cd48b9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ed60f3bd6fdc4528836d3cd637cd48b9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ed60f3bd6fdc4528836d3cd637cd48b9.avif"
     },
     {
         "franchise": "SAC",
@@ -5068,7 +5068,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_967cbecfc41a4fdd872ce618dedf2ad6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_967cbecfc41a4fdd872ce618dedf2ad6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_967cbecfc41a4fdd872ce618dedf2ad6.avif"
     },
     {
         "franchise": "SAC",
@@ -5083,7 +5083,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ed1c7141cf52454a91a489b7a654ac19~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ed1c7141cf52454a91a489b7a654ac19~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ed1c7141cf52454a91a489b7a654ac19.avif"
     },
     {
         "franchise": "SAC",
@@ -5098,7 +5098,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7d9319ac2f25424ea6d1a6b5dc56e2eb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7d9319ac2f25424ea6d1a6b5dc56e2eb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7d9319ac2f25424ea6d1a6b5dc56e2eb.avif"
     },
     {
         "franchise": "SAC",
@@ -5112,7 +5112,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f14b6c97a11d4499af3532b547a34215~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f14b6c97a11d4499af3532b547a34215~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f14b6c97a11d4499af3532b547a34215.avif"
     },
     {
         "franchise": "SAC",
@@ -5128,7 +5128,7 @@
             "1976-77",
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3f24831d4fe54467b2a0c9f9384a0d25~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3f24831d4fe54467b2a0c9f9384a0d25~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3f24831d4fe54467b2a0c9f9384a0d25.avif"
     },
     {
         "franchise": "SAC",
@@ -5143,7 +5143,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_586eed5da52340969b23fe98f574825c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_586eed5da52340969b23fe98f574825c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_586eed5da52340969b23fe98f574825c.avif"
     },
     {
         "franchise": "SAC",
@@ -5157,7 +5157,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2baae89e26014b8b9dfceca7b97a1782~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2baae89e26014b8b9dfceca7b97a1782~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2baae89e26014b8b9dfceca7b97a1782.avif"
     },
     {
         "franchise": "SAC",
@@ -5174,7 +5174,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_478488af7a2648b1a1827665f7bd5264~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_478488af7a2648b1a1827665f7bd5264~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_478488af7a2648b1a1827665f7bd5264.avif"
     },
     {
         "franchise": "SAC",
@@ -5188,7 +5188,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f0644a19764b49f39835ac490488a04a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f0644a19764b49f39835ac490488a04a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f0644a19764b49f39835ac490488a04a.avif"
     },
     {
         "franchise": "SAC",
@@ -5205,7 +5205,7 @@
             "1988-89",
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a1a9e10a0cfa4877a8864df18fc9e13f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a1a9e10a0cfa4877a8864df18fc9e13f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a1a9e10a0cfa4877a8864df18fc9e13f.avif"
     },
     {
         "franchise": "SAC",
@@ -5222,7 +5222,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_10057a9554a84cc5b104c781b5fa90f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_10057a9554a84cc5b104c781b5fa90f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_10057a9554a84cc5b104c781b5fa90f8.avif"
     },
     {
         "franchise": "SAC",
@@ -5240,7 +5240,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aab982ebc1ff47b5bf663dc8746d9899~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aab982ebc1ff47b5bf663dc8746d9899~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aab982ebc1ff47b5bf663dc8746d9899.avif"
     },
     {
         "franchise": "SAC",
@@ -5254,7 +5254,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9a666527d7e6416184155bac158ff309~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9a666527d7e6416184155bac158ff309~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9a666527d7e6416184155bac158ff309.avif"
     },
     {
         "franchise": "SAC",
@@ -5269,7 +5269,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c3040dee8cef44cdbbab27f3227aa95e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c3040dee8cef44cdbbab27f3227aa95e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c3040dee8cef44cdbbab27f3227aa95e.avif"
     },
     {
         "franchise": "SAC",
@@ -5283,7 +5283,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_73b9a67e126446ff973b33fe2c9399b9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_73b9a67e126446ff973b33fe2c9399b9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_73b9a67e126446ff973b33fe2c9399b9.avif"
     },
     {
         "franchise": "SAC",
@@ -5300,7 +5300,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3a11e55ddeae4530b35ee338f7b55eed~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3a11e55ddeae4530b35ee338f7b55eed~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3a11e55ddeae4530b35ee338f7b55eed.avif"
     },
     {
         "franchise": "SAC",
@@ -5315,7 +5315,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d506bb180bc044409f9086468c49722f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d506bb180bc044409f9086468c49722f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d506bb180bc044409f9086468c49722f.avif"
     },
     {
         "franchise": "SAC",
@@ -5334,7 +5334,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88ea6e1a04de477e861e9031c205718d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88ea6e1a04de477e861e9031c205718d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88ea6e1a04de477e861e9031c205718d.avif"
     },
     {
         "franchise": "SAC",
@@ -5349,7 +5349,7 @@
             "2014-15",
             "2015-16"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8dd48df525384547acb6ad18c8fe1472~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8dd48df525384547acb6ad18c8fe1472~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8dd48df525384547acb6ad18c8fe1472.avif"
     },
     {
         "franchise": "SAC",
@@ -5363,7 +5363,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1e68213694ee4c6dbe3cd8b5ab4d34f7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1e68213694ee4c6dbe3cd8b5ab4d34f7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1e68213694ee4c6dbe3cd8b5ab4d34f7.avif"
     },
     {
         "franchise": "SAC",
@@ -5381,7 +5381,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c9c37c1d0f884e23b1e983aa058cda3a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c9c37c1d0f884e23b1e983aa058cda3a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c9c37c1d0f884e23b1e983aa058cda3a.avif"
     },
     {
         "franchise": "SAC",
@@ -5395,7 +5395,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_08338d6c8e5c484e80b7e0b2ccd424b6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_08338d6c8e5c484e80b7e0b2ccd424b6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_08338d6c8e5c484e80b7e0b2ccd424b6.avif"
     },
     {
         "franchise": "SAC",
@@ -5409,7 +5409,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4073b90cb25f4686950a48a9946ce25a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4073b90cb25f4686950a48a9946ce25a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4073b90cb25f4686950a48a9946ce25a.avif"
     },
     {
         "franchise": "SAC",
@@ -5423,7 +5423,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7173279c2b9b4998a9634acf4e922320~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7173279c2b9b4998a9634acf4e922320~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7173279c2b9b4998a9634acf4e922320.avif"
     },
     {
         "franchise": "UTA",
@@ -5437,7 +5437,7 @@
         "seasons": [
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1b87fe1d76794a7992d547042b4aa6ec~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1b87fe1d76794a7992d547042b4aa6ec~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1b87fe1d76794a7992d547042b4aa6ec.avif"
     },
     {
         "franchise": "UTA",
@@ -5454,7 +5454,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_89dcb20610014c36a29ec4187eaf3d03~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_89dcb20610014c36a29ec4187eaf3d03~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_89dcb20610014c36a29ec4187eaf3d03.avif"
     },
     {
         "franchise": "UTA",
@@ -5468,7 +5468,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8edb60f9876b45d88f13a1aade75abc5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8edb60f9876b45d88f13a1aade75abc5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8edb60f9876b45d88f13a1aade75abc5.avif"
     },
     {
         "franchise": "UTA",
@@ -5485,7 +5485,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dd07df9af50e47b8a6a609ab7fd13b95~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dd07df9af50e47b8a6a609ab7fd13b95~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dd07df9af50e47b8a6a609ab7fd13b95.avif"
     },
     {
         "franchise": "UTA",
@@ -5501,7 +5501,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1545fb7f484f408ea56a60a8510283f1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1545fb7f484f408ea56a60a8510283f1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1545fb7f484f408ea56a60a8510283f1.avif"
     },
     {
         "franchise": "UTA",
@@ -5516,7 +5516,7 @@
             "2014-15",
             "2015-16"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0568b36dc06d47e8b3c6c03a5f729146~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0568b36dc06d47e8b3c6c03a5f729146~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0568b36dc06d47e8b3c6c03a5f729146.avif"
     },
     {
         "franchise": "UTA",
@@ -5530,7 +5530,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d15eaa81b80948b3a7c1baa6d67d0f33~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d15eaa81b80948b3a7c1baa6d67d0f33~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d15eaa81b80948b3a7c1baa6d67d0f33.avif"
     },
     {
         "franchise": "UTA",
@@ -5546,7 +5546,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2cbc9884f556435ba7c0a6e98b6457c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2cbc9884f556435ba7c0a6e98b6457c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2cbc9884f556435ba7c0a6e98b6457c4.avif"
     },
     {
         "franchise": "UTA",
@@ -5560,7 +5560,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5bf14f60fb0045fda44718bcf0a9ca6e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5bf14f60fb0045fda44718bcf0a9ca6e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5bf14f60fb0045fda44718bcf0a9ca6e.avif"
     },
     {
         "franchise": "UTA",
@@ -5574,7 +5574,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e26f292c36a4409caa58d3701499b038~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e26f292c36a4409caa58d3701499b038~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e26f292c36a4409caa58d3701499b038.avif"
     },
     {
         "franchise": "UTA",
@@ -5588,7 +5588,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7397f2bfbad04d49bf5a5a351a49c7c5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7397f2bfbad04d49bf5a5a351a49c7c5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7397f2bfbad04d49bf5a5a351a49c7c5.avif"
     },
     {
         "franchise": "UTA",
@@ -5603,7 +5603,7 @@
             "2023-24",
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_92e7c2191cb84b419b2225171556056b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_92e7c2191cb84b419b2225171556056b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_92e7c2191cb84b419b2225171556056b.avif"
     },
     {
         "franchise": "UTA",
@@ -5617,7 +5617,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ae15641cd8b24b2e988ee81f43500297~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ae15641cd8b24b2e988ee81f43500297~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ae15641cd8b24b2e988ee81f43500297.avif"
     },
     {
         "franchise": "UTA",
@@ -5631,7 +5631,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4fa6bc679fba4f899bcccd86a92e6a2f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4fa6bc679fba4f899bcccd86a92e6a2f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4fa6bc679fba4f899bcccd86a92e6a2f.avif"
     },
     {
         "franchise": "UTA",
@@ -5648,7 +5648,7 @@
             "1977-78",
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_074803bbc9114067824265c8bed31ce1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_074803bbc9114067824265c8bed31ce1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_074803bbc9114067824265c8bed31ce1.avif"
     },
     {
         "franchise": "UTA",
@@ -5662,7 +5662,7 @@
         "seasons": [
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_77e23687da284a33979de22abce8f543~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_77e23687da284a33979de22abce8f543~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_77e23687da284a33979de22abce8f543.avif"
     },
     {
         "franchise": "UTA",
@@ -5676,7 +5676,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e5a1ccc2ad214f1594383f2a1f4e16dc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e5a1ccc2ad214f1594383f2a1f4e16dc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e5a1ccc2ad214f1594383f2a1f4e16dc.avif"
     },
     {
         "franchise": "UTA",
@@ -5692,7 +5692,7 @@
             "1982-83",
             "1983-84"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1955e59f096b4b59b507724debfe2e1a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1955e59f096b4b59b507724debfe2e1a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1955e59f096b4b59b507724debfe2e1a.avif"
     },
     {
         "franchise": "UTA",
@@ -5707,7 +5707,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4b1273ea6f57479fa6ec60f9fa4a5ec3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4b1273ea6f57479fa6ec60f9fa4a5ec3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4b1273ea6f57479fa6ec60f9fa4a5ec3.avif"
     },
     {
         "franchise": "UTA",
@@ -5728,7 +5728,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f99073a657504c6289a54c7c2a3a71d2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f99073a657504c6289a54c7c2a3a71d2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f99073a657504c6289a54c7c2a3a71d2.avif"
     },
     {
         "franchise": "UTA",
@@ -5743,7 +5743,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2e97e76feb814a84ab3803e2aba6b241~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2e97e76feb814a84ab3803e2aba6b241~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2e97e76feb814a84ab3803e2aba6b241.avif"
     },
     {
         "franchise": "UTA",
@@ -5757,7 +5757,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d96314a3f7654ee1ad646ba1ba6d717f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d96314a3f7654ee1ad646ba1ba6d717f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d96314a3f7654ee1ad646ba1ba6d717f.avif"
     },
     {
         "franchise": "UTA",
@@ -5772,7 +5772,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7e8fda4f398c479d9d0b59093dc8ea9d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7e8fda4f398c479d9d0b59093dc8ea9d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7e8fda4f398c479d9d0b59093dc8ea9d.avif"
     },
     {
         "franchise": "UTA",
@@ -5789,7 +5789,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_80c25a4685b84f0393cd971eb7f5d35d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_80c25a4685b84f0393cd971eb7f5d35d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_80c25a4685b84f0393cd971eb7f5d35d.avif"
     },
     {
         "franchise": "UTA",
@@ -5803,7 +5803,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4d66d6a6365b425b971d1a2db247e862~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4d66d6a6365b425b971d1a2db247e862~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4d66d6a6365b425b971d1a2db247e862.avif"
     },
     {
         "franchise": "UTA",
@@ -5822,7 +5822,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d2c08c82a72244abb078297fb29ef24e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d2c08c82a72244abb078297fb29ef24e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d2c08c82a72244abb078297fb29ef24e.avif"
     },
     {
         "franchise": "UTA",
@@ -5839,7 +5839,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_236e40f0fb3145beb521443d905b89f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_236e40f0fb3145beb521443d905b89f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_236e40f0fb3145beb521443d905b89f8.avif"
     },
     {
         "franchise": "UTA",
@@ -5854,7 +5854,7 @@
             "2014-15",
             "2015-16"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_113de98fbfd44625a4a1f54005b1bc10~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_113de98fbfd44625a4a1f54005b1bc10~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_113de98fbfd44625a4a1f54005b1bc10.avif"
     },
     {
         "franchise": "UTA",
@@ -5868,7 +5868,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2bd10ef77d544c78a6a21d7b65bbd674~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2bd10ef77d544c78a6a21d7b65bbd674~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2bd10ef77d544c78a6a21d7b65bbd674.avif"
     },
     {
         "franchise": "UTA",
@@ -5885,7 +5885,7 @@
             "2019-20",
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a59e8b846ad0431ba2da4294af5b8d74~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a59e8b846ad0431ba2da4294af5b8d74~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a59e8b846ad0431ba2da4294af5b8d74.avif"
     },
     {
         "franchise": "UTA",
@@ -5899,7 +5899,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3afe5fa26fe543f081be90fa0c58ff05~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3afe5fa26fe543f081be90fa0c58ff05~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3afe5fa26fe543f081be90fa0c58ff05.avif"
     },
     {
         "franchise": "UTA",
@@ -5913,7 +5913,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e5b459d6d0740679a033bdf986f39e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e5b459d6d0740679a033bdf986f39e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e5b459d6d0740679a033bdf986f39e0.avif"
     },
     {
         "franchise": "UTA",
@@ -5927,7 +5927,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_79e4a834110041408dea62d1e35625b2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_79e4a834110041408dea62d1e35625b2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_79e4a834110041408dea62d1e35625b2.avif"
     },
     {
         "franchise": "KEN",
@@ -5942,7 +5942,7 @@
             "1967-68",
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_659643921bd64f9c9265828a4824b5e6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_659643921bd64f9c9265828a4824b5e6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_659643921bd64f9c9265828a4824b5e6.avif"
     },
     {
         "franchise": "KEN",
@@ -5954,7 +5954,7 @@
         "endYear": 1970,
         "years": "1969-70",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_04ce3619706849e79d0b771f8d90ca3f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_04ce3619706849e79d0b771f8d90ca3f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_04ce3619706849e79d0b771f8d90ca3f.avif"
     },
     {
         "franchise": "KEN",
@@ -5971,7 +5971,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6d18fb8b35744a75acad3b70c70d99c6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6d18fb8b35744a75acad3b70c70d99c6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6d18fb8b35744a75acad3b70c70d99c6.avif"
     },
     {
         "franchise": "KEN",
@@ -5986,7 +5986,7 @@
             "1974-75",
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cb14c1fb81af425a8eaf6c9eeff905b9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cb14c1fb81af425a8eaf6c9eeff905b9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cb14c1fb81af425a8eaf6c9eeff905b9.avif"
     },
     {
         "franchise": "MIL",
@@ -6001,7 +6001,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fadcda95fd7b4980a78ba7fbfabafd5e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fadcda95fd7b4980a78ba7fbfabafd5e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fadcda95fd7b4980a78ba7fbfabafd5e.avif"
     },
     {
         "franchise": "MIL",
@@ -6015,7 +6015,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3ad997d341144fe2979ad096a4e26878~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3ad997d341144fe2979ad096a4e26878~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3ad997d341144fe2979ad096a4e26878.avif"
     },
     {
         "franchise": "MIL",
@@ -6030,7 +6030,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b7a7c7ba8eed4689b8ffc0ef3df74883~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b7a7c7ba8eed4689b8ffc0ef3df74883~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b7a7c7ba8eed4689b8ffc0ef3df74883.avif"
     },
     {
         "franchise": "MIL",
@@ -6045,7 +6045,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5ea3a03a16624c90a6783dae514c1707~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5ea3a03a16624c90a6783dae514c1707~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5ea3a03a16624c90a6783dae514c1707.avif"
     },
     {
         "franchise": "MIL",
@@ -6060,7 +6060,7 @@
             "1975-76",
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4e77184a76ff4310b603709e9349c949~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4e77184a76ff4310b603709e9349c949~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4e77184a76ff4310b603709e9349c949.avif"
     },
     {
         "franchise": "MIL",
@@ -6076,7 +6076,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8def97886c53453d80a29684eb9e75c9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8def97886c53453d80a29684eb9e75c9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8def97886c53453d80a29684eb9e75c9.avif"
     },
     {
         "franchise": "MIL",
@@ -6090,7 +6090,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bab8287abd60409da8a2a0ef67a4ccce~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bab8287abd60409da8a2a0ef67a4ccce~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bab8287abd60409da8a2a0ef67a4ccce.avif"
     },
     {
         "franchise": "MIL",
@@ -6107,7 +6107,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_43edd18749744a6daeeac85f10a7caf5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_43edd18749744a6daeeac85f10a7caf5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_43edd18749744a6daeeac85f10a7caf5.avif"
     },
     {
         "franchise": "MIL",
@@ -6121,7 +6121,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_17071f57c87141ad85c87440c005153a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_17071f57c87141ad85c87440c005153a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_17071f57c87141ad85c87440c005153a.avif"
     },
     {
         "franchise": "MIL",
@@ -6141,7 +6141,7 @@
             "1991-92",
             "1992-93"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9da66b9cf71d4f6886f489aedfbbbe09~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9da66b9cf71d4f6886f489aedfbbbe09~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9da66b9cf71d4f6886f489aedfbbbe09.avif"
     },
     {
         "franchise": "MIL",
@@ -6155,7 +6155,7 @@
         "seasons": [
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_407c28fd79444dfa824dfaa7d4544a12~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_407c28fd79444dfa824dfaa7d4544a12~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_407c28fd79444dfa824dfaa7d4544a12.avif"
     },
     {
         "franchise": "MIL",
@@ -6172,7 +6172,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7804a11375c74bc6b6fe4b951d115df9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7804a11375c74bc6b6fe4b951d115df9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7804a11375c74bc6b6fe4b951d115df9.avif"
     },
     {
         "franchise": "MIL",
@@ -6186,7 +6186,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a80b2cb6fbda40468e40cf1352fcbbef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a80b2cb6fbda40468e40cf1352fcbbef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a80b2cb6fbda40468e40cf1352fcbbef.avif"
     },
     {
         "franchise": "MIL",
@@ -6200,7 +6200,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3632fbfa024648bf90f25125efe6ed72~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3632fbfa024648bf90f25125efe6ed72~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3632fbfa024648bf90f25125efe6ed72.avif"
     },
     {
         "franchise": "MIL",
@@ -6214,7 +6214,7 @@
         "seasons": [
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9b51d99da3be4c48a5229f5e896c360e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9b51d99da3be4c48a5229f5e896c360e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9b51d99da3be4c48a5229f5e896c360e.avif"
     },
     {
         "franchise": "MIL",
@@ -6228,7 +6228,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1ed27ed82a38440ab912ad2c5bc7c557~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1ed27ed82a38440ab912ad2c5bc7c557~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1ed27ed82a38440ab912ad2c5bc7c557.avif"
     },
     {
         "franchise": "MIL",
@@ -6244,7 +6244,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_02b148227ac94332b89b787d9d466be2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_02b148227ac94332b89b787d9d466be2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_02b148227ac94332b89b787d9d466be2.avif"
     },
     {
         "franchise": "MIL",
@@ -6258,7 +6258,7 @@
         "seasons": [
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cc2dcf87e64b4bf58e777a1cd7180c5d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cc2dcf87e64b4bf58e777a1cd7180c5d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cc2dcf87e64b4bf58e777a1cd7180c5d.avif"
     },
     {
         "franchise": "MIL",
@@ -6275,7 +6275,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_80eb0278b8a14228bec97938e98698df~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_80eb0278b8a14228bec97938e98698df~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_80eb0278b8a14228bec97938e98698df.avif"
     },
     {
         "franchise": "MIL",
@@ -6292,7 +6292,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f95b27fe80534c34a1c8d1e97f39d9c7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f95b27fe80534c34a1c8d1e97f39d9c7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f95b27fe80534c34a1c8d1e97f39d9c7.avif"
     },
     {
         "franchise": "MIL",
@@ -6306,7 +6306,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_064f2b7df89e42edb50a39a36aff98a4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_064f2b7df89e42edb50a39a36aff98a4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_064f2b7df89e42edb50a39a36aff98a4.avif"
     },
     {
         "franchise": "MIL",
@@ -6321,7 +6321,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2c462dc4c994477f8ba5e48cd834504d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2c462dc4c994477f8ba5e48cd834504d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2c462dc4c994477f8ba5e48cd834504d.avif"
     },
     {
         "franchise": "MIL",
@@ -6339,7 +6339,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2e2463de7c6944bf85cbcc023bfb7923~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2e2463de7c6944bf85cbcc023bfb7923~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2e2463de7c6944bf85cbcc023bfb7923.avif"
     },
     {
         "franchise": "MIL",
@@ -6353,7 +6353,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fa305632b11148939a0e7e2e965468e4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fa305632b11148939a0e7e2e965468e4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fa305632b11148939a0e7e2e965468e4.avif"
     },
     {
         "franchise": "MIL",
@@ -6367,7 +6367,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_54eec43651cf4999acea1b172a0fe04e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_54eec43651cf4999acea1b172a0fe04e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_54eec43651cf4999acea1b172a0fe04e.avif"
     },
     {
         "franchise": "MIL",
@@ -6383,7 +6383,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e3ca3ceefae5476395c5985010a01797~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e3ca3ceefae5476395c5985010a01797~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e3ca3ceefae5476395c5985010a01797.avif"
     },
     {
         "franchise": "MIL",
@@ -6397,7 +6397,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_684751d151a643f9a365de295cdc9c08~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_684751d151a643f9a365de295cdc9c08~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_684751d151a643f9a365de295cdc9c08.avif"
     },
     {
         "franchise": "MIL",
@@ -6416,7 +6416,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aedff8c532584dc8af96c9e6c0da9cad~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aedff8c532584dc8af96c9e6c0da9cad~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aedff8c532584dc8af96c9e6c0da9cad.avif"
     },
     {
         "franchise": "MIL",
@@ -6430,7 +6430,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_425a7b62d3844cfa97ba1604e3c1f5dc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_425a7b62d3844cfa97ba1604e3c1f5dc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_425a7b62d3844cfa97ba1604e3c1f5dc.avif"
     },
     {
         "franchise": "MIL",
@@ -6445,7 +6445,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0d844e14e9044a06888218954781607b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0d844e14e9044a06888218954781607b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0d844e14e9044a06888218954781607b.avif"
     },
     {
         "franchise": "MIL",
@@ -6460,7 +6460,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8f08e154a458472fb84f7a2a09a65c31~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8f08e154a458472fb84f7a2a09a65c31~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8f08e154a458472fb84f7a2a09a65c31.avif"
     },
     {
         "franchise": "MIL",
@@ -6474,7 +6474,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a3853eb9b69542beb1ce92a5e6c151bc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a3853eb9b69542beb1ce92a5e6c151bc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a3853eb9b69542beb1ce92a5e6c151bc.avif"
     },
     {
         "franchise": "MIL",
@@ -6488,7 +6488,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_272caf72cebb45358d12f5ecc6df6f79~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_272caf72cebb45358d12f5ecc6df6f79~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_272caf72cebb45358d12f5ecc6df6f79.avif"
     },
     {
         "franchise": "MIL",
@@ -6502,7 +6502,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8e41979abcca4b2fba285fdde7960391~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8e41979abcca4b2fba285fdde7960391~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8e41979abcca4b2fba285fdde7960391.avif"
     },
     {
         "franchise": "MIL",
@@ -6516,7 +6516,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2377dad42a9d4a95af58579a550c0002~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2377dad42a9d4a95af58579a550c0002~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2377dad42a9d4a95af58579a550c0002.avif"
     },
     {
         "franchise": "MIL",
@@ -6530,7 +6530,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ec19329a3aa443248f3677a684b40a52~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ec19329a3aa443248f3677a684b40a52~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ec19329a3aa443248f3677a684b40a52.avif"
     },
     {
         "franchise": "OKC",
@@ -6544,7 +6544,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a13fbb573afc484eac43a49dca435a38~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a13fbb573afc484eac43a49dca435a38~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a13fbb573afc484eac43a49dca435a38.avif"
     },
     {
         "franchise": "OKC",
@@ -6558,7 +6558,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f58ba13ab119409a9e3af2280fa6ec94~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f58ba13ab119409a9e3af2280fa6ec94~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f58ba13ab119409a9e3af2280fa6ec94.avif"
     },
     {
         "franchise": "OKC",
@@ -6572,7 +6572,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f2ae09861ff047be9a9ad042afc7db6b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f2ae09861ff047be9a9ad042afc7db6b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f2ae09861ff047be9a9ad042afc7db6b.avif"
     },
     {
         "franchise": "OKC",
@@ -6586,7 +6586,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9b531805b0f5489db9500db37ec6d38a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9b531805b0f5489db9500db37ec6d38a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9b531805b0f5489db9500db37ec6d38a.avif"
     },
     {
         "franchise": "OKC",
@@ -6601,7 +6601,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_227f5d193a6f4cd292ac5f144548871a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_227f5d193a6f4cd292ac5f144548871a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_227f5d193a6f4cd292ac5f144548871a.avif"
     },
     {
         "franchise": "OKC",
@@ -6615,7 +6615,7 @@
         "seasons": [
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3ce0ea7a5cb9440aa84f33f9d5489968~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3ce0ea7a5cb9440aa84f33f9d5489968~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3ce0ea7a5cb9440aa84f33f9d5489968.avif"
     },
     {
         "franchise": "OKC",
@@ -6631,7 +6631,7 @@
             "1975-76",
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c5df9d99917a4ed18a7082c5860940e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c5df9d99917a4ed18a7082c5860940e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c5df9d99917a4ed18a7082c5860940e0.avif"
     },
     {
         "franchise": "OKC",
@@ -6645,7 +6645,7 @@
         "seasons": [
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_57473c62b7d746a8bdde4e23aabf7070~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_57473c62b7d746a8bdde4e23aabf7070~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_57473c62b7d746a8bdde4e23aabf7070.avif"
     },
     {
         "franchise": "OKC",
@@ -6664,7 +6664,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4ca83c6c8c374e679e38eb5bcfd57ec0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4ca83c6c8c374e679e38eb5bcfd57ec0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4ca83c6c8c374e679e38eb5bcfd57ec0.avif"
     },
     {
         "franchise": "OKC",
@@ -6678,7 +6678,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3f9b496a1f0e429cb85f1a70fa6c6031~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3f9b496a1f0e429cb85f1a70fa6c6031~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3f9b496a1f0e429cb85f1a70fa6c6031.avif"
     },
     {
         "franchise": "OKC",
@@ -6692,7 +6692,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c6c0975151144078bac3df4ec19ddd75~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c6c0975151144078bac3df4ec19ddd75~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c6c0975151144078bac3df4ec19ddd75.avif"
     },
     {
         "franchise": "OKC",
@@ -6712,7 +6712,7 @@
             "1991-92",
             "1992-93"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4d880117e3de4a3dac112ddcd8e20de0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4d880117e3de4a3dac112ddcd8e20de0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4d880117e3de4a3dac112ddcd8e20de0.avif"
     },
     {
         "franchise": "OKC",
@@ -6726,7 +6726,7 @@
         "seasons": [
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_896686bdfb3248419898159320f6fae8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_896686bdfb3248419898159320f6fae8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_896686bdfb3248419898159320f6fae8.avif"
     },
     {
         "franchise": "OKC",
@@ -6740,7 +6740,7 @@
         "seasons": [
             "1994-95"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_725d5dc21aed46e6a21c68a40157108e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_725d5dc21aed46e6a21c68a40157108e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_725d5dc21aed46e6a21c68a40157108e.avif"
     },
     {
         "franchise": "OKC",
@@ -6756,7 +6756,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ecc6d2e24a834beb9b90e869c49b7ddd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ecc6d2e24a834beb9b90e869c49b7ddd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ecc6d2e24a834beb9b90e869c49b7ddd.avif"
     },
     {
         "franchise": "OKC",
@@ -6770,7 +6770,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a4ea7243f478412d8cd47d3dab95b4e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a4ea7243f478412d8cd47d3dab95b4e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a4ea7243f478412d8cd47d3dab95b4e0.avif"
     },
     {
         "franchise": "OKC",
@@ -6784,7 +6784,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_609b913900134306a78de362bf59eb34~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_609b913900134306a78de362bf59eb34~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_609b913900134306a78de362bf59eb34.avif"
     },
     {
         "franchise": "OKC",
@@ -6798,7 +6798,7 @@
         "seasons": [
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fa189d2a10e541b9ac41959e547f505a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fa189d2a10e541b9ac41959e547f505a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fa189d2a10e541b9ac41959e547f505a.avif"
     },
     {
         "franchise": "OKC",
@@ -6812,7 +6812,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e3df3d6a869a4f448cd6588015af9dbc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e3df3d6a869a4f448cd6588015af9dbc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e3df3d6a869a4f448cd6588015af9dbc.avif"
     },
     {
         "franchise": "OKC",
@@ -6830,7 +6830,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_04d1d6bc9a5646d587bee9f9380ab021~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_04d1d6bc9a5646d587bee9f9380ab021~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_04d1d6bc9a5646d587bee9f9380ab021.avif"
     },
     {
         "franchise": "OKC",
@@ -6845,7 +6845,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9ff7d3aa88a547cb8931cb533981bc98~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9ff7d3aa88a547cb8931cb533981bc98~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9ff7d3aa88a547cb8931cb533981bc98.avif"
     },
     {
         "franchise": "OKC",
@@ -6860,7 +6860,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9ec1d0234ef3437a884760fd4b297e3c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9ec1d0234ef3437a884760fd4b297e3c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9ec1d0234ef3437a884760fd4b297e3c.avif"
     },
     {
         "franchise": "OKC",
@@ -6875,7 +6875,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d98559c12e2846eeab90168d141e6030~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d98559c12e2846eeab90168d141e6030~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d98559c12e2846eeab90168d141e6030.avif"
     },
     {
         "franchise": "OKC",
@@ -6890,7 +6890,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b522dedbe31542a69492b1f371e2a2f5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b522dedbe31542a69492b1f371e2a2f5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b522dedbe31542a69492b1f371e2a2f5.avif"
     },
     {
         "franchise": "PHI",
@@ -6908,7 +6908,7 @@
             "1951-52",
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_72137ea0e1d245e6bf2f2691353be42c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_72137ea0e1d245e6bf2f2691353be42c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_72137ea0e1d245e6bf2f2691353be42c.avif"
     },
     {
         "franchise": "PHI",
@@ -6924,7 +6924,7 @@
             "1954-55",
             "1955-56"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ee4c283192764d1eab6967f1f51479f3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ee4c283192764d1eab6967f1f51479f3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ee4c283192764d1eab6967f1f51479f3.avif"
     },
     {
         "franchise": "PHI",
@@ -6940,7 +6940,7 @@
             "1954-55",
             "1955-56"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cc36e895cf804d289966ebd3555f8147~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cc36e895cf804d289966ebd3555f8147~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cc36e895cf804d289966ebd3555f8147.avif"
     },
     {
         "franchise": "PHI",
@@ -6958,7 +6958,7 @@
             "1959-60",
             "1960-61"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8a9fc83e5d5d4f3a8f46eb0fafd79510~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8a9fc83e5d5d4f3a8f46eb0fafd79510~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8a9fc83e5d5d4f3a8f46eb0fafd79510.avif"
     },
     {
         "franchise": "PHI",
@@ -6973,7 +6973,7 @@
             "1961-62",
             "1962-63"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ff53a55d5e6a40ffa5ba3ed13f05da7f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ff53a55d5e6a40ffa5ba3ed13f05da7f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ff53a55d5e6a40ffa5ba3ed13f05da7f.avif"
     },
     {
         "franchise": "PHI",
@@ -6988,7 +6988,7 @@
             "1963-64",
             "1964-65"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f456920331364ab6b639e264843d7992~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f456920331364ab6b639e264843d7992~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f456920331364ab6b639e264843d7992.avif"
     },
     {
         "franchise": "PHI",
@@ -7002,7 +7002,7 @@
         "seasons": [
             "1965-66"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1827fc808b5c498cbefddd18c909b58c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1827fc808b5c498cbefddd18c909b58c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1827fc808b5c498cbefddd18c909b58c.avif"
     },
     {
         "franchise": "PHI",
@@ -7017,7 +7017,7 @@
             "1966-67",
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6c77e16d19704894ac4caa2befdbbd0b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6c77e16d19704894ac4caa2befdbbd0b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6c77e16d19704894ac4caa2befdbbd0b.avif"
     },
     {
         "franchise": "PHI",
@@ -7032,7 +7032,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4d66fd52fb794726b8179fa8648b9961~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4d66fd52fb794726b8179fa8648b9961~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4d66fd52fb794726b8179fa8648b9961.avif"
     },
     {
         "franchise": "PHI",
@@ -7046,7 +7046,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_359df6a206ee4e37bbc8347c0b892ced~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_359df6a206ee4e37bbc8347c0b892ced~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_359df6a206ee4e37bbc8347c0b892ced.avif"
     },
     {
         "franchise": "PHI",
@@ -7060,7 +7060,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6632974d4d254fe584b3e315648499f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6632974d4d254fe584b3e315648499f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6632974d4d254fe584b3e315648499f8.avif"
     },
     {
         "franchise": "PHI",
@@ -7077,7 +7077,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_82bc4a60ad7f498bbbaa883207f4ff02~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_82bc4a60ad7f498bbbaa883207f4ff02~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_82bc4a60ad7f498bbbaa883207f4ff02.avif"
     },
     {
         "franchise": "PHI",
@@ -7091,7 +7091,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_622fabb6ad1f4facba424ce8d5fb1f42~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_622fabb6ad1f4facba424ce8d5fb1f42~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_622fabb6ad1f4facba424ce8d5fb1f42.avif"
     },
     {
         "franchise": "PHI",
@@ -7105,7 +7105,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7f3d0fedade24f69a2c6c13ed4115ced~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7f3d0fedade24f69a2c6c13ed4115ced~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7f3d0fedade24f69a2c6c13ed4115ced.avif"
     },
     {
         "franchise": "PHI",
@@ -7119,7 +7119,7 @@
         "seasons": [
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3d40340da2994f1487289d2cf9f286e5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3d40340da2994f1487289d2cf9f286e5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3d40340da2994f1487289d2cf9f286e5.avif"
     },
     {
         "franchise": "PHI",
@@ -7139,7 +7139,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f482a8561bcd4560bc0e56c2770731a4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f482a8561bcd4560bc0e56c2770731a4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f482a8561bcd4560bc0e56c2770731a4.avif"
     },
     {
         "franchise": "PHI",
@@ -7153,7 +7153,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2749af5a54f04d8c910722b8b1c317af~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2749af5a54f04d8c910722b8b1c317af~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2749af5a54f04d8c910722b8b1c317af.avif"
     },
     {
         "franchise": "PHI",
@@ -7171,7 +7171,7 @@
             "1989-90",
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_75872c8b15744dd195a980f31a58f10e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_75872c8b15744dd195a980f31a58f10e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_75872c8b15744dd195a980f31a58f10e.avif"
     },
     {
         "franchise": "PHI",
@@ -7187,7 +7187,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b5d1a5dcdc134e72a3e46bac03220fd1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b5d1a5dcdc134e72a3e46bac03220fd1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b5d1a5dcdc134e72a3e46bac03220fd1.avif"
     },
     {
         "franchise": "PHI",
@@ -7202,7 +7202,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4e85812c82f54d099efd9d38aa3a8f28~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4e85812c82f54d099efd9d38aa3a8f28~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4e85812c82f54d099efd9d38aa3a8f28.avif"
     },
     {
         "franchise": "PHI",
@@ -7216,7 +7216,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c5645e5cdce446a3b4882a9dd472a3ab~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c5645e5cdce446a3b4882a9dd472a3ab~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c5645e5cdce446a3b4882a9dd472a3ab.avif"
     },
     {
         "franchise": "PHI",
@@ -7231,7 +7231,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_70e905eeccc6412fbf477004a6c25ce2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_70e905eeccc6412fbf477004a6c25ce2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_70e905eeccc6412fbf477004a6c25ce2.avif"
     },
     {
         "franchise": "PHI",
@@ -7245,7 +7245,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6be2a42f1f8d4c2e96c3f07e2c5f5938~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6be2a42f1f8d4c2e96c3f07e2c5f5938~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6be2a42f1f8d4c2e96c3f07e2c5f5938.avif"
     },
     {
         "franchise": "PHI",
@@ -7264,7 +7264,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4978af52adc4f01a68a826a5dc3bfd9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4978af52adc4f01a68a826a5dc3bfd9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4978af52adc4f01a68a826a5dc3bfd9.avif"
     },
     {
         "franchise": "PHI",
@@ -7278,7 +7278,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b65882c9ddc24a31bc6f25dd75e7cdf5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b65882c9ddc24a31bc6f25dd75e7cdf5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b65882c9ddc24a31bc6f25dd75e7cdf5.avif"
     },
     {
         "franchise": "PHI",
@@ -7293,7 +7293,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f6ff33314fef41efaf2d6e2aec3d222c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f6ff33314fef41efaf2d6e2aec3d222c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f6ff33314fef41efaf2d6e2aec3d222c.avif"
     },
     {
         "franchise": "PHI",
@@ -7307,7 +7307,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0471c5996ba413bb7740f84246974cf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0471c5996ba413bb7740f84246974cf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0471c5996ba413bb7740f84246974cf.avif"
     },
     {
         "franchise": "PHI",
@@ -7324,7 +7324,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a459e57b3bc94324808881385bd024ee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a459e57b3bc94324808881385bd024ee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a459e57b3bc94324808881385bd024ee.avif"
     },
     {
         "franchise": "PHI",
@@ -7338,7 +7338,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f985c86b552849ce9520e08bec4852a3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f985c86b552849ce9520e08bec4852a3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f985c86b552849ce9520e08bec4852a3.avif"
     },
     {
         "franchise": "PHI",
@@ -7353,7 +7353,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_95c5a3c3d0f242658d701f59aa5c3122~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_95c5a3c3d0f242658d701f59aa5c3122~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_95c5a3c3d0f242658d701f59aa5c3122.avif"
     },
     {
         "franchise": "PHI",
@@ -7368,7 +7368,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0accb235acbb4825bc49dd7668ceb3a5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0accb235acbb4825bc49dd7668ceb3a5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0accb235acbb4825bc49dd7668ceb3a5.avif"
     },
     {
         "franchise": "PHI",
@@ -7383,7 +7383,7 @@
             "2019-20",
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d46f8575190448e9bb90efaba29c2980~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d46f8575190448e9bb90efaba29c2980~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d46f8575190448e9bb90efaba29c2980.avif"
     },
     {
         "franchise": "PHI",
@@ -7397,7 +7397,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e9714b9e107b4117bfbe6fb5e3e0676c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e9714b9e107b4117bfbe6fb5e3e0676c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e9714b9e107b4117bfbe6fb5e3e0676c.avif"
     },
     {
         "franchise": "PHI",
@@ -7411,7 +7411,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ef1c7631c9bd41689fc5e8127b1e78b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ef1c7631c9bd41689fc5e8127b1e78b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ef1c7631c9bd41689fc5e8127b1e78b1.avif"
     },
     {
         "franchise": "PHI",
@@ -7425,7 +7425,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ed6dc71a87ab4c849aebe97020a378d6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ed6dc71a87ab4c849aebe97020a378d6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ed6dc71a87ab4c849aebe97020a378d6.avif"
     },
     {
         "franchise": "PHI",
@@ -7439,7 +7439,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5d8da913528f4b389903f0e24aafb3c2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5d8da913528f4b389903f0e24aafb3c2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5d8da913528f4b389903f0e24aafb3c2.avif"
     },
     {
         "franchise": "PHI",
@@ -7457,7 +7457,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_72062184ce134336b40a2c25afed648d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_72062184ce134336b40a2c25afed648d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_72062184ce134336b40a2c25afed648d.avif"
     },
     {
         "franchise": "PHI",
@@ -7471,7 +7471,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7a323db478cb496b96291c86f5307c8c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7a323db478cb496b96291c86f5307c8c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7a323db478cb496b96291c86f5307c8c.avif"
     },
     {
         "franchise": "PHI",
@@ -7487,7 +7487,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e829e38acad41e2b92fce9bad58cd2f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e829e38acad41e2b92fce9bad58cd2f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e829e38acad41e2b92fce9bad58cd2f.avif"
     },
     {
         "franchise": "PHI",
@@ -7502,7 +7502,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b70b5071e8744ad3b999a484293e62ed~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b70b5071e8744ad3b999a484293e62ed~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b70b5071e8744ad3b999a484293e62ed.avif"
     },
     {
         "franchise": "PHI",
@@ -7517,7 +7517,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_66fb6ce01b46447d9789c78f3818bfa3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_66fb6ce01b46447d9789c78f3818bfa3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_66fb6ce01b46447d9789c78f3818bfa3.avif"
     },
     {
         "franchise": "PHI",
@@ -7532,7 +7532,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0ccd1dc605e4d608cc39b94ad24f9ac~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0ccd1dc605e4d608cc39b94ad24f9ac~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0ccd1dc605e4d608cc39b94ad24f9ac.avif"
     },
     {
         "franchise": "PHI",
@@ -7546,7 +7546,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dff862789f57423fbc70b99c6f64dd22~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dff862789f57423fbc70b99c6f64dd22~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dff862789f57423fbc70b99c6f64dd22.avif"
     },
     {
         "franchise": "PHI",
@@ -7560,7 +7560,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_015f2850d0f74a93b54c48c521ef402b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_015f2850d0f74a93b54c48c521ef402b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_015f2850d0f74a93b54c48c521ef402b.avif"
     },
     {
         "franchise": "PHI",
@@ -7574,7 +7574,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c743dbfd8474092b2711075afa44d3e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c743dbfd8474092b2711075afa44d3e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c743dbfd8474092b2711075afa44d3e.avif"
     },
     {
         "franchise": "PHI",
@@ -7588,7 +7588,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cb6804fc260b4f4d9211fb4fa37ad6f1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cb6804fc260b4f4d9211fb4fa37ad6f1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cb6804fc260b4f4d9211fb4fa37ad6f1.avif"
     },
     {
         "franchise": "PHI",
@@ -7602,7 +7602,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d86adb18e13743f8a317f9099d0832c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d86adb18e13743f8a317f9099d0832c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d86adb18e13743f8a317f9099d0832c4.avif"
     },
     {
         "franchise": "NOH",
@@ -7616,7 +7616,7 @@
         "seasons": [
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0aa66ccc1945452f941986a3bc6e48e3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0aa66ccc1945452f941986a3bc6e48e3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0aa66ccc1945452f941986a3bc6e48e3.avif"
     },
     {
         "franchise": "NOH",
@@ -7631,7 +7631,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_af9f9978fa8e49d1971afce985df190a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_af9f9978fa8e49d1971afce985df190a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_af9f9978fa8e49d1971afce985df190a.avif"
     },
     {
         "franchise": "NOH",
@@ -7646,7 +7646,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8f20c273d6f842798770785632659808~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8f20c273d6f842798770785632659808~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8f20c273d6f842798770785632659808.avif"
     },
     {
         "franchise": "NOH",
@@ -7660,7 +7660,7 @@
         "seasons": [
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_261a348f7c3047b7896a103b8a10a5fc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_261a348f7c3047b7896a103b8a10a5fc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_261a348f7c3047b7896a103b8a10a5fc.avif"
     },
     {
         "franchise": "NOH",
@@ -7675,7 +7675,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0ae8da35a4344371bb3cbd62157c0671~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0ae8da35a4344371bb3cbd62157c0671~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0ae8da35a4344371bb3cbd62157c0671.avif"
     },
     {
         "franchise": "NOH",
@@ -7689,7 +7689,7 @@
         "seasons": [
             "2010-11"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_559ef46f34f24a1e84f823cb7a24cffe~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_559ef46f34f24a1e84f823cb7a24cffe~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_559ef46f34f24a1e84f823cb7a24cffe.avif"
     },
     {
         "franchise": "NOH",
@@ -7705,7 +7705,7 @@
             "2011-12",
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c980b0dbbe2415293ebee666d824556~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c980b0dbbe2415293ebee666d824556~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c980b0dbbe2415293ebee666d824556.avif"
     },
     {
         "franchise": "NOH",
@@ -7719,7 +7719,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8577cc85ee1b442d878cda95dffe18d0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8577cc85ee1b442d878cda95dffe18d0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8577cc85ee1b442d878cda95dffe18d0.avif"
     },
     {
         "franchise": "NOH",
@@ -7735,7 +7735,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7647f3fe9f6f42f6966c1a717d65de7b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7647f3fe9f6f42f6966c1a717d65de7b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7647f3fe9f6f42f6966c1a717d65de7b.avif"
     },
     {
         "franchise": "NOH",
@@ -7753,7 +7753,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_722a72fa139242aa924203b5d857bccb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_722a72fa139242aa924203b5d857bccb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_722a72fa139242aa924203b5d857bccb.avif"
     },
     {
         "franchise": "NOH",
@@ -7767,7 +7767,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3b858979b9974b4ca8fc05a7ecd1d36e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3b858979b9974b4ca8fc05a7ecd1d36e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3b858979b9974b4ca8fc05a7ecd1d36e.avif"
     },
     {
         "franchise": "NOH",
@@ -7781,7 +7781,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b20210f4dad84e2b8894f462eca9fba0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b20210f4dad84e2b8894f462eca9fba0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b20210f4dad84e2b8894f462eca9fba0.avif"
     },
     {
         "franchise": "NOH",
@@ -7795,7 +7795,7 @@
         "seasons": [
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_322107a6263443fd8a2b74f67e0fa690~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_322107a6263443fd8a2b74f67e0fa690~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_322107a6263443fd8a2b74f67e0fa690.avif"
     },
     {
         "franchise": "NOH",
@@ -7810,7 +7810,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5825d636e7c84df08a24b98c9826abc1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5825d636e7c84df08a24b98c9826abc1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5825d636e7c84df08a24b98c9826abc1.avif"
     },
     {
         "franchise": "NOH",
@@ -7824,7 +7824,7 @@
         "seasons": [
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5538d417fc5a4deda56eb48e650df72b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5538d417fc5a4deda56eb48e650df72b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5538d417fc5a4deda56eb48e650df72b.avif"
     },
     {
         "franchise": "NOH",
@@ -7840,7 +7840,7 @@
             "2011-12",
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_93c48ccf47c442178de56579295f7204~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_93c48ccf47c442178de56579295f7204~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_93c48ccf47c442178de56579295f7204.avif"
     },
     {
         "franchise": "NOH",
@@ -7856,7 +7856,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_10c83a6036b14f01a8c138030fb44e0d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_10c83a6036b14f01a8c138030fb44e0d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_10c83a6036b14f01a8c138030fb44e0d.avif"
     },
     {
         "franchise": "NOH",
@@ -7872,7 +7872,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_744db9e039004a0f840991f8ed066892~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_744db9e039004a0f840991f8ed066892~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_744db9e039004a0f840991f8ed066892.avif"
     },
     {
         "franchise": "NOH",
@@ -7886,7 +7886,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0b4d79ceeaf24e43830dda8559d08290~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0b4d79ceeaf24e43830dda8559d08290~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0b4d79ceeaf24e43830dda8559d08290.avif"
     },
     {
         "franchise": "NOH",
@@ -7900,7 +7900,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ad9713c40b124a1591532046ad19144f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ad9713c40b124a1591532046ad19144f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ad9713c40b124a1591532046ad19144f.avif"
     },
     {
         "franchise": "NOH",
@@ -7914,7 +7914,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f1d8cccd0d674126868b66ad6bb6b785~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f1d8cccd0d674126868b66ad6bb6b785~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f1d8cccd0d674126868b66ad6bb6b785.avif"
     },
     {
         "franchise": "NOH",
@@ -7928,7 +7928,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b8d42df011964e25b8b93aa86ac0d646~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b8d42df011964e25b8b93aa86ac0d646~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b8d42df011964e25b8b93aa86ac0d646.avif"
     },
     {
         "franchise": "LAL",
@@ -7944,7 +7944,7 @@
             "1949-50",
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_193f0ed2ddfd4590b6d310f5fb4dfd7f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_193f0ed2ddfd4590b6d310f5fb4dfd7f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_193f0ed2ddfd4590b6d310f5fb4dfd7f.avif"
     },
     {
         "franchise": "LAL",
@@ -7964,7 +7964,7 @@
             "1956-57",
             "1957-58"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_15d6f364d4fe4587930cfccac646e5a1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_15d6f364d4fe4587930cfccac646e5a1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_15d6f364d4fe4587930cfccac646e5a1.avif"
     },
     {
         "franchise": "LAL",
@@ -7979,7 +7979,7 @@
             "1958-59",
             "1959-60"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_46bfb75c8b9b4f8899b889222e612ebc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_46bfb75c8b9b4f8899b889222e612ebc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_46bfb75c8b9b4f8899b889222e612ebc.avif"
     },
     {
         "franchise": "LAL",
@@ -7993,7 +7993,7 @@
         "seasons": [
             "1960-61"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_eb4a032f807b417297d3b90a22753cf0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_eb4a032f807b417297d3b90a22753cf0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_eb4a032f807b417297d3b90a22753cf0.avif"
     },
     {
         "franchise": "LAL",
@@ -8012,7 +8012,7 @@
             "1965-66",
             "1966-67"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4567e805c9ae445bb190b43c0bf441f9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4567e805c9ae445bb190b43c0bf441f9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4567e805c9ae445bb190b43c0bf441f9.avif"
     },
     {
         "franchise": "LAL",
@@ -8029,7 +8029,7 @@
             "1969-70",
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_22ca0b3a4d0549cbb383db237e82460e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_22ca0b3a4d0549cbb383db237e82460e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_22ca0b3a4d0549cbb383db237e82460e.avif"
     },
     {
         "franchise": "LAL",
@@ -8043,7 +8043,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e13eecf313c4593ab7d75da9acb7ba9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e13eecf313c4593ab7d75da9acb7ba9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e13eecf313c4593ab7d75da9acb7ba9.avif"
     },
     {
         "franchise": "LAL",
@@ -8057,7 +8057,7 @@
         "seasons": [
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ac9bc3a4f4e5424cb791058ff76c9b30~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ac9bc3a4f4e5424cb791058ff76c9b30~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ac9bc3a4f4e5424cb791058ff76c9b30.avif"
     },
     {
         "franchise": "LAL",
@@ -8071,7 +8071,7 @@
         "seasons": [
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2b6e30c9f5b54f3b91646f9e7efaa437~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2b6e30c9f5b54f3b91646f9e7efaa437~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2b6e30c9f5b54f3b91646f9e7efaa437.avif"
     },
     {
         "franchise": "LAL",
@@ -8089,7 +8089,7 @@
             "1976-77",
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e0ab9c70f704032921764bc203e71d2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e0ab9c70f704032921764bc203e71d2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e0ab9c70f704032921764bc203e71d2.avif"
     },
     {
         "franchise": "LAL",
@@ -8109,7 +8109,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aa2bad471d5f4d969cb6ac9be90f89a7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aa2bad471d5f4d969cb6ac9be90f89a7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aa2bad471d5f4d969cb6ac9be90f89a7.avif"
     },
     {
         "franchise": "LAL",
@@ -8123,7 +8123,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_551bcec85695442982e1b5166118a0bb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_551bcec85695442982e1b5166118a0bb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_551bcec85695442982e1b5166118a0bb.avif"
     },
     {
         "franchise": "LAL",
@@ -8137,7 +8137,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9959d2523d9e4ccc9276a24010969efa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9959d2523d9e4ccc9276a24010969efa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9959d2523d9e4ccc9276a24010969efa.avif"
     },
     {
         "franchise": "LAL",
@@ -8157,7 +8157,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_abf0d33640904ab980fcfb7381fd2a38~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_abf0d33640904ab980fcfb7381fd2a38~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_abf0d33640904ab980fcfb7381fd2a38.avif"
     },
     {
         "franchise": "LAL",
@@ -8174,7 +8174,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fab963e2565042f288fe2b161d044c76~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fab963e2565042f288fe2b161d044c76~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fab963e2565042f288fe2b161d044c76.avif"
     },
     {
         "franchise": "LAL",
@@ -8188,7 +8188,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9232a94a23cb4b58b2fcc7179159fad3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9232a94a23cb4b58b2fcc7179159fad3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9232a94a23cb4b58b2fcc7179159fad3.avif"
     },
     {
         "franchise": "LAL",
@@ -8205,7 +8205,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_abb4cb4c086a4e739059ade0ec7f8817~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_abb4cb4c086a4e739059ade0ec7f8817~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_abb4cb4c086a4e739059ade0ec7f8817.avif"
     },
     {
         "franchise": "LAL",
@@ -8219,7 +8219,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9bec20824dcc4e748b95551290ea473c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9bec20824dcc4e748b95551290ea473c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9bec20824dcc4e748b95551290ea473c.avif"
     },
     {
         "franchise": "LAL",
@@ -8233,7 +8233,7 @@
         "seasons": [
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3b6995d98aa64c91ba333164f710d343~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3b6995d98aa64c91ba333164f710d343~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3b6995d98aa64c91ba333164f710d343.avif"
     },
     {
         "franchise": "LAL",
@@ -8255,7 +8255,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_485f845c00884c949bbf868dd2ee34b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_485f845c00884c949bbf868dd2ee34b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_485f845c00884c949bbf868dd2ee34b1.avif"
     },
     {
         "franchise": "LAL",
@@ -8271,7 +8271,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a95a129fb7f94a04a4e10e41f8749bc6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a95a129fb7f94a04a4e10e41f8749bc6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a95a129fb7f94a04a4e10e41f8749bc6.avif"
     },
     {
         "franchise": "LAL",
@@ -8285,7 +8285,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_06de8e93709c493498200d6e96db1395~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_06de8e93709c493498200d6e96db1395~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_06de8e93709c493498200d6e96db1395.avif"
     },
     {
         "franchise": "LAL",
@@ -8302,7 +8302,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_42b960577b8a4a4192c64611daf70d14~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_42b960577b8a4a4192c64611daf70d14~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_42b960577b8a4a4192c64611daf70d14.avif"
     },
     {
         "franchise": "LAL",
@@ -8316,7 +8316,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6b7c64b76e184b9d9974b219ece0d211~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6b7c64b76e184b9d9974b219ece0d211~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6b7c64b76e184b9d9974b219ece0d211.avif"
     },
     {
         "franchise": "LAL",
@@ -8330,7 +8330,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f9760f3945b241238767c7c1b5b8e3e4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f9760f3945b241238767c7c1b5b8e3e4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f9760f3945b241238767c7c1b5b8e3e4.avif"
     },
     {
         "franchise": "LAL",
@@ -8346,7 +8346,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_00ad57ac3af34149ab052ea85157a0a7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_00ad57ac3af34149ab052ea85157a0a7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_00ad57ac3af34149ab052ea85157a0a7.avif"
     },
     {
         "franchise": "LAL",
@@ -8368,7 +8368,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_452137d592c943c89c44e01dbba32d7b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_452137d592c943c89c44e01dbba32d7b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_452137d592c943c89c44e01dbba32d7b.avif"
     },
     {
         "franchise": "LAL",
@@ -8382,7 +8382,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3e30db33d03a464da7b36666f763a3c7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3e30db33d03a464da7b36666f763a3c7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3e30db33d03a464da7b36666f763a3c7.avif"
     },
     {
         "franchise": "LAL",
@@ -8398,7 +8398,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d96cb408882d4b8398e8888f693abd19~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d96cb408882d4b8398e8888f693abd19~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d96cb408882d4b8398e8888f693abd19.avif"
     },
     {
         "franchise": "LAL",
@@ -8412,7 +8412,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6592174b1877464296cb3385f8726c2b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6592174b1877464296cb3385f8726c2b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6592174b1877464296cb3385f8726c2b.avif"
     },
     {
         "franchise": "LAL",
@@ -8427,7 +8427,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a746887c8ceb42bc872e8eebbe3b28aa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a746887c8ceb42bc872e8eebbe3b28aa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a746887c8ceb42bc872e8eebbe3b28aa.avif"
     },
     {
         "franchise": "LAL",
@@ -8441,7 +8441,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fac8756fbeea4a519b2d50897308fd81~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fac8756fbeea4a519b2d50897308fd81~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fac8756fbeea4a519b2d50897308fd81.avif"
     },
     {
         "franchise": "LAL",
@@ -8455,7 +8455,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cd4c9f39fc2d4979b1f9b98b4ae5353a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cd4c9f39fc2d4979b1f9b98b4ae5353a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cd4c9f39fc2d4979b1f9b98b4ae5353a.avif"
     },
     {
         "franchise": "LAL",
@@ -8469,7 +8469,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d2924590d85c445fb07178f0964d8261~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d2924590d85c445fb07178f0964d8261~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d2924590d85c445fb07178f0964d8261.avif"
     },
     {
         "franchise": "LAL",
@@ -8483,7 +8483,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b1b7663d998748c9806decf996a3b9f2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b1b7663d998748c9806decf996a3b9f2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b1b7663d998748c9806decf996a3b9f2.avif"
     },
     {
         "franchise": "PTC",
@@ -8497,7 +8497,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_20fb30f60b6a466782c238e7f9e11298~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_20fb30f60b6a466782c238e7f9e11298~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_20fb30f60b6a466782c238e7f9e11298.avif"
     },
     {
         "franchise": "PTC",
@@ -8511,7 +8511,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8a03f168b8654803901adfb2004079a9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8a03f168b8654803901adfb2004079a9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8a03f168b8654803901adfb2004079a9.avif"
     },
     {
         "franchise": "PTC",
@@ -8525,7 +8525,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f77e8396733745b9aaf620f066191f80~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f77e8396733745b9aaf620f066191f80~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f77e8396733745b9aaf620f066191f80.avif"
     },
     {
         "franchise": "PTC",
@@ -8539,7 +8539,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8c23f38e30c04456937cfbe70d27ffcc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8c23f38e30c04456937cfbe70d27ffcc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8c23f38e30c04456937cfbe70d27ffcc.avif"
     },
     {
         "franchise": "PTC",
@@ -8553,7 +8553,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e2aa4895fac8433f9d28cf0dc3424a4b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e2aa4895fac8433f9d28cf0dc3424a4b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e2aa4895fac8433f9d28cf0dc3424a4b.avif"
     },
     {
         "franchise": "WAS",
@@ -8567,7 +8567,7 @@
         "seasons": [
             "1961-62"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2e8b8c870e0d4a35a5502bbabfc820a0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2e8b8c870e0d4a35a5502bbabfc820a0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2e8b8c870e0d4a35a5502bbabfc820a0.avif"
     },
     {
         "franchise": "WAS",
@@ -8581,7 +8581,7 @@
         "seasons": [
             "1962-63"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_35b065166af14a0e8d05c7af43bb6d62~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_35b065166af14a0e8d05c7af43bb6d62~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_35b065166af14a0e8d05c7af43bb6d62.avif"
     },
     {
         "franchise": "WAS",
@@ -8595,7 +8595,7 @@
         "seasons": [
             "1963-64"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_65e2448cf574439295c36ff04b2628e4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_65e2448cf574439295c36ff04b2628e4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_65e2448cf574439295c36ff04b2628e4.avif"
     },
     {
         "franchise": "WAS",
@@ -8610,7 +8610,7 @@
             "1964-65",
             "1965-66"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_11b208369991479c91e308fe1a37b1f1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_11b208369991479c91e308fe1a37b1f1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_11b208369991479c91e308fe1a37b1f1.avif"
     },
     {
         "franchise": "WAS",
@@ -8626,7 +8626,7 @@
             "1967-68",
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f7ba556b1fb24f1d969bfa0be804b5d2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f7ba556b1fb24f1d969bfa0be804b5d2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f7ba556b1fb24f1d969bfa0be804b5d2.avif"
     },
     {
         "franchise": "WAS",
@@ -8642,7 +8642,7 @@
             "1967-68",
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c8087eb5e6c742a59e893b9edfd23fdd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c8087eb5e6c742a59e893b9edfd23fdd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c8087eb5e6c742a59e893b9edfd23fdd.avif"
     },
     {
         "franchise": "WAS",
@@ -8656,7 +8656,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_161155aebf494f53a2a88133982846b0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_161155aebf494f53a2a88133982846b0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_161155aebf494f53a2a88133982846b0.avif"
     },
     {
         "franchise": "WAS",
@@ -8670,7 +8670,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1518cd3b06c0447e968ba1854848a6f1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1518cd3b06c0447e968ba1854848a6f1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1518cd3b06c0447e968ba1854848a6f1.avif"
     },
     {
         "franchise": "WAS",
@@ -8684,7 +8684,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_eec66f9f7a2f4cd5827e88517705c27d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_eec66f9f7a2f4cd5827e88517705c27d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_eec66f9f7a2f4cd5827e88517705c27d.avif"
     },
     {
         "franchise": "WAS",
@@ -8699,7 +8699,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_240573749843495f8b0fd8813f172881~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_240573749843495f8b0fd8813f172881~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_240573749843495f8b0fd8813f172881.avif"
     },
     {
         "franchise": "WAS",
@@ -8713,7 +8713,7 @@
         "seasons": [
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a2b811ba824a4a019aa12fe39c5a83de~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a2b811ba824a4a019aa12fe39c5a83de~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a2b811ba824a4a019aa12fe39c5a83de.avif"
     },
     {
         "franchise": "WAS",
@@ -8736,7 +8736,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_752091a4f082490b9bc5ffa3fa6be6ac~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_752091a4f082490b9bc5ffa3fa6be6ac~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_752091a4f082490b9bc5ffa3fa6be6ac.avif"
     },
     {
         "franchise": "WAS",
@@ -8750,7 +8750,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0777e0f582a049088e5d1a0e3ba36cff~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0777e0f582a049088e5d1a0e3ba36cff~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0777e0f582a049088e5d1a0e3ba36cff.avif"
     },
     {
         "franchise": "WAS",
@@ -8764,7 +8764,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a35055f37b0d4d43aec89a6e9109e669~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a35055f37b0d4d43aec89a6e9109e669~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a35055f37b0d4d43aec89a6e9109e669.avif"
     },
     {
         "franchise": "WAS",
@@ -8778,7 +8778,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_33e878e441954b4889d5edc1759e2b1b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_33e878e441954b4889d5edc1759e2b1b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_33e878e441954b4889d5edc1759e2b1b.avif"
     },
     {
         "franchise": "WAS",
@@ -8792,7 +8792,7 @@
         "seasons": [
             "1987-88"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b9f4946060d948ff8c85cbe421ef8b08~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b9f4946060d948ff8c85cbe421ef8b08~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b9f4946060d948ff8c85cbe421ef8b08.avif"
     },
     {
         "franchise": "WAS",
@@ -8807,7 +8807,7 @@
             "1988-89",
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d26c0f30e608490bb47eba441408c216~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d26c0f30e608490bb47eba441408c216~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d26c0f30e608490bb47eba441408c216.avif"
     },
     {
         "franchise": "WAS",
@@ -8824,7 +8824,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c7d6ad68abed4eecb11c0f1c01ffeb13~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c7d6ad68abed4eecb11c0f1c01ffeb13~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c7d6ad68abed4eecb11c0f1c01ffeb13.avif"
     },
     {
         "franchise": "WAS",
@@ -8840,7 +8840,7 @@
             "1995-96",
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bd92650e2ab84aefaf5e17c4a1eca480~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bd92650e2ab84aefaf5e17c4a1eca480~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bd92650e2ab84aefaf5e17c4a1eca480.avif"
     },
     {
         "franchise": "WAS",
@@ -8854,7 +8854,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2c6ea902a8ca4245b46d20f00550a9f6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2c6ea902a8ca4245b46d20f00550a9f6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2c6ea902a8ca4245b46d20f00550a9f6.avif"
     },
     {
         "franchise": "WAS",
@@ -8869,7 +8869,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e90d8889b6a140eb8c69d5e442c8e550~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e90d8889b6a140eb8c69d5e442c8e550~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e90d8889b6a140eb8c69d5e442c8e550.avif"
     },
     {
         "franchise": "WAS",
@@ -8886,7 +8886,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b4ad1dbad1a847e694230994552afd0c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b4ad1dbad1a847e694230994552afd0c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b4ad1dbad1a847e694230994552afd0c.avif"
     },
     {
         "franchise": "WAS",
@@ -8900,7 +8900,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3a67329df3304a66a404a718043794f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3a67329df3304a66a404a718043794f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3a67329df3304a66a404a718043794f8.avif"
     },
     {
         "franchise": "WAS",
@@ -8916,7 +8916,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9f8ee334985d4fa494442f6a98e78546~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9f8ee334985d4fa494442f6a98e78546~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9f8ee334985d4fa494442f6a98e78546.avif"
     },
     {
         "franchise": "WAS",
@@ -8932,7 +8932,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_57c2a3aebd5a4c2bbb3ec89980b13c53~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_57c2a3aebd5a4c2bbb3ec89980b13c53~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_57c2a3aebd5a4c2bbb3ec89980b13c53.avif"
     },
     {
         "franchise": "WAS",
@@ -8946,7 +8946,7 @@
         "seasons": [
             "2010-11"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a254db871c454deab19ee08000002d1b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a254db871c454deab19ee08000002d1b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a254db871c454deab19ee08000002d1b.avif"
     },
     {
         "franchise": "WAS",
@@ -8962,7 +8962,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5cf0a70654cb46618510ef44f2da9f45~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5cf0a70654cb46618510ef44f2da9f45~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5cf0a70654cb46618510ef44f2da9f45.avif"
     },
     {
         "franchise": "WAS",
@@ -8978,7 +8978,7 @@
             "2015-16",
             "2015-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e33d5a43b92245c4a32d3674b5a299a6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e33d5a43b92245c4a32d3674b5a299a6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e33d5a43b92245c4a32d3674b5a299a6.avif"
     },
     {
         "franchise": "WAS",
@@ -8997,7 +8997,7 @@
             "2021-22",
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_456935156e714cd086aa40a0707034d3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_456935156e714cd086aa40a0707034d3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_456935156e714cd086aa40a0707034d3.avif"
     },
     {
         "franchise": "WAS",
@@ -9011,7 +9011,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_845841bbc18b4eb9b0d9066731ddb992~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_845841bbc18b4eb9b0d9066731ddb992~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_845841bbc18b4eb9b0d9066731ddb992.avif"
     },
     {
         "franchise": "WAS",
@@ -9025,7 +9025,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d82935c9d2e148ac836a3a86d1021997~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d82935c9d2e148ac836a3a86d1021997~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d82935c9d2e148ac836a3a86d1021997.avif"
     },
     {
         "franchise": "WAS",
@@ -9041,7 +9041,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_406396a4f3e842ecbf3fad511124db2b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_406396a4f3e842ecbf3fad511124db2b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_406396a4f3e842ecbf3fad511124db2b.avif"
     },
     {
         "franchise": "WAS",
@@ -9057,7 +9057,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c47e9cd3b6dc46cb8eeb9701f84e2ce3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c47e9cd3b6dc46cb8eeb9701f84e2ce3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c47e9cd3b6dc46cb8eeb9701f84e2ce3.avif"
     },
     {
         "franchise": "WAS",
@@ -9071,7 +9071,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dd9f0e67c6694158a821cb27fbc5aa23~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dd9f0e67c6694158a821cb27fbc5aa23~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dd9f0e67c6694158a821cb27fbc5aa23.avif"
     },
     {
         "franchise": "WAS",
@@ -9086,7 +9086,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e5929745bb1240a59e70c273681c3b9d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e5929745bb1240a59e70c273681c3b9d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e5929745bb1240a59e70c273681c3b9d.avif"
     },
     {
         "franchise": "WAS",
@@ -9100,7 +9100,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f45c228cf3e646d8a0696b4c98d4ac92~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f45c228cf3e646d8a0696b4c98d4ac92~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f45c228cf3e646d8a0696b4c98d4ac92.avif"
     },
     {
         "franchise": "WAS",
@@ -9115,7 +9115,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_08ef60e6db0d4729953a2660565fe331~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_08ef60e6db0d4729953a2660565fe331~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_08ef60e6db0d4729953a2660565fe331.avif"
     },
     {
         "franchise": "WAS",
@@ -9129,7 +9129,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b8151a52735c4d0499c7e9e1c46f40af~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b8151a52735c4d0499c7e9e1c46f40af~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b8151a52735c4d0499c7e9e1c46f40af.avif"
     },
     {
         "franchise": "WAS",
@@ -9143,7 +9143,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c5612d777b4449cbb6b87ba81091dbf4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c5612d777b4449cbb6b87ba81091dbf4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c5612d777b4449cbb6b87ba81091dbf4.avif"
     },
     {
         "franchise": "WAS",
@@ -9157,7 +9157,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e9a274e1c9ab4adbba958fa5b30ffe67~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e9a274e1c9ab4adbba958fa5b30ffe67~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e9a274e1c9ab4adbba958fa5b30ffe67.avif"
     },
     {
         "franchise": "MIN",
@@ -9175,7 +9175,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1cf1dad8f6a84cddb4b061a924f0e717~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1cf1dad8f6a84cddb4b061a924f0e717~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1cf1dad8f6a84cddb4b061a924f0e717.avif"
     },
     {
         "franchise": "MIN",
@@ -9190,7 +9190,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_62d5e04263804e739ebea1e0bd764bcc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_62d5e04263804e739ebea1e0bd764bcc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_62d5e04263804e739ebea1e0bd764bcc.avif"
     },
     {
         "franchise": "MIN",
@@ -9204,7 +9204,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_399f412ca9b34090bc1c1340a1452643~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_399f412ca9b34090bc1c1340a1452643~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_399f412ca9b34090bc1c1340a1452643.avif"
     },
     {
         "franchise": "MIN",
@@ -9219,7 +9219,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d7e6dd1d273749feb0bdaffd2a044588~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d7e6dd1d273749feb0bdaffd2a044588~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d7e6dd1d273749feb0bdaffd2a044588.avif"
     },
     {
         "franchise": "MIN",
@@ -9240,7 +9240,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_325812d8f285442fbeb5865ac93fc2d6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_325812d8f285442fbeb5865ac93fc2d6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_325812d8f285442fbeb5865ac93fc2d6.avif"
     },
     {
         "franchise": "MIN",
@@ -9254,7 +9254,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_91c60363dd3547edb13ef5fcc6dc4eb4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_91c60363dd3547edb13ef5fcc6dc4eb4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_91c60363dd3547edb13ef5fcc6dc4eb4.avif"
     },
     {
         "franchise": "MIN",
@@ -9269,7 +9269,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_56af7e5ce5f84371b5b2f75f00e31f8d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_56af7e5ce5f84371b5b2f75f00e31f8d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_56af7e5ce5f84371b5b2f75f00e31f8d.avif"
     },
     {
         "franchise": "MIN",
@@ -9286,7 +9286,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e8a1df8e8fb5488ca2c851e088561e4d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e8a1df8e8fb5488ca2c851e088561e4d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e8a1df8e8fb5488ca2c851e088561e4d.avif"
     },
     {
         "franchise": "MIN",
@@ -9302,7 +9302,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_166203d1e5d74c1e91458e1192bf5834~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_166203d1e5d74c1e91458e1192bf5834~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_166203d1e5d74c1e91458e1192bf5834.avif"
     },
     {
         "franchise": "MIN",
@@ -9320,7 +9320,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4f5c0c77810744418be2e688f584ff96~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4f5c0c77810744418be2e688f584ff96~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4f5c0c77810744418be2e688f584ff96.avif"
     },
     {
         "franchise": "MIN",
@@ -9334,7 +9334,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a8f35a53d8e54398afcc14214d350edc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a8f35a53d8e54398afcc14214d350edc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a8f35a53d8e54398afcc14214d350edc.avif"
     },
     {
         "franchise": "MIN",
@@ -9348,7 +9348,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_46add656d7244ca89a5ec0733ffd6558~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_46add656d7244ca89a5ec0733ffd6558~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_46add656d7244ca89a5ec0733ffd6558.avif"
     },
     {
         "franchise": "MIN",
@@ -9363,7 +9363,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4100a0674c6245ffa028b2f5d2f2ec5a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4100a0674c6245ffa028b2f5d2f2ec5a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4100a0674c6245ffa028b2f5d2f2ec5a.avif"
     },
     {
         "franchise": "MIN",
@@ -9384,7 +9384,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9ca49513bc764680982b7a6a1ea75978~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9ca49513bc764680982b7a6a1ea75978~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9ca49513bc764680982b7a6a1ea75978.avif"
     },
     {
         "franchise": "MIN",
@@ -9398,7 +9398,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bf93f320eece4f488a170b049825767f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bf93f320eece4f488a170b049825767f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bf93f320eece4f488a170b049825767f.avif"
     },
     {
         "franchise": "MIN",
@@ -9414,7 +9414,7 @@
             "2011-12",
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d337a881b9cf4a108401f5219cd23530~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d337a881b9cf4a108401f5219cd23530~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d337a881b9cf4a108401f5219cd23530.avif"
     },
     {
         "franchise": "MIN",
@@ -9428,7 +9428,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f105a889069443df87ed56e724de5d6b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f105a889069443df87ed56e724de5d6b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f105a889069443df87ed56e724de5d6b.avif"
     },
     {
         "franchise": "MIN",
@@ -9444,7 +9444,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_812e9a3b62d04a3aa10c39b398a36acf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_812e9a3b62d04a3aa10c39b398a36acf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_812e9a3b62d04a3aa10c39b398a36acf.avif"
     },
     {
         "franchise": "MIN",
@@ -9460,7 +9460,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b820f2afedf44afe8e55af4bb4fc8cd1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b820f2afedf44afe8e55af4bb4fc8cd1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b820f2afedf44afe8e55af4bb4fc8cd1.avif"
     },
     {
         "franchise": "MIN",
@@ -9474,7 +9474,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7930ab627b564cddb5e87c103d02e1c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7930ab627b564cddb5e87c103d02e1c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7930ab627b564cddb5e87c103d02e1c4.avif"
     },
     {
         "franchise": "MIN",
@@ -9488,7 +9488,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_afee27d95a6e416eb8f641263152b121~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_afee27d95a6e416eb8f641263152b121~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_afee27d95a6e416eb8f641263152b121.avif"
     },
     {
         "franchise": "MIN",
@@ -9502,7 +9502,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0a3016301baf4912aaa16776bac7fb06~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0a3016301baf4912aaa16776bac7fb06~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0a3016301baf4912aaa16776bac7fb06.avif"
     },
     {
         "franchise": "MIN",
@@ -9516,7 +9516,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f0289a1797ba419f93cad1a9ddaf656a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f0289a1797ba419f93cad1a9ddaf656a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f0289a1797ba419f93cad1a9ddaf656a.avif"
     },
     {
         "franchise": "",
@@ -9530,7 +9530,7 @@
         "seasons": [
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f94472d1d7484b298158220329eded89~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f94472d1d7484b298158220329eded89~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f94472d1d7484b298158220329eded89.avif"
     },
     {
         "franchise": "",
@@ -9544,7 +9544,7 @@
         "seasons": [
             "1951-52"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_18eaa9d06d6a45c09f976055d926a935~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_18eaa9d06d6a45c09f976055d926a935~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_18eaa9d06d6a45c09f976055d926a935.avif"
     },
     {
         "franchise": "",
@@ -9558,7 +9558,7 @@
         "seasons": [
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ad06c4e6559442fe906526a396d79f00~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ad06c4e6559442fe906526a396d79f00~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ad06c4e6559442fe906526a396d79f00.avif"
     },
     {
         "franchise": "",
@@ -9572,7 +9572,7 @@
         "seasons": [
             "1953-54"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_735526449374468996edbf926b2f5c58~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_735526449374468996edbf926b2f5c58~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_735526449374468996edbf926b2f5c58.avif"
     },
     {
         "franchise": "",
@@ -9586,7 +9586,7 @@
         "seasons": [
             "1954-55"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aeeb38c57be54aff80bf1d7e412b229d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aeeb38c57be54aff80bf1d7e412b229d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aeeb38c57be54aff80bf1d7e412b229d.avif"
     },
     {
         "franchise": "",
@@ -9600,7 +9600,7 @@
         "seasons": [
             "1955-56"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3493c84046944f6f81c5a39163399c2f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3493c84046944f6f81c5a39163399c2f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3493c84046944f6f81c5a39163399c2f.avif"
     },
     {
         "franchise": "",
@@ -9614,7 +9614,7 @@
         "seasons": [
             "1956-57"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_45d2d7e53bc6461991be679d23a2ee35~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_45d2d7e53bc6461991be679d23a2ee35~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_45d2d7e53bc6461991be679d23a2ee35.avif"
     },
     {
         "franchise": "",
@@ -9628,7 +9628,7 @@
         "seasons": [
             "1957-58"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_44eaa02f826b4ae49381f6bf91186356~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_44eaa02f826b4ae49381f6bf91186356~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_44eaa02f826b4ae49381f6bf91186356.avif"
     },
     {
         "franchise": "",
@@ -9642,7 +9642,7 @@
         "seasons": [
             "1958-59"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5d6f3e160f27445f9737600a9cff3fee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5d6f3e160f27445f9737600a9cff3fee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5d6f3e160f27445f9737600a9cff3fee.avif"
     },
     {
         "franchise": "",
@@ -9656,7 +9656,7 @@
         "seasons": [
             "1959-60"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4709b4ce27534208bbc114c7aa5d0312~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4709b4ce27534208bbc114c7aa5d0312~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4709b4ce27534208bbc114c7aa5d0312.avif"
     },
     {
         "franchise": "",
@@ -9670,7 +9670,7 @@
         "seasons": [
             "1960-61"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c10fb15f5b8a4c8c957bf4df1258ea8c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c10fb15f5b8a4c8c957bf4df1258ea8c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c10fb15f5b8a4c8c957bf4df1258ea8c.avif"
     },
     {
         "franchise": "",
@@ -9684,7 +9684,7 @@
         "seasons": [
             "1961-62"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7c454b8b533e4da781441f2e83289995~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7c454b8b533e4da781441f2e83289995~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7c454b8b533e4da781441f2e83289995.avif"
     },
     {
         "franchise": "",
@@ -9698,7 +9698,7 @@
         "seasons": [
             "1962-63"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bda3d500d5d64cc6a2532095f932c171~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bda3d500d5d64cc6a2532095f932c171~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bda3d500d5d64cc6a2532095f932c171.avif"
     },
     {
         "franchise": "",
@@ -9712,7 +9712,7 @@
         "seasons": [
             "1963-64"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8314200d8b774a149b3692832ad7dcfd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8314200d8b774a149b3692832ad7dcfd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8314200d8b774a149b3692832ad7dcfd.avif"
     },
     {
         "franchise": "",
@@ -9726,7 +9726,7 @@
         "seasons": [
             "1964-65"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a4a858adc3254eba9738f4c405db0ab9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a4a858adc3254eba9738f4c405db0ab9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a4a858adc3254eba9738f4c405db0ab9.avif"
     },
     {
         "franchise": "",
@@ -9740,7 +9740,7 @@
         "seasons": [
             "1965-66"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_edfc91f33ec84e49ba5dd0f06f608307~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_edfc91f33ec84e49ba5dd0f06f608307~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_edfc91f33ec84e49ba5dd0f06f608307.avif"
     },
     {
         "franchise": "",
@@ -9754,7 +9754,7 @@
         "seasons": [
             "1966-67"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_92e87b3bab2f488fb479ec02ee29971b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_92e87b3bab2f488fb479ec02ee29971b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_92e87b3bab2f488fb479ec02ee29971b.avif"
     },
     {
         "franchise": "",
@@ -9768,7 +9768,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1b267bb63e924b27a29fa837e98a7463~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1b267bb63e924b27a29fa837e98a7463~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1b267bb63e924b27a29fa837e98a7463.avif"
     },
     {
         "franchise": "",
@@ -9782,7 +9782,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b6bfe7a3e7794d929322048ade853b2d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b6bfe7a3e7794d929322048ade853b2d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b6bfe7a3e7794d929322048ade853b2d.avif"
     },
     {
         "franchise": "",
@@ -9796,7 +9796,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8f28f10e8ae04b88bf81731e04fe6973~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8f28f10e8ae04b88bf81731e04fe6973~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8f28f10e8ae04b88bf81731e04fe6973.avif"
     },
     {
         "franchise": "",
@@ -9810,7 +9810,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_108fd427a34b48bea9ac9efdd09740a7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_108fd427a34b48bea9ac9efdd09740a7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_108fd427a34b48bea9ac9efdd09740a7.avif"
     },
     {
         "franchise": "",
@@ -9824,7 +9824,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d4fcf982a8714692913ca619efb7580d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d4fcf982a8714692913ca619efb7580d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d4fcf982a8714692913ca619efb7580d.avif"
     },
     {
         "franchise": "",
@@ -9838,7 +9838,7 @@
         "seasons": [
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6959d992da8f44bb95c5c95b82701ac3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6959d992da8f44bb95c5c95b82701ac3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6959d992da8f44bb95c5c95b82701ac3.avif"
     },
     {
         "franchise": "",
@@ -9852,7 +9852,7 @@
         "seasons": [
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f41e5b9cb50841b4a983444db8f70b1c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f41e5b9cb50841b4a983444db8f70b1c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f41e5b9cb50841b4a983444db8f70b1c.avif"
     },
     {
         "franchise": "",
@@ -9866,7 +9866,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_188963bed4134e589e54b4c5dce3b727~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_188963bed4134e589e54b4c5dce3b727~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_188963bed4134e589e54b4c5dce3b727.avif"
     },
     {
         "franchise": "",
@@ -9880,7 +9880,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d43512311b984f238199129eb19b70b4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d43512311b984f238199129eb19b70b4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d43512311b984f238199129eb19b70b4.avif"
     },
     {
         "franchise": "",
@@ -9894,7 +9894,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f687d27b911244df8f2f5d9f6ebbbe94~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f687d27b911244df8f2f5d9f6ebbbe94~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f687d27b911244df8f2f5d9f6ebbbe94.avif"
     },
     {
         "franchise": "",
@@ -9908,7 +9908,7 @@
         "seasons": [
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f3db3b9a2b8345578b45f9b88785dfb9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f3db3b9a2b8345578b45f9b88785dfb9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f3db3b9a2b8345578b45f9b88785dfb9.avif"
     },
     {
         "franchise": "",
@@ -9922,7 +9922,7 @@
         "seasons": [
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_18a93db4f9014668ad7dbd18ce68bd5d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_18a93db4f9014668ad7dbd18ce68bd5d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_18a93db4f9014668ad7dbd18ce68bd5d.avif"
     },
     {
         "franchise": "",
@@ -9936,7 +9936,7 @@
         "seasons": [
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ae069d36afb14c0dbbd69007e4f0b65d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ae069d36afb14c0dbbd69007e4f0b65d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ae069d36afb14c0dbbd69007e4f0b65d.avif"
     },
     {
         "franchise": "",
@@ -9950,7 +9950,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_72633234d2ae4ab9b3d42af9c8721f72~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_72633234d2ae4ab9b3d42af9c8721f72~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_72633234d2ae4ab9b3d42af9c8721f72.avif"
     },
     {
         "franchise": "",
@@ -9964,7 +9964,7 @@
         "seasons": [
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4c2811f51a9147d68ee686513f7c8bb2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4c2811f51a9147d68ee686513f7c8bb2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4c2811f51a9147d68ee686513f7c8bb2.avif"
     },
     {
         "franchise": "",
@@ -9978,7 +9978,7 @@
         "seasons": [
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_32540d36df3a4af3b3cbc8210db4b50f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_32540d36df3a4af3b3cbc8210db4b50f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_32540d36df3a4af3b3cbc8210db4b50f.avif"
     },
     {
         "franchise": "",
@@ -9992,7 +9992,7 @@
         "seasons": [
             "1983-84"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e43f395c878d4a34976cc481b48f6070~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e43f395c878d4a34976cc481b48f6070~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e43f395c878d4a34976cc481b48f6070.avif"
     },
     {
         "franchise": "",
@@ -10006,7 +10006,7 @@
         "seasons": [
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_43445bd211e84d5d84d70fbcd18ababd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_43445bd211e84d5d84d70fbcd18ababd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_43445bd211e84d5d84d70fbcd18ababd.avif"
     },
     {
         "franchise": "",
@@ -10020,7 +10020,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0fd32909ad204a9e9522d23f5bc8653f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0fd32909ad204a9e9522d23f5bc8653f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0fd32909ad204a9e9522d23f5bc8653f.avif"
     },
     {
         "franchise": "",
@@ -10034,7 +10034,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6be86028f5004ac8b8a5b7d2263cbeb0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6be86028f5004ac8b8a5b7d2263cbeb0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6be86028f5004ac8b8a5b7d2263cbeb0.avif"
     },
     {
         "franchise": "",
@@ -10048,7 +10048,7 @@
         "seasons": [
             "1987-88"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f0e3dedade594e2ebd40be552cc7af85~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f0e3dedade594e2ebd40be552cc7af85~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f0e3dedade594e2ebd40be552cc7af85.avif"
     },
     {
         "franchise": "",
@@ -10062,7 +10062,7 @@
         "seasons": [
             "1988-89"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3e37458297034a4bb3ded69611f191e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3e37458297034a4bb3ded69611f191e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3e37458297034a4bb3ded69611f191e0.avif"
     },
     {
         "franchise": "",
@@ -10076,7 +10076,7 @@
         "seasons": [
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3c233120559643f9b94f85a5dc0c83d8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3c233120559643f9b94f85a5dc0c83d8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3c233120559643f9b94f85a5dc0c83d8.avif"
     },
     {
         "franchise": "",
@@ -10090,7 +10090,7 @@
         "seasons": [
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bd2b19b2c45d44f2b1131e4c58126541~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bd2b19b2c45d44f2b1131e4c58126541~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bd2b19b2c45d44f2b1131e4c58126541.avif"
     },
     {
         "franchise": "",
@@ -10104,7 +10104,7 @@
         "seasons": [
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c3196b5efdd04062a05f481857a23fe0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c3196b5efdd04062a05f481857a23fe0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c3196b5efdd04062a05f481857a23fe0.avif"
     },
     {
         "franchise": "",
@@ -10118,7 +10118,7 @@
         "seasons": [
             "1992-93"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6f5632be1b6745adbafb62b1bc41717e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6f5632be1b6745adbafb62b1bc41717e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6f5632be1b6745adbafb62b1bc41717e.avif"
     },
     {
         "franchise": "",
@@ -10132,7 +10132,7 @@
         "seasons": [
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_79807ef0dbb84e5ab1aabb8d3a2512de~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_79807ef0dbb84e5ab1aabb8d3a2512de~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_79807ef0dbb84e5ab1aabb8d3a2512de.avif"
     },
     {
         "franchise": "",
@@ -10146,7 +10146,7 @@
         "seasons": [
             "1994-95"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dc857c05cebc4b7c89b7f3e290324390~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dc857c05cebc4b7c89b7f3e290324390~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dc857c05cebc4b7c89b7f3e290324390.avif"
     },
     {
         "franchise": "",
@@ -10160,7 +10160,7 @@
         "seasons": [
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a74ebfe81e8a4ab9b4e8bcb8fabe2593~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a74ebfe81e8a4ab9b4e8bcb8fabe2593~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a74ebfe81e8a4ab9b4e8bcb8fabe2593.avif"
     },
     {
         "franchise": "",
@@ -10174,7 +10174,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2c80facc13fc4e56811fa54db88f57bb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2c80facc13fc4e56811fa54db88f57bb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2c80facc13fc4e56811fa54db88f57bb.avif"
     },
     {
         "franchise": "",
@@ -10188,7 +10188,7 @@
         "seasons": [
             "1997-98"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7b320b06729843f69592ad88a34adbc8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7b320b06729843f69592ad88a34adbc8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7b320b06729843f69592ad88a34adbc8.avif"
     },
     {
         "franchise": "",
@@ -10202,7 +10202,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d248c8b948ef4ba289c467b304576253~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d248c8b948ef4ba289c467b304576253~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d248c8b948ef4ba289c467b304576253.avif"
     },
     {
         "franchise": "",
@@ -10216,7 +10216,7 @@
         "seasons": [
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5940a03d043c463d9800a7c7f23967bf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5940a03d043c463d9800a7c7f23967bf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5940a03d043c463d9800a7c7f23967bf.avif"
     },
     {
         "franchise": "",
@@ -10230,7 +10230,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_59a455104ca1400189e4d0330f5792ba~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_59a455104ca1400189e4d0330f5792ba~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_59a455104ca1400189e4d0330f5792ba.avif"
     },
     {
         "franchise": "",
@@ -10244,7 +10244,7 @@
         "seasons": [
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8358aaff011a4015bb5f9cf47830b19e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8358aaff011a4015bb5f9cf47830b19e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8358aaff011a4015bb5f9cf47830b19e.avif"
     },
     {
         "franchise": "",
@@ -10258,7 +10258,7 @@
         "seasons": [
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e1962feb2a60425ab880a66744c445b3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e1962feb2a60425ab880a66744c445b3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e1962feb2a60425ab880a66744c445b3.avif"
     },
     {
         "franchise": "",
@@ -10272,7 +10272,7 @@
         "seasons": [
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d11a1dcba51149ffa49ac05d9bd74b0f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d11a1dcba51149ffa49ac05d9bd74b0f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d11a1dcba51149ffa49ac05d9bd74b0f.avif"
     },
     {
         "franchise": "",
@@ -10286,7 +10286,7 @@
         "seasons": [
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_da5ae72d153149159431372621d9668f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_da5ae72d153149159431372621d9668f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_da5ae72d153149159431372621d9668f.avif"
     },
     {
         "franchise": "",
@@ -10300,7 +10300,7 @@
         "seasons": [
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_394f15efc76048ae82eab998c8249769~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_394f15efc76048ae82eab998c8249769~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_394f15efc76048ae82eab998c8249769.avif"
     },
     {
         "franchise": "",
@@ -10314,7 +10314,7 @@
         "seasons": [
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_db95420da51d4fcb878f121713ecc198~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_db95420da51d4fcb878f121713ecc198~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_db95420da51d4fcb878f121713ecc198.avif"
     },
     {
         "franchise": "",
@@ -10328,7 +10328,7 @@
         "seasons": [
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9cb6117a502948a5ae590bcc2668399e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9cb6117a502948a5ae590bcc2668399e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9cb6117a502948a5ae590bcc2668399e.avif"
     },
     {
         "franchise": "",
@@ -10342,7 +10342,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_86fb35cbe7ab497f96783f73a3d0c97f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_86fb35cbe7ab497f96783f73a3d0c97f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_86fb35cbe7ab497f96783f73a3d0c97f.avif"
     },
     {
         "franchise": "",
@@ -10356,7 +10356,7 @@
         "seasons": [
             "2010-11"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cab29bc37db849a0841690865273e6b0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cab29bc37db849a0841690865273e6b0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cab29bc37db849a0841690865273e6b0.avif"
     },
     {
         "franchise": "",
@@ -10370,7 +10370,7 @@
         "seasons": [
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_111e308d9c33400ab6ba27e8d3a275c9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_111e308d9c33400ab6ba27e8d3a275c9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_111e308d9c33400ab6ba27e8d3a275c9.avif"
     },
     {
         "franchise": "",
@@ -10384,7 +10384,7 @@
         "seasons": [
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bd560628863343148c56cce427def92e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bd560628863343148c56cce427def92e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bd560628863343148c56cce427def92e.avif"
     },
     {
         "franchise": "",
@@ -10398,7 +10398,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_30d095de57b94166abf73837f183afa0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_30d095de57b94166abf73837f183afa0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_30d095de57b94166abf73837f183afa0.avif"
     },
     {
         "franchise": "",
@@ -10412,7 +10412,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1d59ec1e5bcc4e93bacf056074f05f7d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1d59ec1e5bcc4e93bacf056074f05f7d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1d59ec1e5bcc4e93bacf056074f05f7d.avif"
     },
     {
         "franchise": "",
@@ -10426,7 +10426,7 @@
         "seasons": [
             "2015-16"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8da972e6465244aa843ba367ee14cbb6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8da972e6465244aa843ba367ee14cbb6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8da972e6465244aa843ba367ee14cbb6.avif"
     },
     {
         "franchise": "",
@@ -10440,7 +10440,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_71f8d57dded745f0b82f93fd5f946a4f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_71f8d57dded745f0b82f93fd5f946a4f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_71f8d57dded745f0b82f93fd5f946a4f.avif"
     },
     {
         "franchise": "",
@@ -10454,7 +10454,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a3f17257134b4c6cb084f2c92746f8c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a3f17257134b4c6cb084f2c92746f8c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a3f17257134b4c6cb084f2c92746f8c4.avif"
     },
     {
         "franchise": "",
@@ -10468,7 +10468,7 @@
         "seasons": [
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_090f2e574c0d4284b323bdf555293df8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_090f2e574c0d4284b323bdf555293df8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_090f2e574c0d4284b323bdf555293df8.avif"
     },
     {
         "franchise": "",
@@ -10482,7 +10482,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f833348045da432db371a53bebfd4db3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f833348045da432db371a53bebfd4db3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f833348045da432db371a53bebfd4db3.avif"
     },
     {
         "franchise": "",
@@ -10496,7 +10496,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e45a39de0eed447a8ac4b767d3786206~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e45a39de0eed447a8ac4b767d3786206~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e45a39de0eed447a8ac4b767d3786206.avif"
     },
     {
         "franchise": "",
@@ -10510,7 +10510,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b86827c60458455bbbf21e200648c211~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b86827c60458455bbbf21e200648c211~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b86827c60458455bbbf21e200648c211.avif"
     },
     {
         "franchise": "",
@@ -10524,7 +10524,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_15d256b404dc4ce59c13f119de423416~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_15d256b404dc4ce59c13f119de423416~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_15d256b404dc4ce59c13f119de423416.avif"
     },
     {
         "franchise": "",
@@ -10538,7 +10538,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_13ca5c80875648f38d34af76a631ab9d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_13ca5c80875648f38d34af76a631ab9d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_13ca5c80875648f38d34af76a631ab9d.avif"
     },
     {
         "franchise": "",
@@ -10552,7 +10552,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e3d5e96cd316420684a05fac55f7662f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e3d5e96cd316420684a05fac55f7662f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e3d5e96cd316420684a05fac55f7662f.avif"
     },
     {
         "franchise": "HOU",
@@ -10566,7 +10566,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9414401fe60b4ef0a0cf9ab9f0fd8214~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9414401fe60b4ef0a0cf9ab9f0fd8214~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9414401fe60b4ef0a0cf9ab9f0fd8214.avif"
     },
     {
         "franchise": "HOU",
@@ -10580,7 +10580,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d1c233b4b5d84fbaa3fdd59f6e3bcb7c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d1c233b4b5d84fbaa3fdd59f6e3bcb7c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d1c233b4b5d84fbaa3fdd59f6e3bcb7c.avif"
     },
     {
         "franchise": "HOU",
@@ -10594,7 +10594,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2a41a3965c9048149fe816b4e9d152d5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2a41a3965c9048149fe816b4e9d152d5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2a41a3965c9048149fe816b4e9d152d5.avif"
     },
     {
         "franchise": "HOU",
@@ -10609,7 +10609,7 @@
             "1969-70",
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1190372f7685454987a7e3a7a4baf5fe~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1190372f7685454987a7e3a7a4baf5fe~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1190372f7685454987a7e3a7a4baf5fe.avif"
     },
     {
         "franchise": "HOU",
@@ -10623,7 +10623,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_87f33958f47042e292e4ac36ac0c1cea~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_87f33958f47042e292e4ac36ac0c1cea~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_87f33958f47042e292e4ac36ac0c1cea.avif"
     },
     {
         "franchise": "HOU",
@@ -10637,7 +10637,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b4e4108858db4f71988c672c5e2afda0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b4e4108858db4f71988c672c5e2afda0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b4e4108858db4f71988c672c5e2afda0.avif"
     },
     {
         "franchise": "HOU",
@@ -10651,7 +10651,7 @@
         "seasons": [
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6587a3269f8544d98eb43bdf9838e3b5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6587a3269f8544d98eb43bdf9838e3b5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6587a3269f8544d98eb43bdf9838e3b5.avif"
     },
     {
         "franchise": "HOU",
@@ -10665,7 +10665,7 @@
         "seasons": [
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f51d99aac7c4483e89bb2f35b69b7693~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f51d99aac7c4483e89bb2f35b69b7693~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f51d99aac7c4483e89bb2f35b69b7693.avif"
     },
     {
         "franchise": "HOU",
@@ -10679,7 +10679,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ae2313ffba104ba6bebef6a20cc720d5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ae2313ffba104ba6bebef6a20cc720d5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ae2313ffba104ba6bebef6a20cc720d5.avif"
     },
     {
         "franchise": "HOU",
@@ -10693,7 +10693,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d6363221ff994f1882c765a388f060ee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d6363221ff994f1882c765a388f060ee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d6363221ff994f1882c765a388f060ee.avif"
     },
     {
         "franchise": "HOU",
@@ -10709,7 +10709,7 @@
             "1976-77",
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4155da77763d40c7876ee1b45cf9873b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4155da77763d40c7876ee1b45cf9873b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4155da77763d40c7876ee1b45cf9873b.avif"
     },
     {
         "franchise": "HOU",
@@ -10725,7 +10725,7 @@
             "1979-80",
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cbc214b80ffb415fb85ab21f7783f372~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cbc214b80ffb415fb85ab21f7783f372~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cbc214b80ffb415fb85ab21f7783f372.avif"
     },
     {
         "franchise": "HOU",
@@ -10739,7 +10739,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d3e2466338c046b6b6f327f46f0e4774~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d3e2466338c046b6b6f327f46f0e4774~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d3e2466338c046b6b6f327f46f0e4774.avif"
     },
     {
         "franchise": "HOU",
@@ -10756,7 +10756,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_04e083a0208643719e08421831d1c783~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_04e083a0208643719e08421831d1c783~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_04e083a0208643719e08421831d1c783.avif"
     },
     {
         "franchise": "HOU",
@@ -10777,7 +10777,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b6547a4f9bf2453fb60ea3fc9a6f8ca2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b6547a4f9bf2453fb60ea3fc9a6f8ca2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b6547a4f9bf2453fb60ea3fc9a6f8ca2.avif"
     },
     {
         "franchise": "HOU",
@@ -10791,7 +10791,7 @@
         "seasons": [
             "1994-95"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_56bb6260f9c0457baed09031b156e434~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_56bb6260f9c0457baed09031b156e434~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_56bb6260f9c0457baed09031b156e434.avif"
     },
     {
         "franchise": "HOU",
@@ -10808,7 +10808,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0efe914b3724763a988d88e4df91a0e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0efe914b3724763a988d88e4df91a0e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0efe914b3724763a988d88e4df91a0e.avif"
     },
     {
         "franchise": "HOU",
@@ -10822,7 +10822,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bb9ff667f6d94c358e5837837a93b3b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bb9ff667f6d94c358e5837837a93b3b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bb9ff667f6d94c358e5837837a93b3b1.avif"
     },
     {
         "franchise": "HOU",
@@ -10838,7 +10838,7 @@
             "2000-01",
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3cff19547f794dfb80f0e1ab06691a5a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3cff19547f794dfb80f0e1ab06691a5a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3cff19547f794dfb80f0e1ab06691a5a.avif"
     },
     {
         "franchise": "HOU",
@@ -10852,7 +10852,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0410c75c17e5431baeefde972b392044~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0410c75c17e5431baeefde972b392044~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0410c75c17e5431baeefde972b392044.avif"
     },
     {
         "franchise": "HOU",
@@ -10872,7 +10872,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_21205e7e71e547caa52f9ba35018a31b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_21205e7e71e547caa52f9ba35018a31b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_21205e7e71e547caa52f9ba35018a31b.avif"
     },
     {
         "franchise": "HOU",
@@ -10889,7 +10889,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d55e3e3341294f0295ec11be90033494~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d55e3e3341294f0295ec11be90033494~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d55e3e3341294f0295ec11be90033494.avif"
     },
     {
         "franchise": "HOU",
@@ -10903,7 +10903,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b71f5905947c46618836b7bd21401495~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b71f5905947c46618836b7bd21401495~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b71f5905947c46618836b7bd21401495.avif"
     },
     {
         "franchise": "HOU",
@@ -10918,7 +10918,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5c053759901140509780453010d98566~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5c053759901140509780453010d98566~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5c053759901140509780453010d98566.avif"
     },
     {
         "franchise": "HOU",
@@ -10933,7 +10933,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ab4548c60ae54c1c95d2de15d670e188~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ab4548c60ae54c1c95d2de15d670e188~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ab4548c60ae54c1c95d2de15d670e188.avif"
     },
     {
         "franchise": "HOU",
@@ -10949,7 +10949,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a99919e6a6094100986d95eafcff0ba6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a99919e6a6094100986d95eafcff0ba6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a99919e6a6094100986d95eafcff0ba6.avif"
     },
     {
         "franchise": "HOU",
@@ -10963,7 +10963,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aaf68ab812ff4dd7a8c1f9af195b488e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aaf68ab812ff4dd7a8c1f9af195b488e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aaf68ab812ff4dd7a8c1f9af195b488e.avif"
     },
     {
         "franchise": "HOU",
@@ -10977,7 +10977,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_740c1bdbb70e432782903bc81ff882a2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_740c1bdbb70e432782903bc81ff882a2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_740c1bdbb70e432782903bc81ff882a2.avif"
     },
     {
         "franchise": "HOU",
@@ -10991,7 +10991,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5f18dd51477a473993726b10c59382cb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5f18dd51477a473993726b10c59382cb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5f18dd51477a473993726b10c59382cb.avif"
     },
     {
         "franchise": "HOU",
@@ -11008,7 +11008,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7315e46c1189410da91babd57ccc6fac~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7315e46c1189410da91babd57ccc6fac~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7315e46c1189410da91babd57ccc6fac.avif"
     },
     {
         "franchise": "HOU",
@@ -11022,7 +11022,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7159cf3180b640fc94dbb80e604dcb98~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7159cf3180b640fc94dbb80e604dcb98~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7159cf3180b640fc94dbb80e604dcb98.avif"
     },
     {
         "franchise": "HOU",
@@ -11037,7 +11037,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d6aa7a7027174bd2b36e499dcee0c770~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d6aa7a7027174bd2b36e499dcee0c770~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d6aa7a7027174bd2b36e499dcee0c770.avif"
     },
     {
         "franchise": "HOU",
@@ -11051,7 +11051,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b9dc82caeb274f97a27a93269eaf898d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b9dc82caeb274f97a27a93269eaf898d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b9dc82caeb274f97a27a93269eaf898d.avif"
     },
     {
         "franchise": "HOU",
@@ -11067,7 +11067,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_96500dfe61554be8bb9fe8fa23f8cc35~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_96500dfe61554be8bb9fe8fa23f8cc35~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_96500dfe61554be8bb9fe8fa23f8cc35.avif"
     },
     {
         "franchise": "HOU",
@@ -11082,7 +11082,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_34aa3d315335472bba49f729fd959f9a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_34aa3d315335472bba49f729fd959f9a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_34aa3d315335472bba49f729fd959f9a.avif"
     },
     {
         "franchise": "HOU",
@@ -11096,7 +11096,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bfc770a2cff743b08f69609ecace1f85~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bfc770a2cff743b08f69609ecace1f85~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bfc770a2cff743b08f69609ecace1f85.avif"
     },
     {
         "franchise": "HOU",
@@ -11110,7 +11110,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_710a7636ba8b417997504b648a128712~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_710a7636ba8b417997504b648a128712~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_710a7636ba8b417997504b648a128712.avif"
     },
     {
         "franchise": "TOR",
@@ -11124,7 +11124,7 @@
         "seasons": [
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_53ea76f0cdd144569d71e318a81d148e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_53ea76f0cdd144569d71e318a81d148e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_53ea76f0cdd144569d71e318a81d148e.avif"
     },
     {
         "franchise": "TOR",
@@ -11138,7 +11138,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_56fc2e3ee93c4d839c42803e23a45f7e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_56fc2e3ee93c4d839c42803e23a45f7e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_56fc2e3ee93c4d839c42803e23a45f7e.avif"
     },
     {
         "franchise": "TOR",
@@ -11153,7 +11153,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_64ec966b8902418bb91a364269b317ec~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_64ec966b8902418bb91a364269b317ec~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_64ec966b8902418bb91a364269b317ec.avif"
     },
     {
         "franchise": "TOR",
@@ -11170,7 +11170,7 @@
             "2001-02",
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1bf73e4e605841ddac0a795ee9653422~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1bf73e4e605841ddac0a795ee9653422~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1bf73e4e605841ddac0a795ee9653422.avif"
     },
     {
         "franchise": "TOR",
@@ -11184,7 +11184,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_387145bf0b034c67b66340a4810b9fd9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_387145bf0b034c67b66340a4810b9fd9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_387145bf0b034c67b66340a4810b9fd9.avif"
     },
     {
         "franchise": "TOR",
@@ -11198,7 +11198,7 @@
         "seasons": [
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_81627b173cc8422bb3fd5216e29a4fdf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_81627b173cc8422bb3fd5216e29a4fdf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_81627b173cc8422bb3fd5216e29a4fdf.avif"
     },
     {
         "franchise": "TOR",
@@ -11213,7 +11213,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_33fb635d68dd4257910ad4c98b7c7755~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_33fb635d68dd4257910ad4c98b7c7755~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_33fb635d68dd4257910ad4c98b7c7755.avif"
     },
     {
         "franchise": "TOR",
@@ -11230,7 +11230,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_92637cdfe9ec4b74abd03bad210edc0f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_92637cdfe9ec4b74abd03bad210edc0f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_92637cdfe9ec4b74abd03bad210edc0f.avif"
     },
     {
         "franchise": "TOR",
@@ -11247,7 +11247,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_70e4e30710ad4804b104d1ffe67dca97~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_70e4e30710ad4804b104d1ffe67dca97~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_70e4e30710ad4804b104d1ffe67dca97.avif"
     },
     {
         "franchise": "TOR",
@@ -11261,7 +11261,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5a57729dbe0b464882f00d545c88d76b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5a57729dbe0b464882f00d545c88d76b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5a57729dbe0b464882f00d545c88d76b.avif"
     },
     {
         "franchise": "TOR",
@@ -11276,7 +11276,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_83275bcd834a49429d6594e07b4bf4c5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_83275bcd834a49429d6594e07b4bf4c5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_83275bcd834a49429d6594e07b4bf4c5.avif"
     },
     {
         "franchise": "TOR",
@@ -11292,7 +11292,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d54b612f4e79466ebadc36ad2e9d3ef2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d54b612f4e79466ebadc36ad2e9d3ef2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d54b612f4e79466ebadc36ad2e9d3ef2.avif"
     },
     {
         "franchise": "TOR",
@@ -11307,7 +11307,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_07f2a08ecfbe48a39c1601cd568b31b2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_07f2a08ecfbe48a39c1601cd568b31b2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_07f2a08ecfbe48a39c1601cd568b31b2.avif"
     },
     {
         "franchise": "TOR",
@@ -11321,7 +11321,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dadf0c8083c749c591b77a2329b4afe1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dadf0c8083c749c591b77a2329b4afe1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dadf0c8083c749c591b77a2329b4afe1.avif"
     },
     {
         "franchise": "TOR",
@@ -11335,7 +11335,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88be1746e9c24ee395166919d335c38c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88be1746e9c24ee395166919d335c38c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88be1746e9c24ee395166919d335c38c.avif"
     },
     {
         "franchise": "TOR",
@@ -11349,7 +11349,7 @@
         "seasons": [
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_33b6acb46da4405594941e816a6fddb0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_33b6acb46da4405594941e816a6fddb0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_33b6acb46da4405594941e816a6fddb0.avif"
     },
     {
         "franchise": "TOR",
@@ -11364,7 +11364,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f86c024b2da24262ba207306e42b4639~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f86c024b2da24262ba207306e42b4639~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f86c024b2da24262ba207306e42b4639.avif"
     },
     {
         "franchise": "TOR",
@@ -11379,7 +11379,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0af4a8d100174e9b9f3712fa8e07b08b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0af4a8d100174e9b9f3712fa8e07b08b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0af4a8d100174e9b9f3712fa8e07b08b.avif"
     },
     {
         "franchise": "TOR",
@@ -11396,7 +11396,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0da38513f39c4f548d87fbaedc724192~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0da38513f39c4f548d87fbaedc724192~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0da38513f39c4f548d87fbaedc724192.avif"
     },
     {
         "franchise": "TOR",
@@ -11410,7 +11410,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4716c6f5f1f64cdcb2663ac44df23eb3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4716c6f5f1f64cdcb2663ac44df23eb3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4716c6f5f1f64cdcb2663ac44df23eb3.avif"
     },
     {
         "franchise": "TOR",
@@ -11425,7 +11425,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b45eaad859ad4d12971cc8faa1f03909~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b45eaad859ad4d12971cc8faa1f03909~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b45eaad859ad4d12971cc8faa1f03909.avif"
     },
     {
         "franchise": "TOR",
@@ -11440,7 +11440,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e7d289e5673941328751845c3a7566ce~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e7d289e5673941328751845c3a7566ce~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e7d289e5673941328751845c3a7566ce.avif"
     },
     {
         "franchise": "TOR",
@@ -11456,7 +11456,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7b5658fcd6984c4d8d485573ae5bf753~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7b5658fcd6984c4d8d485573ae5bf753~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7b5658fcd6984c4d8d485573ae5bf753.avif"
     },
     {
         "franchise": "TOR",
@@ -11471,7 +11471,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88f4cb16df0d4af5b690ba2ca6d1f798~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88f4cb16df0d4af5b690ba2ca6d1f798~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88f4cb16df0d4af5b690ba2ca6d1f798.avif"
     },
     {
         "franchise": "TOR",
@@ -11485,7 +11485,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d5d0a10520284ae6a1dc8dcca4e52741~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d5d0a10520284ae6a1dc8dcca4e52741~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d5d0a10520284ae6a1dc8dcca4e52741.avif"
     },
     {
         "franchise": "TOR",
@@ -11499,7 +11499,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ba9a3647c80b478f9907b17590de4fcf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ba9a3647c80b478f9907b17590de4fcf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ba9a3647c80b478f9907b17590de4fcf.avif"
     },
     {
         "franchise": "LAC",
@@ -11513,7 +11513,7 @@
         "seasons": [
             "1983-84"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e72b8a676a634b95999372494d547330~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e72b8a676a634b95999372494d547330~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e72b8a676a634b95999372494d547330.avif"
     },
     {
         "franchise": "LAC",
@@ -11534,7 +11534,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1bf6d46515de47a39fd50e367095e8b8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1bf6d46515de47a39fd50e367095e8b8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1bf6d46515de47a39fd50e367095e8b8.avif"
     },
     {
         "franchise": "LAC",
@@ -11551,7 +11551,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a326ada0c6f041b5b2f40825c09df98b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a326ada0c6f041b5b2f40825c09df98b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a326ada0c6f041b5b2f40825c09df98b.avif"
     },
     {
         "franchise": "LAC",
@@ -11566,7 +11566,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bff589a9f41b4ff5b755d898e5f458ff~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bff589a9f41b4ff5b755d898e5f458ff~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bff589a9f41b4ff5b755d898e5f458ff.avif"
     },
     {
         "franchise": "LAC",
@@ -11582,7 +11582,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c43e259f743141aea67d80bf662d025e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c43e259f743141aea67d80bf662d025e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c43e259f743141aea67d80bf662d025e.avif"
     },
     {
         "franchise": "LAC",
@@ -11596,7 +11596,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bad20c719da046b799398c9f6ae5f6c6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bad20c719da046b799398c9f6ae5f6c6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bad20c719da046b799398c9f6ae5f6c6.avif"
     },
     {
         "franchise": "LAC",
@@ -11610,7 +11610,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6c9022cad2d24c79b35fe306767cbf9a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6c9022cad2d24c79b35fe306767cbf9a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6c9022cad2d24c79b35fe306767cbf9a.avif"
     },
     {
         "franchise": "LAC",
@@ -11624,7 +11624,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_137a567b319849b88a2a3e8922cbe679~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_137a567b319849b88a2a3e8922cbe679~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_137a567b319849b88a2a3e8922cbe679.avif"
     },
     {
         "franchise": "LAC",
@@ -11638,7 +11638,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4f8401592c54cd1810e525033c7b667~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4f8401592c54cd1810e525033c7b667~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4f8401592c54cd1810e525033c7b667.avif"
     },
     {
         "franchise": "LAC",
@@ -11652,7 +11652,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5cf490aa216c488fbcfff7a7737736a5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5cf490aa216c488fbcfff7a7737736a5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5cf490aa216c488fbcfff7a7737736a5.avif"
     },
     {
         "franchise": "LAC",
@@ -11666,7 +11666,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bf4d5291e7ac447fbb632a86a7a31f24~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bf4d5291e7ac447fbb632a86a7a31f24~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bf4d5291e7ac447fbb632a86a7a31f24.avif"
     },
     {
         "franchise": "LAC",
@@ -11680,7 +11680,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_defce4a2592f4fe0bf0a29476da6c3c5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_defce4a2592f4fe0bf0a29476da6c3c5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_defce4a2592f4fe0bf0a29476da6c3c5.avif"
     },
     {
         "franchise": "LAC",
@@ -11694,7 +11694,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ad21284cb7cb48fe9b05430beaf09fbd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ad21284cb7cb48fe9b05430beaf09fbd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ad21284cb7cb48fe9b05430beaf09fbd.avif"
     },
     {
         "franchise": "LAC",
@@ -11709,7 +11709,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c6f327b2600d4265b62009f443810ce9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c6f327b2600d4265b62009f443810ce9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c6f327b2600d4265b62009f443810ce9.avif"
     },
     {
         "franchise": "LAC",
@@ -11724,7 +11724,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2d55ca11f1924f6d963b78054dcffc77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2d55ca11f1924f6d963b78054dcffc77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2d55ca11f1924f6d963b78054dcffc77.avif"
     },
     {
         "franchise": "LAC",
@@ -11740,7 +11740,7 @@
             "1976-77",
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_12ae2199b6164dde81c3cfb560e710a2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_12ae2199b6164dde81c3cfb560e710a2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_12ae2199b6164dde81c3cfb560e710a2.avif"
     },
     {
         "franchise": "LAC",
@@ -11755,7 +11755,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_583d11af9b464143968499332065e5b7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_583d11af9b464143968499332065e5b7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_583d11af9b464143968499332065e5b7.avif"
     },
     {
         "franchise": "LAC",
@@ -11769,7 +11769,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_53d54586ee324bcf89354da0ef9b467c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_53d54586ee324bcf89354da0ef9b467c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_53d54586ee324bcf89354da0ef9b467c.avif"
     },
     {
         "franchise": "LAC",
@@ -11783,7 +11783,7 @@
         "seasons": [
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a928d52359d642db89f49c28afce3ff3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a928d52359d642db89f49c28afce3ff3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a928d52359d642db89f49c28afce3ff3.avif"
     },
     {
         "franchise": "LAC",
@@ -11795,7 +11795,7 @@
         "endYear": 1984,
         "years": "1982-83 – 1983-84",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_e1b7970be2f34176bfcd002a64ea7fba~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e1b7970be2f34176bfcd002a64ea7fba~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e1b7970be2f34176bfcd002a64ea7fba.avif"
     },
     {
         "franchise": "LAC",
@@ -11810,7 +11810,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8eeb2156b5a042c1b6b90067c9d40a1f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8eeb2156b5a042c1b6b90067c9d40a1f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8eeb2156b5a042c1b6b90067c9d40a1f.avif"
     },
     {
         "franchise": "LAC",
@@ -11824,7 +11824,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c882edaff72c4eb7a72429c6caf67f89~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c882edaff72c4eb7a72429c6caf67f89~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c882edaff72c4eb7a72429c6caf67f89.avif"
     },
     {
         "franchise": "LAC",
@@ -11838,7 +11838,7 @@
         "seasons": [
             "1987-88"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8faf63c6cf0e4147a87891aa1d3c4609~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8faf63c6cf0e4147a87891aa1d3c4609~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8faf63c6cf0e4147a87891aa1d3c4609.avif"
     },
     {
         "franchise": "LAC",
@@ -11852,7 +11852,7 @@
         "seasons": [
             "1988-89"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9bb6fe9e0bcb4a3fbe09fc0f0b1271fa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9bb6fe9e0bcb4a3fbe09fc0f0b1271fa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9bb6fe9e0bcb4a3fbe09fc0f0b1271fa.avif"
     },
     {
         "franchise": "LAC",
@@ -11866,7 +11866,7 @@
         "seasons": [
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dd44d5f069ba4f69b588a0516e9524db~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dd44d5f069ba4f69b588a0516e9524db~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dd44d5f069ba4f69b588a0516e9524db.avif"
     },
     {
         "franchise": "LAC",
@@ -11883,7 +11883,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b4a855d56be7462eae8c80b4c2972230~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b4a855d56be7462eae8c80b4c2972230~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b4a855d56be7462eae8c80b4c2972230.avif"
     },
     {
         "franchise": "LAC",
@@ -11900,7 +11900,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_79de7a72075241d290039098bfe6b95b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_79de7a72075241d290039098bfe6b95b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_79de7a72075241d290039098bfe6b95b.avif"
     },
     {
         "franchise": "LAC",
@@ -11914,7 +11914,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fa775adf77274e5aa708dce12de1fd76~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fa775adf77274e5aa708dce12de1fd76~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fa775adf77274e5aa708dce12de1fd76.avif"
     },
     {
         "franchise": "LAC",
@@ -11928,7 +11928,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f91dd9e7de824315b73da5a10a83622d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f91dd9e7de824315b73da5a10a83622d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f91dd9e7de824315b73da5a10a83622d.avif"
     },
     {
         "franchise": "LAC",
@@ -11950,7 +11950,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c19cc3aa6ee44c1dafc2cc4e162d4646~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c19cc3aa6ee44c1dafc2cc4e162d4646~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c19cc3aa6ee44c1dafc2cc4e162d4646.avif"
     },
     {
         "franchise": "LAC",
@@ -11964,7 +11964,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe9ee959fadf4f58a0d650db7553808c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe9ee959fadf4f58a0d650db7553808c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe9ee959fadf4f58a0d650db7553808c.avif"
     },
     {
         "franchise": "LAC",
@@ -11981,7 +11981,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0a03688275554a5f92a3311317fac755~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0a03688275554a5f92a3311317fac755~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0a03688275554a5f92a3311317fac755.avif"
     },
     {
         "franchise": "LAC",
@@ -11995,7 +11995,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_402234cdb5e544f9a616a1083c657e77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_402234cdb5e544f9a616a1083c657e77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_402234cdb5e544f9a616a1083c657e77.avif"
     },
     {
         "franchise": "LAC",
@@ -12010,7 +12010,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2a1d39d7bc4742928449e6e4fe5c12d6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2a1d39d7bc4742928449e6e4fe5c12d6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2a1d39d7bc4742928449e6e4fe5c12d6.avif"
     },
     {
         "franchise": "LAC",
@@ -12028,7 +12028,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f9a7e0f9766a470e84488a6907076aee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f9a7e0f9766a470e84488a6907076aee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f9a7e0f9766a470e84488a6907076aee.avif"
     },
     {
         "franchise": "LAC",
@@ -12042,7 +12042,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e384f27d94af4558ba691cb86baa4a81~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e384f27d94af4558ba691cb86baa4a81~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e384f27d94af4558ba691cb86baa4a81.avif"
     },
     {
         "franchise": "LAC",
@@ -12056,7 +12056,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ef2c5a57edf44c5baedcbd4c3985ebfd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ef2c5a57edf44c5baedcbd4c3985ebfd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ef2c5a57edf44c5baedcbd4c3985ebfd.avif"
     },
     {
         "franchise": "LAC",
@@ -12070,7 +12070,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f5f7cf97697a49049e959c38e90d68cd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f5f7cf97697a49049e959c38e90d68cd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f5f7cf97697a49049e959c38e90d68cd.avif"
     },
     {
         "franchise": "VIR",
@@ -12085,7 +12085,7 @@
             "1967-68",
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a6d6a1a7bc8c4a32b2624aa985452395~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a6d6a1a7bc8c4a32b2624aa985452395~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a6d6a1a7bc8c4a32b2624aa985452395.avif"
     },
     {
         "franchise": "VIR",
@@ -12099,7 +12099,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_eaee25c5f9844919a7c7a479462e47a2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_eaee25c5f9844919a7c7a479462e47a2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_eaee25c5f9844919a7c7a479462e47a2.avif"
     },
     {
         "franchise": "VIR",
@@ -12113,7 +12113,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_853f4d0e861f48db8276c6853747f0a9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_853f4d0e861f48db8276c6853747f0a9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_853f4d0e861f48db8276c6853747f0a9.avif"
     },
     {
         "franchise": "VIR",
@@ -12127,7 +12127,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e6614c18c2b7485cb322f3e7a2297f7f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e6614c18c2b7485cb322f3e7a2297f7f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e6614c18c2b7485cb322f3e7a2297f7f.avif"
     },
     {
         "franchise": "VIR",
@@ -12141,7 +12141,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e215a0c1fb534ae29ad459413ad5777a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e215a0c1fb534ae29ad459413ad5777a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e215a0c1fb534ae29ad459413ad5777a.avif"
     },
     {
         "franchise": "VIR",
@@ -12156,7 +12156,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c0f21e5c4c4d4eafb556ec0f2721c49a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c0f21e5c4c4d4eafb556ec0f2721c49a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c0f21e5c4c4d4eafb556ec0f2721c49a.avif"
     },
     {
         "franchise": "VIR",
@@ -12170,7 +12170,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8dce0ad90ad9481ba7e904300ef205cb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8dce0ad90ad9481ba7e904300ef205cb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8dce0ad90ad9481ba7e904300ef205cb.avif"
     },
     {
         "franchise": "VIR",
@@ -12184,7 +12184,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_967514f8974a4c1cb9eb0ba0d81edde6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_967514f8974a4c1cb9eb0ba0d81edde6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_967514f8974a4c1cb9eb0ba0d81edde6.avif"
     },
     {
         "franchise": "FLO",
@@ -12198,7 +12198,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6ecd5c62818644b9a30e93f5d86cf72c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6ecd5c62818644b9a30e93f5d86cf72c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6ecd5c62818644b9a30e93f5d86cf72c.avif"
     },
     {
         "franchise": "FLO",
@@ -12213,7 +12213,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b8a28e84ea2541a2b4d6c8125a8372b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b8a28e84ea2541a2b4d6c8125a8372b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b8a28e84ea2541a2b4d6c8125a8372b1.avif"
     },
     {
         "franchise": "FLO",
@@ -12227,7 +12227,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ecc97ba2f47b445381d9017f7bde58e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ecc97ba2f47b445381d9017f7bde58e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ecc97ba2f47b445381d9017f7bde58e0.avif"
     },
     {
         "franchise": "FLO",
@@ -12242,7 +12242,7 @@
             "1970-71",
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2e60154d05db4ecfb1dddecf58090cc7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2e60154d05db4ecfb1dddecf58090cc7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2e60154d05db4ecfb1dddecf58090cc7.avif"
     },
     {
         "franchise": "SSL",
@@ -12257,7 +12257,7 @@
             "1967-68",
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bbf1923433f844bf8f20090240b43fb8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bbf1923433f844bf8f20090240b43fb8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bbf1923433f844bf8f20090240b43fb8.avif"
     },
     {
         "franchise": "SSL",
@@ -12272,7 +12272,7 @@
             "1969-70",
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_863f597aaabc442fbb9eaeb6864fa281~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_863f597aaabc442fbb9eaeb6864fa281~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_863f597aaabc442fbb9eaeb6864fa281.avif"
     },
     {
         "franchise": "SSL",
@@ -12287,7 +12287,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f77e87f02e2a455286c2aaa962ac754a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f77e87f02e2a455286c2aaa962ac754a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f77e87f02e2a455286c2aaa962ac754a.avif"
     },
     {
         "franchise": "SSL",
@@ -12302,7 +12302,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a038570f83d44670bbf4b7882f4e070b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a038570f83d44670bbf4b7882f4e070b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a038570f83d44670bbf4b7882f4e070b.avif"
     },
     {
         "franchise": "SSL",
@@ -12317,7 +12317,7 @@
             "1974-75",
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c471e214a514a5d8e92325459429724~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c471e214a514a5d8e92325459429724~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c471e214a514a5d8e92325459429724.avif"
     },
     {
         "franchise": "",
@@ -12331,7 +12331,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e29899137c914652a72f2a2a26e1f558~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e29899137c914652a72f2a2a26e1f558~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e29899137c914652a72f2a2a26e1f558.avif"
     },
     {
         "franchise": "",
@@ -12345,7 +12345,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b89674a339b34bc1aa1eb7f251467c62~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b89674a339b34bc1aa1eb7f251467c62~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b89674a339b34bc1aa1eb7f251467c62.avif"
     },
     {
         "franchise": "",
@@ -12359,7 +12359,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0445db1585044c83a7f00934ef8dd369~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0445db1585044c83a7f00934ef8dd369~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0445db1585044c83a7f00934ef8dd369.avif"
     },
     {
         "franchise": "",
@@ -12373,7 +12373,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a0e9505cf940474e9ec1945e204c5384~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a0e9505cf940474e9ec1945e204c5384~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a0e9505cf940474e9ec1945e204c5384.avif"
     },
     {
         "franchise": "",
@@ -12387,7 +12387,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d485b9fbb0354117af036ec649848798~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d485b9fbb0354117af036ec649848798~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d485b9fbb0354117af036ec649848798.avif"
     },
     {
         "franchise": "",
@@ -12401,7 +12401,7 @@
         "seasons": [
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d8e7e0560a784f328f46621c8687e637~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d8e7e0560a784f328f46621c8687e637~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d8e7e0560a784f328f46621c8687e637.avif"
     },
     {
         "franchise": "",
@@ -12415,7 +12415,7 @@
         "seasons": [
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_244d9e1ee3f14fa79400dca7691aa000~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_244d9e1ee3f14fa79400dca7691aa000~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_244d9e1ee3f14fa79400dca7691aa000.avif"
     },
     {
         "franchise": "",
@@ -12429,7 +12429,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2f6a7065684e482fac3d76252c8d8663~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2f6a7065684e482fac3d76252c8d8663~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2f6a7065684e482fac3d76252c8d8663.avif"
     },
     {
         "franchise": "",
@@ -12443,7 +12443,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_457920d5d868457a83c79416f0bf3b5f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_457920d5d868457a83c79416f0bf3b5f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_457920d5d868457a83c79416f0bf3b5f.avif"
     },
     {
         "franchise": "NYK",
@@ -12457,7 +12457,7 @@
         "seasons": [
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe2cf65acbf74fe797d3ca6c8812dd6d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe2cf65acbf74fe797d3ca6c8812dd6d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe2cf65acbf74fe797d3ca6c8812dd6d.avif"
     },
     {
         "franchise": "NYK",
@@ -12471,7 +12471,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0abb083557e84c13b732b76bf359080c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0abb083557e84c13b732b76bf359080c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0abb083557e84c13b732b76bf359080c.avif"
     },
     {
         "franchise": "NYK",
@@ -12485,7 +12485,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d85792ad8d984fda9664117d3750434d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d85792ad8d984fda9664117d3750434d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d85792ad8d984fda9664117d3750434d.avif"
     },
     {
         "franchise": "NYK",
@@ -12500,7 +12500,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ac852c8d543249fda123220dad481f46~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ac852c8d543249fda123220dad481f46~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ac852c8d543249fda123220dad481f46.avif"
     },
     {
         "franchise": "NYK",
@@ -12514,7 +12514,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c685bac5ab1341019cb3624d9329ae18~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c685bac5ab1341019cb3624d9329ae18~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c685bac5ab1341019cb3624d9329ae18.avif"
     },
     {
         "franchise": "NYK",
@@ -12528,7 +12528,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6daad82682454c09b5c30144980dfc02~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6daad82682454c09b5c30144980dfc02~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6daad82682454c09b5c30144980dfc02.avif"
     },
     {
         "franchise": "NYK",
@@ -12542,7 +12542,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f353c7d2e3ab4d1a95aa11dcac501528~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f353c7d2e3ab4d1a95aa11dcac501528~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f353c7d2e3ab4d1a95aa11dcac501528.avif"
     },
     {
         "franchise": "NYK",
@@ -12556,7 +12556,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_261e47c754a8496a812042913535a144~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_261e47c754a8496a812042913535a144~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_261e47c754a8496a812042913535a144.avif"
     },
     {
         "franchise": "NYK",
@@ -12570,7 +12570,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bace8284f68542a088b9d07093f4c2f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bace8284f68542a088b9d07093f4c2f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bace8284f68542a088b9d07093f4c2f8.avif"
     },
     {
         "franchise": "NYK",
@@ -12584,7 +12584,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_58b1dd1103c946f0aff5f1a71119f6f6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_58b1dd1103c946f0aff5f1a71119f6f6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_58b1dd1103c946f0aff5f1a71119f6f6.avif"
     },
     {
         "franchise": "NYK",
@@ -12604,7 +12604,7 @@
             "1951-52",
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_50220249ce7740c1aadd9f792a2bd9e1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50220249ce7740c1aadd9f792a2bd9e1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50220249ce7740c1aadd9f792a2bd9e1.avif"
     },
     {
         "franchise": "NYK",
@@ -12624,7 +12624,7 @@
             "1951-52",
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_254d093d17734af785f3d0abdf898fd4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_254d093d17734af785f3d0abdf898fd4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_254d093d17734af785f3d0abdf898fd4.avif"
     },
     {
         "franchise": "NYK",
@@ -12646,7 +12646,7 @@
             "1960-61",
             "1961-62"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_790168d99cde4d3bb41422471c4cedea~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_790168d99cde4d3bb41422471c4cedea~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_790168d99cde4d3bb41422471c4cedea.avif"
     },
     {
         "franchise": "NYK",
@@ -12662,7 +12662,7 @@
             "1963-64",
             "1964-65"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_97775f250b1e40edb53205f6e5907300~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_97775f250b1e40edb53205f6e5907300~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_97775f250b1e40edb53205f6e5907300.avif"
     },
     {
         "franchise": "NYK",
@@ -12678,7 +12678,7 @@
             "1966-67",
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2693a126dd87438fa98fb0ff3d5aac27~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2693a126dd87438fa98fb0ff3d5aac27~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2693a126dd87438fa98fb0ff3d5aac27.avif"
     },
     {
         "franchise": "NYK",
@@ -12692,7 +12692,7 @@
         "seasons": [
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_22ddfe3e56b44bf6925aad865281a4ee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_22ddfe3e56b44bf6925aad865281a4ee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_22ddfe3e56b44bf6925aad865281a4ee.avif"
     },
     {
         "franchise": "NYK",
@@ -12706,7 +12706,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b8beb426c67d4f49a1d9dbf6c697744c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b8beb426c67d4f49a1d9dbf6c697744c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b8beb426c67d4f49a1d9dbf6c697744c.avif"
     },
     {
         "franchise": "NYK",
@@ -12720,7 +12720,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6a62126162f94a188d671f8a8192de4c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6a62126162f94a188d671f8a8192de4c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6a62126162f94a188d671f8a8192de4c.avif"
     },
     {
         "franchise": "NYK",
@@ -12740,7 +12740,7 @@
             "1976-77",
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b715aba4d5cb4c0dbf7d607a6000feba~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b715aba4d5cb4c0dbf7d607a6000feba~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b715aba4d5cb4c0dbf7d607a6000feba.avif"
     },
     {
         "franchise": "NYK",
@@ -12754,7 +12754,7 @@
         "seasons": [
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7a5414cad4074cd18960ec2528c3b316~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7a5414cad4074cd18960ec2528c3b316~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7a5414cad4074cd18960ec2528c3b316.avif"
     },
     {
         "franchise": "NYK",
@@ -12769,7 +12769,7 @@
             "1979-80",
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cff3579fffe0464e818d2749c84ff6c0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cff3579fffe0464e818d2749c84ff6c0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cff3579fffe0464e818d2749c84ff6c0.avif"
     },
     {
         "franchise": "NYK",
@@ -12783,7 +12783,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_81c4cc1404aa4b1eb43fcf4cc95c9b1f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_81c4cc1404aa4b1eb43fcf4cc95c9b1f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_81c4cc1404aa4b1eb43fcf4cc95c9b1f.avif"
     },
     {
         "franchise": "NYK",
@@ -12797,7 +12797,7 @@
         "seasons": [
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2d3ab2bc926d4449b8adf8dfcb0c1f8f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2d3ab2bc926d4449b8adf8dfcb0c1f8f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2d3ab2bc926d4449b8adf8dfcb0c1f8f.avif"
     },
     {
         "franchise": "NYK",
@@ -12813,7 +12813,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_97cdca32f59f470091d8e68841c664c7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_97cdca32f59f470091d8e68841c664c7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_97cdca32f59f470091d8e68841c664c7.avif"
     },
     {
         "franchise": "NYK",
@@ -12827,7 +12827,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ce3f6b149f734a94961b9bf5c8282da1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ce3f6b149f734a94961b9bf5c8282da1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ce3f6b149f734a94961b9bf5c8282da1.avif"
     },
     {
         "franchise": "NYK",
@@ -12844,7 +12844,7 @@
             "1989-90",
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b05ea27c462a491b930ba854337811ec~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b05ea27c462a491b930ba854337811ec~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b05ea27c462a491b930ba854337811ec.avif"
     },
     {
         "franchise": "NYK",
@@ -12858,7 +12858,7 @@
         "seasons": [
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7efa328f119e4dd1b925b4252a720200~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7efa328f119e4dd1b925b4252a720200~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7efa328f119e4dd1b925b4252a720200.avif"
     },
     {
         "franchise": "NYK",
@@ -12873,7 +12873,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_08918c16c0ae4c5988e4d6a19f4466af~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_08918c16c0ae4c5988e4d6a19f4466af~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_08918c16c0ae4c5988e4d6a19f4466af.avif"
     },
     {
         "franchise": "NYK",
@@ -12887,7 +12887,7 @@
         "seasons": [
             "1994-95"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c41dc347a2994a83ade69ca2abd992bf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c41dc347a2994a83ade69ca2abd992bf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c41dc347a2994a83ade69ca2abd992bf.avif"
     },
     {
         "franchise": "NYK",
@@ -12901,7 +12901,7 @@
         "seasons": [
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a2e430ccf0354f83b6c6999ac36261b2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a2e430ccf0354f83b6c6999ac36261b2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a2e430ccf0354f83b6c6999ac36261b2.avif"
     },
     {
         "franchise": "NYK",
@@ -12915,7 +12915,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_579c40b8ae5245f68874c1160402c18a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_579c40b8ae5245f68874c1160402c18a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_579c40b8ae5245f68874c1160402c18a.avif"
     },
     {
         "franchise": "NYK",
@@ -12930,7 +12930,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2285b3992ddf4414892627db423173a5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2285b3992ddf4414892627db423173a5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2285b3992ddf4414892627db423173a5.avif"
     },
     {
         "franchise": "NYK",
@@ -12945,7 +12945,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_696b665f180d4fcaa9300352f550c66f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_696b665f180d4fcaa9300352f550c66f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_696b665f180d4fcaa9300352f550c66f.avif"
     },
     {
         "franchise": "NYK",
@@ -12959,7 +12959,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f4a532622135452badc3456e4c31e150~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f4a532622135452badc3456e4c31e150~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f4a532622135452badc3456e4c31e150.avif"
     },
     {
         "franchise": "NYK",
@@ -12976,7 +12976,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5276c9ba674946c5aa94a7bacf0ab0f7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5276c9ba674946c5aa94a7bacf0ab0f7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5276c9ba674946c5aa94a7bacf0ab0f7.avif"
     },
     {
         "franchise": "NYK",
@@ -12993,7 +12993,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f54dfe5875114dbdb9500136c29237d3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f54dfe5875114dbdb9500136c29237d3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f54dfe5875114dbdb9500136c29237d3.avif"
     },
     {
         "franchise": "NYK",
@@ -13007,7 +13007,7 @@
         "seasons": [
             "2010-11"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4b89e390df0b4096b14bf86aaf992b98~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4b89e390df0b4096b14bf86aaf992b98~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4b89e390df0b4096b14bf86aaf992b98.avif"
     },
     {
         "franchise": "NYK",
@@ -13021,7 +13021,7 @@
         "seasons": [
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_426a6171a65940b9923d21e0d8abcc89~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_426a6171a65940b9923d21e0d8abcc89~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_426a6171a65940b9923d21e0d8abcc89.avif"
     },
     {
         "franchise": "NYK",
@@ -13036,7 +13036,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8a1c28f16dd64564beea65f059f8eab2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8a1c28f16dd64564beea65f059f8eab2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8a1c28f16dd64564beea65f059f8eab2.avif"
     },
     {
         "franchise": "NYK",
@@ -13052,7 +13052,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f86e10f4219f4166b360efa5d8010c97~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f86e10f4219f4166b360efa5d8010c97~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f86e10f4219f4166b360efa5d8010c97.avif"
     },
     {
         "franchise": "NYK",
@@ -13070,7 +13070,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4e2b889385d4d06942fdab6adc62d74~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4e2b889385d4d06942fdab6adc62d74~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4e2b889385d4d06942fdab6adc62d74.avif"
     },
     {
         "franchise": "NYK",
@@ -13084,7 +13084,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5c1bb9d15b2e40b8aed73be6e1e8d9e1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5c1bb9d15b2e40b8aed73be6e1e8d9e1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5c1bb9d15b2e40b8aed73be6e1e8d9e1.avif"
     },
     {
         "franchise": "NYK",
@@ -13098,7 +13098,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7e7a2c6c0b9e4e0baae2daccd03f5c34~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7e7a2c6c0b9e4e0baae2daccd03f5c34~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7e7a2c6c0b9e4e0baae2daccd03f5c34.avif"
     },
     {
         "franchise": "MMS",
@@ -13112,7 +13112,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ee751f0d1a80486c9e95980412a38a5c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ee751f0d1a80486c9e95980412a38a5c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ee751f0d1a80486c9e95980412a38a5c.avif"
     },
     {
         "franchise": "MMS",
@@ -13124,7 +13124,7 @@
         "endYear": 1969,
         "years": "1968-69",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_97fe1c975bd447a5bbbd6d1d9a8e0438~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_97fe1c975bd447a5bbbd6d1d9a8e0438~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_97fe1c975bd447a5bbbd6d1d9a8e0438.avif"
     },
     {
         "franchise": "MMS",
@@ -13138,7 +13138,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_54d8653923ce4cf7b07041acb8c6bcfa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_54d8653923ce4cf7b07041acb8c6bcfa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_54d8653923ce4cf7b07041acb8c6bcfa.avif"
     },
     {
         "franchise": "MMS",
@@ -13152,7 +13152,7 @@
         "seasons": [
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e8022c48bd694165b5fb5a293e9f0ad1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e8022c48bd694165b5fb5a293e9f0ad1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e8022c48bd694165b5fb5a293e9f0ad1.avif"
     },
     {
         "franchise": "MMS",
@@ -13167,7 +13167,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2361c6de677a4fda84cfe2b3c8233e7e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2361c6de677a4fda84cfe2b3c8233e7e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2361c6de677a4fda84cfe2b3c8233e7e.avif"
     },
     {
         "franchise": "MMS",
@@ -13182,7 +13182,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0c56d2df2c904186af30573828465f5c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0c56d2df2c904186af30573828465f5c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0c56d2df2c904186af30573828465f5c.avif"
     },
     {
         "franchise": "MMS",
@@ -13197,7 +13197,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0e57e8ff41bb45aa8192c4691f42e006~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0e57e8ff41bb45aa8192c4691f42e006~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0e57e8ff41bb45aa8192c4691f42e006.avif"
     },
     {
         "franchise": "MMS",
@@ -13212,7 +13212,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f66fde12c44f4d6483e05181c06cae36~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f66fde12c44f4d6483e05181c06cae36~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f66fde12c44f4d6483e05181c06cae36.avif"
     },
     {
         "franchise": "MMS",
@@ -13227,7 +13227,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0a06eaf0a6147d8a467f8a324c68b88~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0a06eaf0a6147d8a467f8a324c68b88~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0a06eaf0a6147d8a467f8a324c68b88.avif"
     },
     {
         "franchise": "MMS",
@@ -13242,7 +13242,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6c367d5e5514463186d3e8a313454ace~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6c367d5e5514463186d3e8a313454ace~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6c367d5e5514463186d3e8a313454ace.avif"
     },
     {
         "franchise": "MMS",
@@ -13257,7 +13257,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e054fb48cda848068fdecc5202d64674~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e054fb48cda848068fdecc5202d64674~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e054fb48cda848068fdecc5202d64674.avif"
     },
     {
         "franchise": "MMS",
@@ -13271,7 +13271,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bc35321c40394016a27f840a3f0dca58~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bc35321c40394016a27f840a3f0dca58~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bc35321c40394016a27f840a3f0dca58.avif"
     },
     {
         "franchise": "IND",
@@ -13286,7 +13286,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4c70a9a0421546cdbf5f03f47d09848b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4c70a9a0421546cdbf5f03f47d09848b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4c70a9a0421546cdbf5f03f47d09848b.avif"
     },
     {
         "franchise": "IND",
@@ -13300,7 +13300,7 @@
         "seasons": [
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d30f0aefdc36451ba08d3599988726ca~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d30f0aefdc36451ba08d3599988726ca~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d30f0aefdc36451ba08d3599988726ca.avif"
     },
     {
         "franchise": "IND",
@@ -13318,7 +13318,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7c354bcade18496995a2f19a914cdfa1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7c354bcade18496995a2f19a914cdfa1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7c354bcade18496995a2f19a914cdfa1.avif"
     },
     {
         "franchise": "IND",
@@ -13332,7 +13332,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_13241aa804d44bf7a6beea681882e092~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_13241aa804d44bf7a6beea681882e092~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_13241aa804d44bf7a6beea681882e092.avif"
     },
     {
         "franchise": "IND",
@@ -13352,7 +13352,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a44d8c9e8d43425eb90da3c3540654d2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a44d8c9e8d43425eb90da3c3540654d2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a44d8c9e8d43425eb90da3c3540654d2.avif"
     },
     {
         "franchise": "IND",
@@ -13368,7 +13368,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b290036e5e7c4600b3e96c4efe7468eb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b290036e5e7c4600b3e96c4efe7468eb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b290036e5e7c4600b3e96c4efe7468eb.avif"
     },
     {
         "franchise": "IND",
@@ -13383,7 +13383,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bc2eb1288e8e481ab49a2d0347c60458~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bc2eb1288e8e481ab49a2d0347c60458~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bc2eb1288e8e481ab49a2d0347c60458.avif"
     },
     {
         "franchise": "IND",
@@ -13397,7 +13397,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_aadd08013da7454296c7156fe8160a52~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_aadd08013da7454296c7156fe8160a52~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_aadd08013da7454296c7156fe8160a52.avif"
     },
     {
         "franchise": "IND",
@@ -13412,7 +13412,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4c5f30ea03064fe0895e8d688bc81769~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4c5f30ea03064fe0895e8d688bc81769~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4c5f30ea03064fe0895e8d688bc81769.avif"
     },
     {
         "franchise": "IND",
@@ -13426,7 +13426,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_54ac51cc7770439c908c6d420d941d3c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_54ac51cc7770439c908c6d420d941d3c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_54ac51cc7770439c908c6d420d941d3c.avif"
     },
     {
         "franchise": "IND",
@@ -13440,7 +13440,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f83f3410193e4e8b86ee7d42e9e60eb0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f83f3410193e4e8b86ee7d42e9e60eb0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f83f3410193e4e8b86ee7d42e9e60eb0.avif"
     },
     {
         "franchise": "IND",
@@ -13452,7 +13452,7 @@
         "endYear": 1969,
         "years": "1967-68 – 1968-69",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_d31c26ce6fec4dc79e284071ca8ab10f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d31c26ce6fec4dc79e284071ca8ab10f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d31c26ce6fec4dc79e284071ca8ab10f.avif"
     },
     {
         "franchise": "IND",
@@ -13464,7 +13464,7 @@
         "endYear": 1970,
         "years": "1969-70",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_509e9b5a1a934af5bc82e5ca293cdd47~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_509e9b5a1a934af5bc82e5ca293cdd47~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_509e9b5a1a934af5bc82e5ca293cdd47.avif"
     },
     {
         "franchise": "IND",
@@ -13476,7 +13476,7 @@
         "endYear": 1971,
         "years": "1970-71",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_1f45b999c25c4137b6256e361011edab~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1f45b999c25c4137b6256e361011edab~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1f45b999c25c4137b6256e361011edab.avif"
     },
     {
         "franchise": "IND",
@@ -13488,7 +13488,7 @@
         "endYear": 1974,
         "years": "1971-72 – 1973-74",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_186c58e9cfd64c7f8e1b738c40014d93~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_186c58e9cfd64c7f8e1b738c40014d93~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_186c58e9cfd64c7f8e1b738c40014d93.avif"
     },
     {
         "franchise": "IND",
@@ -13500,7 +13500,7 @@
         "endYear": 1976,
         "years": "1974-75 – 1975-76",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_b51f200517d54f34bc30e0e350f67f58~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b51f200517d54f34bc30e0e350f67f58~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b51f200517d54f34bc30e0e350f67f58.avif"
     },
     {
         "franchise": "IND",
@@ -13514,7 +13514,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_35fb793e850a4d88b1fa6c2ec297992f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_35fb793e850a4d88b1fa6c2ec297992f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_35fb793e850a4d88b1fa6c2ec297992f.avif"
     },
     {
         "franchise": "IND",
@@ -13528,7 +13528,7 @@
         "seasons": [
             "1977-78"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8cdd97cf7f9f4206953154833586ad28~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8cdd97cf7f9f4206953154833586ad28~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8cdd97cf7f9f4206953154833586ad28.avif"
     },
     {
         "franchise": "IND",
@@ -13543,7 +13543,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0977c4713b8a4b5b92320044d4a3b490~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0977c4713b8a4b5b92320044d4a3b490~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0977c4713b8a4b5b92320044d4a3b490.avif"
     },
     {
         "franchise": "IND",
@@ -13557,7 +13557,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e7ace95d55694163b80705d835d39395~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e7ace95d55694163b80705d835d39395~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e7ace95d55694163b80705d835d39395.avif"
     },
     {
         "franchise": "IND",
@@ -13571,7 +13571,7 @@
         "seasons": [
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e92cc2d21bb84aacaf3381c3fd22998c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e92cc2d21bb84aacaf3381c3fd22998c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e92cc2d21bb84aacaf3381c3fd22998c.avif"
     },
     {
         "franchise": "IND",
@@ -13585,7 +13585,7 @@
         "seasons": [
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c722fec327a3444da86421ec2970efbf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c722fec327a3444da86421ec2970efbf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c722fec327a3444da86421ec2970efbf.avif"
     },
     {
         "franchise": "IND",
@@ -13600,7 +13600,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5dcfb77eb4e945749d979924e5513c8f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5dcfb77eb4e945749d979924e5513c8f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5dcfb77eb4e945749d979924e5513c8f.avif"
     },
     {
         "franchise": "IND",
@@ -13614,7 +13614,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_22db7b3ea9074422814731d81c06bcc8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_22db7b3ea9074422814731d81c06bcc8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_22db7b3ea9074422814731d81c06bcc8.avif"
     },
     {
         "franchise": "IND",
@@ -13628,7 +13628,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88fd6826a13440dba0f5645faa33300b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88fd6826a13440dba0f5645faa33300b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88fd6826a13440dba0f5645faa33300b.avif"
     },
     {
         "franchise": "IND",
@@ -13644,7 +13644,7 @@
             "1988-89",
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_98b21c697b5c492ca178998f902b00f9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_98b21c697b5c492ca178998f902b00f9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_98b21c697b5c492ca178998f902b00f9.avif"
     },
     {
         "franchise": "IND",
@@ -13661,7 +13661,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e41a111d495342c9adcd270e72988ca3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e41a111d495342c9adcd270e72988ca3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e41a111d495342c9adcd270e72988ca3.avif"
     },
     {
         "franchise": "IND",
@@ -13676,7 +13676,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_21373b1ea8744030aec8ee52ba22770c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_21373b1ea8744030aec8ee52ba22770c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_21373b1ea8744030aec8ee52ba22770c.avif"
     },
     {
         "franchise": "IND",
@@ -13690,7 +13690,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d1e55dda96da4c41a2edf12cb61ec4e4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d1e55dda96da4c41a2edf12cb61ec4e4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d1e55dda96da4c41a2edf12cb61ec4e4.avif"
     },
     {
         "franchise": "IND",
@@ -13705,7 +13705,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_624e7175d6df435aa9fe7641fe69e3d5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_624e7175d6df435aa9fe7641fe69e3d5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_624e7175d6df435aa9fe7641fe69e3d5.avif"
     },
     {
         "franchise": "IND",
@@ -13723,7 +13723,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e93c1ccfe82e4f8f8db772e8c2cd769f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e93c1ccfe82e4f8f8db772e8c2cd769f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e93c1ccfe82e4f8f8db772e8c2cd769f.avif"
     },
     {
         "franchise": "IND",
@@ -13737,7 +13737,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1ba48f74055b4c13b332d08ec38c5230~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1ba48f74055b4c13b332d08ec38c5230~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1ba48f74055b4c13b332d08ec38c5230.avif"
     },
     {
         "franchise": "IND",
@@ -13752,7 +13752,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0039d2fb681941d9b6da9c12ba21e417~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0039d2fb681941d9b6da9c12ba21e417~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0039d2fb681941d9b6da9c12ba21e417.avif"
     },
     {
         "franchise": "IND",
@@ -13764,7 +13764,7 @@
         "endYear": 2014,
         "years": "2006-07 – 2013-14",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_dfb70c62be234fe380c4442fd2bf1105~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dfb70c62be234fe380c4442fd2bf1105~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dfb70c62be234fe380c4442fd2bf1105.avif"
     },
     {
         "franchise": "IND",
@@ -13780,7 +13780,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1fc5c08a96744ba0b71a67dd88b71ec9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1fc5c08a96744ba0b71a67dd88b71ec9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1fc5c08a96744ba0b71a67dd88b71ec9.avif"
     },
     {
         "franchise": "IND",
@@ -13798,7 +13798,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4f9692ca30f54f208bc535bbea7531f9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4f9692ca30f54f208bc535bbea7531f9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4f9692ca30f54f208bc535bbea7531f9.avif"
     },
     {
         "franchise": "IND",
@@ -13812,7 +13812,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3620fc2d843344b797e842e169c27480~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3620fc2d843344b797e842e169c27480~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3620fc2d843344b797e842e169c27480.avif"
     },
     {
         "franchise": "IND",
@@ -13826,7 +13826,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_79c28713af40420d9d47074c2b30d60d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_79c28713af40420d9d47074c2b30d60d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_79c28713af40420d9d47074c2b30d60d.avif"
     },
     {
         "franchise": "PRO",
@@ -13840,7 +13840,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8c497a177b8f4e4b95158e8f2a24c228~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8c497a177b8f4e4b95158e8f2a24c228~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8c497a177b8f4e4b95158e8f2a24c228.avif"
     },
     {
         "franchise": "PRO",
@@ -13854,7 +13854,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_37d4c98fe75f4dca9899fe24704d87c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_37d4c98fe75f4dca9899fe24704d87c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_37d4c98fe75f4dca9899fe24704d87c4.avif"
     },
     {
         "franchise": "PRO",
@@ -13868,7 +13868,7 @@
         "seasons": [
             "1947-48"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6f9f57c648aa40b68709bd1e58085d61~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6f9f57c648aa40b68709bd1e58085d61~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6f9f57c648aa40b68709bd1e58085d61.avif"
     },
     {
         "franchise": "PRO",
@@ -13882,7 +13882,7 @@
         "seasons": [
             "1947-48"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b3c453080b0c43e1b2982ce9ac4bc84b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b3c453080b0c43e1b2982ce9ac4bc84b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b3c453080b0c43e1b2982ce9ac4bc84b.avif"
     },
     {
         "franchise": "PRO",
@@ -13896,7 +13896,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_80a7f5d40155461481bebe4eb8f33540~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_80a7f5d40155461481bebe4eb8f33540~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_80a7f5d40155461481bebe4eb8f33540.avif"
     },
     {
         "franchise": "",
@@ -13910,7 +13910,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f1425eb7ee3c4acb85af92b7ad02d211~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f1425eb7ee3c4acb85af92b7ad02d211~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f1425eb7ee3c4acb85af92b7ad02d211.avif"
     },
     {
         "franchise": "TRH",
@@ -13924,7 +13924,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9fb25e7916be4b1ab52f05685c35c151~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9fb25e7916be4b1ab52f05685c35c151~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9fb25e7916be4b1ab52f05685c35c151.avif"
     },
     {
         "franchise": "",
@@ -13938,7 +13938,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_014073fae8834eecbe884fc506d337b1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_014073fae8834eecbe884fc506d337b1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_014073fae8834eecbe884fc506d337b1.avif"
     },
     {
         "franchise": "CLR",
@@ -13952,7 +13952,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c0f3f48e77594f839e27a160afc4c569~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c0f3f48e77594f839e27a160afc4c569~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c0f3f48e77594f839e27a160afc4c569.avif"
     },
     {
         "franchise": "CHS",
@@ -13969,7 +13969,7 @@
             "1948-49",
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fb45844d9a1a49f9a5ce2f7aed9a3313~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fb45844d9a1a49f9a5ce2f7aed9a3313~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fb45844d9a1a49f9a5ce2f7aed9a3313.avif"
     },
     {
         "franchise": "STB",
@@ -13986,7 +13986,7 @@
             "1948-49",
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5bd96fe11d8d4946939279588ddf0799~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5bd96fe11d8d4946939279588ddf0799~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5bd96fe11d8d4946939279588ddf0799.avif"
     },
     {
         "franchise": "",
@@ -14000,7 +14000,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f75b8b9b9dec41ab9ba2f421ddf3c503~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f75b8b9b9dec41ab9ba2f421ddf3c503~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f75b8b9b9dec41ab9ba2f421ddf3c503.avif"
     },
     {
         "franchise": "DEN",
@@ -14014,7 +14014,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_50faf4945f5942d5aa2423c6d2958887~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50faf4945f5942d5aa2423c6d2958887~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50faf4945f5942d5aa2423c6d2958887.avif"
     },
     {
         "franchise": "",
@@ -14028,7 +14028,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9b937f7f808740a098c74b5029f58302~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9b937f7f808740a098c74b5029f58302~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9b937f7f808740a098c74b5029f58302.avif"
     },
     {
         "franchise": "",
@@ -14042,7 +14042,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_86ed53b4589d422b89c7ab79cdbe3875~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_86ed53b4589d422b89c7ab79cdbe3875~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_86ed53b4589d422b89c7ab79cdbe3875.avif"
     },
     {
         "franchise": "",
@@ -14056,7 +14056,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_62820798eb914083b167e5d77e160055~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_62820798eb914083b167e5d77e160055~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_62820798eb914083b167e5d77e160055.avif"
     },
     {
         "franchise": "",
@@ -14070,7 +14070,7 @@
         "seasons": [
             "1947-48"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fd527175d04744b89d9aafe9f047cfdb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fd527175d04744b89d9aafe9f047cfdb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fd527175d04744b89d9aafe9f047cfdb.avif"
     },
     {
         "franchise": "",
@@ -14084,7 +14084,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6412279d56e5402bb6ec4c7d7ab7c64b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6412279d56e5402bb6ec4c7d7ab7c64b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6412279d56e5402bb6ec4c7d7ab7c64b.avif"
     },
     {
         "franchise": "",
@@ -14098,7 +14098,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_009ba38559f4430596dfdbd8637aa929~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_009ba38559f4430596dfdbd8637aa929~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_009ba38559f4430596dfdbd8637aa929.avif"
     },
     {
         "franchise": "",
@@ -14112,7 +14112,7 @@
         "seasons": [
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d451f809759140308340d7c60600feef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d451f809759140308340d7c60600feef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d451f809759140308340d7c60600feef.avif"
     },
     {
         "franchise": "",
@@ -14126,7 +14126,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f3578c35f7434d52a44f2dd92c9fe6c6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f3578c35f7434d52a44f2dd92c9fe6c6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f3578c35f7434d52a44f2dd92c9fe6c6.avif"
     },
     {
         "franchise": "",
@@ -14142,7 +14142,7 @@
             "1950-51",
             "1951-52"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_37610463d31a4cb1b6ac5f2011d74f30~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_37610463d31a4cb1b6ac5f2011d74f30~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_37610463d31a4cb1b6ac5f2011d74f30.avif"
     },
     {
         "franchise": "",
@@ -14156,7 +14156,7 @@
         "seasons": [
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5eda58bdbca143dca5c6f6a2c8f71735~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5eda58bdbca143dca5c6f6a2c8f71735~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5eda58bdbca143dca5c6f6a2c8f71735.avif"
     },
     {
         "franchise": "BLB",
@@ -14170,7 +14170,7 @@
         "seasons": [
             "1947-48"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_987372bff5f94da4bbcd386512600630~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_987372bff5f94da4bbcd386512600630~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_987372bff5f94da4bbcd386512600630.avif"
     },
     {
         "franchise": "BLB",
@@ -14184,7 +14184,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1d4d795fffcf4fcc914d52246cd03733~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1d4d795fffcf4fcc914d52246cd03733~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1d4d795fffcf4fcc914d52246cd03733.avif"
     },
     {
         "franchise": "BLB",
@@ -14198,7 +14198,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e462bb5206c41dc90819f7bc0d81a44~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e462bb5206c41dc90819f7bc0d81a44~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e462bb5206c41dc90819f7bc0d81a44.avif"
     },
     {
         "franchise": "BLB",
@@ -14212,7 +14212,7 @@
         "seasons": [
             "1950-51"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_69fc708264844313b0f388875bb00231~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_69fc708264844313b0f388875bb00231~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_69fc708264844313b0f388875bb00231.avif"
     },
     {
         "franchise": "BLB",
@@ -14227,7 +14227,7 @@
             "1951-52",
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3e50d47efec3493bb7aa70479d8e7b8b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3e50d47efec3493bb7aa70479d8e7b8b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3e50d47efec3493bb7aa70479d8e7b8b.avif"
     },
     {
         "franchise": "BLB",
@@ -14241,7 +14241,7 @@
         "seasons": [
             "1953-54"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_27f2352838ca4c2d8ae3844feadf3b77~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_27f2352838ca4c2d8ae3844feadf3b77~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_27f2352838ca4c2d8ae3844feadf3b77.avif"
     },
     {
         "franchise": "BLB",
@@ -14255,7 +14255,7 @@
         "seasons": [
             "1954-55"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2ddc89bf57b94e6a87d561eb163bf527~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2ddc89bf57b94e6a87d561eb163bf527~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2ddc89bf57b94e6a87d561eb163bf527.avif"
     },
     {
         "franchise": "CHA",
@@ -14270,7 +14270,7 @@
             "1988-89",
             "1989-90"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0b29edbe381b49e9b7e02a0a325482cd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0b29edbe381b49e9b7e02a0a325482cd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0b29edbe381b49e9b7e02a0a325482cd.avif"
     },
     {
         "franchise": "CHA",
@@ -14287,7 +14287,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7299574d3de84a929d247e616594c5a8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7299574d3de84a929d247e616594c5a8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7299574d3de84a929d247e616594c5a8.avif"
     },
     {
         "franchise": "CHA",
@@ -14302,7 +14302,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_76e268be77044e01b47d82f4636825b8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_76e268be77044e01b47d82f4636825b8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_76e268be77044e01b47d82f4636825b8.avif"
     },
     {
         "franchise": "CHA",
@@ -14316,7 +14316,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5950311e27e4425ab89296276fde4917~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5950311e27e4425ab89296276fde4917~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5950311e27e4425ab89296276fde4917.avif"
     },
     {
         "franchise": "CHA",
@@ -14331,7 +14331,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e6e63ed63032466c9e4e97353b7ba874~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e6e63ed63032466c9e4e97353b7ba874~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e6e63ed63032466c9e4e97353b7ba874.avif"
     },
     {
         "franchise": "CHA",
@@ -14346,7 +14346,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1f7ac14dc0484b0db6f4fe4b1ceefe40~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1f7ac14dc0484b0db6f4fe4b1ceefe40~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1f7ac14dc0484b0db6f4fe4b1ceefe40.avif"
     },
     {
         "franchise": "CHA",
@@ -14360,7 +14360,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5b1d68f8e30f4dffb3a45b7429713535~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5b1d68f8e30f4dffb3a45b7429713535~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5b1d68f8e30f4dffb3a45b7429713535.avif"
     },
     {
         "franchise": "CHA",
@@ -14377,7 +14377,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4174860d8b26436b8450e7dd3644c9ab~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4174860d8b26436b8450e7dd3644c9ab~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4174860d8b26436b8450e7dd3644c9ab.avif"
     },
     {
         "franchise": "CHA",
@@ -14391,7 +14391,7 @@
         "seasons": [
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7b8653b7382b415bbf24bde33b8035ee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7b8653b7382b415bbf24bde33b8035ee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7b8653b7382b415bbf24bde33b8035ee.avif"
     },
     {
         "franchise": "CHA",
@@ -14405,7 +14405,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_47fa93682b3d40c09ab8dae21d489636~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_47fa93682b3d40c09ab8dae21d489636~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_47fa93682b3d40c09ab8dae21d489636.avif"
     },
     {
         "franchise": "CHA",
@@ -14420,7 +14420,7 @@
             "2010-11",
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_09340986c1fa464c9a2d6394959a38ec~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_09340986c1fa464c9a2d6394959a38ec~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_09340986c1fa464c9a2d6394959a38ec.avif"
     },
     {
         "franchise": "CHA",
@@ -14435,7 +14435,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_de7e321e07834a93aedced4221dc3f41~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_de7e321e07834a93aedced4221dc3f41~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_de7e321e07834a93aedced4221dc3f41.avif"
     },
     {
         "franchise": "CHA",
@@ -14451,7 +14451,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3aa9a2029f75463eadc6a99563453a58~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3aa9a2029f75463eadc6a99563453a58~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3aa9a2029f75463eadc6a99563453a58.avif"
     },
     {
         "franchise": "CHA",
@@ -14467,7 +14467,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f948b535f8624123a8f3d77d6d2d1fe9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f948b535f8624123a8f3d77d6d2d1fe9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f948b535f8624123a8f3d77d6d2d1fe9.avif"
     },
     {
         "franchise": "CHA",
@@ -14482,7 +14482,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7373fd9979df40e3a3e76b5bbf073804~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7373fd9979df40e3a3e76b5bbf073804~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7373fd9979df40e3a3e76b5bbf073804.avif"
     },
     {
         "franchise": "CHA",
@@ -14496,7 +14496,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f6e1af3fff494356b7af4d58ce45a369~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f6e1af3fff494356b7af4d58ce45a369~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f6e1af3fff494356b7af4d58ce45a369.avif"
     },
     {
         "franchise": "CHA",
@@ -14510,7 +14510,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4eb77dacc5b441dbaa4f7762d0c0a2dc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4eb77dacc5b441dbaa4f7762d0c0a2dc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4eb77dacc5b441dbaa4f7762d0c0a2dc.avif"
     },
     {
         "franchise": "CHA",
@@ -14525,7 +14525,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d174cf232a8747b18bf86dfeef5dbaec~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d174cf232a8747b18bf86dfeef5dbaec~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d174cf232a8747b18bf86dfeef5dbaec.avif"
     },
     {
         "franchise": "CHA",
@@ -14539,7 +14539,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3e673d0e97144093b6be9d79f6c9ead5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3e673d0e97144093b6be9d79f6c9ead5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3e673d0e97144093b6be9d79f6c9ead5.avif"
     },
     {
         "franchise": "CHA",
@@ -14554,7 +14554,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_46e19993d2cb4a2da01f1b13b66614fb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_46e19993d2cb4a2da01f1b13b66614fb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_46e19993d2cb4a2da01f1b13b66614fb.avif"
     },
     {
         "franchise": "CHA",
@@ -14569,7 +14569,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c327bd921a5b4c09927d5863829c7aa0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c327bd921a5b4c09927d5863829c7aa0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c327bd921a5b4c09927d5863829c7aa0.avif"
     },
     {
         "franchise": "CHA",
@@ -14583,7 +14583,7 @@
         "seasons": [
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_49c5935b2d7345709eceeae804ab374a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_49c5935b2d7345709eceeae804ab374a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_49c5935b2d7345709eceeae804ab374a.avif"
     },
     {
         "franchise": "CHA",
@@ -14598,7 +14598,7 @@
             "2009-10",
             "2010-11"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e1f22a2a32c84250bb8a1da45c357f3c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e1f22a2a32c84250bb8a1da45c357f3c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e1f22a2a32c84250bb8a1da45c357f3c.avif"
     },
     {
         "franchise": "CHA",
@@ -14614,7 +14614,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9e2ccec6b54c492f971219f6efce81aa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9e2ccec6b54c492f971219f6efce81aa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9e2ccec6b54c492f971219f6efce81aa.avif"
     },
     {
         "franchise": "CHA",
@@ -14629,7 +14629,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_88a8a0ced5ba4e1bb745def0b0327033~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_88a8a0ced5ba4e1bb745def0b0327033~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_88a8a0ced5ba4e1bb745def0b0327033.avif"
     },
     {
         "franchise": "CHA",
@@ -14644,7 +14644,7 @@
             "2019-20",
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5cd0f86542e2406eb8dfc947e736525b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5cd0f86542e2406eb8dfc947e736525b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5cd0f86542e2406eb8dfc947e736525b.avif"
     },
     {
         "franchise": "CHA",
@@ -14658,7 +14658,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_84a3a00770dd4bf5a8b1ce1051427306~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_84a3a00770dd4bf5a8b1ce1051427306~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_84a3a00770dd4bf5a8b1ce1051427306.avif"
     },
     {
         "franchise": "CHA",
@@ -14672,7 +14672,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fb2e155865974fd59444346299da5874~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fb2e155865974fd59444346299da5874~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fb2e155865974fd59444346299da5874.avif"
     },
     {
         "franchise": "CHA",
@@ -14686,7 +14686,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_df98ee3b3b484564900cae0ee2b47245~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_df98ee3b3b484564900cae0ee2b47245~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_df98ee3b3b484564900cae0ee2b47245.avif"
     },
     {
         "franchise": "DAL",
@@ -14700,7 +14700,7 @@
         "seasons": [
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4be4f5ef1f0f4a029624fd073704cb97~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4be4f5ef1f0f4a029624fd073704cb97~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4be4f5ef1f0f4a029624fd073704cb97.avif"
     },
     {
         "franchise": "DAL",
@@ -14716,7 +14716,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_05b4614643fe4a4dbb78e4923c9e60e4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_05b4614643fe4a4dbb78e4923c9e60e4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_05b4614643fe4a4dbb78e4923c9e60e4.avif"
     },
     {
         "franchise": "DAL",
@@ -14731,7 +14731,7 @@
             "2007-08",
             "2008-09"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0f6cdc861a984aa387765ea22377bef9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0f6cdc861a984aa387765ea22377bef9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0f6cdc861a984aa387765ea22377bef9.avif"
     },
     {
         "franchise": "DAL",
@@ -14745,7 +14745,7 @@
         "seasons": [
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_735f964fca134b4fbc5bc202bea6257d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_735f964fca134b4fbc5bc202bea6257d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_735f964fca134b4fbc5bc202bea6257d.avif"
     },
     {
         "franchise": "DAL",
@@ -14761,7 +14761,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d2eba205c0194ba3aaac297f87865ff3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d2eba205c0194ba3aaac297f87865ff3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d2eba205c0194ba3aaac297f87865ff3.avif"
     },
     {
         "franchise": "DAL",
@@ -14775,7 +14775,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4dc7c0147a4f4ac1b26ea16ada730380~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4dc7c0147a4f4ac1b26ea16ada730380~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4dc7c0147a4f4ac1b26ea16ada730380.avif"
     },
     {
         "franchise": "DAL",
@@ -14790,7 +14790,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1f47f4b4c26b4342909127b079da399b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1f47f4b4c26b4342909127b079da399b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1f47f4b4c26b4342909127b079da399b.avif"
     },
     {
         "franchise": "DAL",
@@ -14805,7 +14805,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9c4f0bbae69348c0b621a30b58854899~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9c4f0bbae69348c0b621a30b58854899~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9c4f0bbae69348c0b621a30b58854899.avif"
     },
     {
         "franchise": "DAL",
@@ -14819,7 +14819,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_391a0d0b4af641739fccc41661749ae8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_391a0d0b4af641739fccc41661749ae8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_391a0d0b4af641739fccc41661749ae8.avif"
     },
     {
         "franchise": "DAL",
@@ -14833,7 +14833,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d8c0eec7aba441cc8d960edb3bdd5e66~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d8c0eec7aba441cc8d960edb3bdd5e66~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d8c0eec7aba441cc8d960edb3bdd5e66.avif"
     },
     {
         "franchise": "DAL",
@@ -14847,7 +14847,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b033f5517f41417887a2b41da715d87a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b033f5517f41417887a2b41da715d87a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b033f5517f41417887a2b41da715d87a.avif"
     },
     {
         "franchise": "DAL",
@@ -14861,7 +14861,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_91c90dce8b8d47a59e502d2f3356d6b0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_91c90dce8b8d47a59e502d2f3356d6b0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_91c90dce8b8d47a59e502d2f3356d6b0.avif"
     },
     {
         "franchise": "DAL",
@@ -14875,7 +14875,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5b01b8b9c6a548f294b3395527951a40~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5b01b8b9c6a548f294b3395527951a40~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5b01b8b9c6a548f294b3395527951a40.avif"
     },
     {
         "franchise": "DAL",
@@ -14889,7 +14889,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2f045f3e7e08489982fbccebc2425332~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2f045f3e7e08489982fbccebc2425332~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2f045f3e7e08489982fbccebc2425332.avif"
     },
     {
         "franchise": "DAL",
@@ -14903,7 +14903,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_46de5a994d2b459883b21bf9e82cac0c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_46de5a994d2b459883b21bf9e82cac0c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_46de5a994d2b459883b21bf9e82cac0c.avif"
     },
     {
         "franchise": "DAL",
@@ -14919,7 +14919,7 @@
             "1982-83",
             "1983-84"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_45c6f7a6df0241fdb0390af3d7c12030~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_45c6f7a6df0241fdb0390af3d7c12030~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_45c6f7a6df0241fdb0390af3d7c12030.avif"
     },
     {
         "franchise": "DAL",
@@ -14934,7 +14934,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e4e25b8d566c40bfb469de5311cba70d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e4e25b8d566c40bfb469de5311cba70d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e4e25b8d566c40bfb469de5311cba70d.avif"
     },
     {
         "franchise": "DAL",
@@ -14952,7 +14952,7 @@
             "1989-90",
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_af8046ef82a646b8a9a14230dee3a6d0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_af8046ef82a646b8a9a14230dee3a6d0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_af8046ef82a646b8a9a14230dee3a6d0.avif"
     },
     {
         "franchise": "DAL",
@@ -14966,7 +14966,7 @@
         "seasons": [
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_092e7478a1c14871a8bcd7ceba55d43f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_092e7478a1c14871a8bcd7ceba55d43f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_092e7478a1c14871a8bcd7ceba55d43f.avif"
     },
     {
         "franchise": "DAL",
@@ -14980,7 +14980,7 @@
         "seasons": [
             "1992-93"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_776ef2bb9ad642adaf08d128a0eeb940~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_776ef2bb9ad642adaf08d128a0eeb940~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_776ef2bb9ad642adaf08d128a0eeb940.avif"
     },
     {
         "franchise": "DAL",
@@ -14994,7 +14994,7 @@
         "seasons": [
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_36930fdf40cc4f3da485d6538d8f9804~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_36930fdf40cc4f3da485d6538d8f9804~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_36930fdf40cc4f3da485d6538d8f9804.avif"
     },
     {
         "franchise": "DAL",
@@ -15011,7 +15011,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1246e7a7bf884228ab981cd248d5e27b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1246e7a7bf884228ab981cd248d5e27b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1246e7a7bf884228ab981cd248d5e27b.avif"
     },
     {
         "franchise": "DAL",
@@ -15025,7 +15025,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d7018309cfd1408d90948c3a20d676e2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d7018309cfd1408d90948c3a20d676e2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d7018309cfd1408d90948c3a20d676e2.avif"
     },
     {
         "franchise": "DAL",
@@ -15040,7 +15040,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_89517d15d1334fef85bdf2d947ac9635~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_89517d15d1334fef85bdf2d947ac9635~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_89517d15d1334fef85bdf2d947ac9635.avif"
     },
     {
         "franchise": "DAL",
@@ -15054,7 +15054,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4ed92e62d6a4458b75ff1622bc2532a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4ed92e62d6a4458b75ff1622bc2532a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4ed92e62d6a4458b75ff1622bc2532a.avif"
     },
     {
         "franchise": "DAL",
@@ -15070,7 +15070,7 @@
             "2002-03",
             "2003-04"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3885a83bc1d54c4bae167caeb7007c26~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3885a83bc1d54c4bae167caeb7007c26~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3885a83bc1d54c4bae167caeb7007c26.avif"
     },
     {
         "franchise": "DAL",
@@ -15086,7 +15086,7 @@
             "2005-06",
             "2006-07"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ab2deae1626240bb9ed99025f555184b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ab2deae1626240bb9ed99025f555184b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ab2deae1626240bb9ed99025f555184b.avif"
     },
     {
         "franchise": "DAL",
@@ -15102,7 +15102,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c221a560aa94485ea94e1ce8cefedeb0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c221a560aa94485ea94e1ce8cefedeb0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c221a560aa94485ea94e1ce8cefedeb0.avif"
     },
     {
         "franchise": "DAL",
@@ -15119,7 +15119,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7897a3a5c1384e70b44425b2d68cae78~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7897a3a5c1384e70b44425b2d68cae78~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7897a3a5c1384e70b44425b2d68cae78.avif"
     },
     {
         "franchise": "DAL",
@@ -15135,7 +15135,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a9e2f2e70c1a484db43da6f92120d86b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a9e2f2e70c1a484db43da6f92120d86b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a9e2f2e70c1a484db43da6f92120d86b.avif"
     },
     {
         "franchise": "DAL",
@@ -15153,7 +15153,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3feaf75d09b04911bdd60e4447cae503~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3feaf75d09b04911bdd60e4447cae503~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3feaf75d09b04911bdd60e4447cae503.avif"
     },
     {
         "franchise": "DAL",
@@ -15167,7 +15167,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_555c22c8fc3f45c1be91bf3e60607d29~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_555c22c8fc3f45c1be91bf3e60607d29~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_555c22c8fc3f45c1be91bf3e60607d29.avif"
     },
     {
         "franchise": "DAL",
@@ -15181,7 +15181,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_40c94f96d6054fa89a21d694bf22f2cb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_40c94f96d6054fa89a21d694bf22f2cb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_40c94f96d6054fa89a21d694bf22f2cb.avif"
     },
     {
         "franchise": "POR",
@@ -15202,7 +15202,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_977d818568ac41ea934e192b3c78561a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_977d818568ac41ea934e192b3c78561a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_977d818568ac41ea934e192b3c78561a.avif"
     },
     {
         "franchise": "POR",
@@ -15220,7 +15220,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_35fb06391cc44af180f3b787ca66fac6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_35fb06391cc44af180f3b787ca66fac6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_35fb06391cc44af180f3b787ca66fac6.avif"
     },
     {
         "franchise": "POR",
@@ -15235,7 +15235,7 @@
             "2010-11",
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0f05218029e642098359c8bd0ca5f6ae~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0f05218029e642098359c8bd0ca5f6ae~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0f05218029e642098359c8bd0ca5f6ae.avif"
     },
     {
         "franchise": "POR",
@@ -15250,7 +15250,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_22f534fa32434152bb88569fd30b179c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_22f534fa32434152bb88569fd30b179c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_22f534fa32434152bb88569fd30b179c.avif"
     },
     {
         "franchise": "POR",
@@ -15266,7 +15266,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_36364578ecec4ba7ad85fd57a935b44b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_36364578ecec4ba7ad85fd57a935b44b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_36364578ecec4ba7ad85fd57a935b44b.avif"
     },
     {
         "franchise": "POR",
@@ -15281,7 +15281,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f03baa2034dd4d1faa644bcf7a9a1cb2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f03baa2034dd4d1faa644bcf7a9a1cb2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f03baa2034dd4d1faa644bcf7a9a1cb2.avif"
     },
     {
         "franchise": "POR",
@@ -15295,7 +15295,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bea2990455484737add9d67bc29b2adb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bea2990455484737add9d67bc29b2adb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bea2990455484737add9d67bc29b2adb.avif"
     },
     {
         "franchise": "POR",
@@ -15309,7 +15309,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3d403a269c5842aa9e2e6a3d0cb4b313~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3d403a269c5842aa9e2e6a3d0cb4b313~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3d403a269c5842aa9e2e6a3d0cb4b313.avif"
     },
     {
         "franchise": "POR",
@@ -15323,7 +15323,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c6c8adc639ab4b3abdac25b776045bdd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c6c8adc639ab4b3abdac25b776045bdd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c6c8adc639ab4b3abdac25b776045bdd.avif"
     },
     {
         "franchise": "POR",
@@ -15337,7 +15337,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_63958e34128e49ffb161c50571b2f5b3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_63958e34128e49ffb161c50571b2f5b3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_63958e34128e49ffb161c50571b2f5b3.avif"
     },
     {
         "franchise": "POR",
@@ -15351,7 +15351,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a35f2366f08c4ef7a9cda08a3f506044~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a35f2366f08c4ef7a9cda08a3f506044~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a35f2366f08c4ef7a9cda08a3f506044.avif"
     },
     {
         "franchise": "POR",
@@ -15365,7 +15365,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1f9a58a4162544579a034b92bfa830df~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1f9a58a4162544579a034b92bfa830df~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1f9a58a4162544579a034b92bfa830df.avif"
     },
     {
         "franchise": "POR",
@@ -15379,7 +15379,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1ae05d2adc5f482a811bc6ab011a2c0b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1ae05d2adc5f482a811bc6ab011a2c0b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1ae05d2adc5f482a811bc6ab011a2c0b.avif"
     },
     {
         "franchise": "POR",
@@ -15396,7 +15396,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7031c93d8141499e989f2297d5ef66d8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7031c93d8141499e989f2297d5ef66d8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7031c93d8141499e989f2297d5ef66d8.avif"
     },
     {
         "franchise": "POR",
@@ -15410,7 +15410,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_713477745847418e88acd1927244f074~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_713477745847418e88acd1927244f074~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_713477745847418e88acd1927244f074.avif"
     },
     {
         "franchise": "POR",
@@ -15424,7 +15424,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_211ff9dc01f74536b06a54d12a1cd4cb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_211ff9dc01f74536b06a54d12a1cd4cb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_211ff9dc01f74536b06a54d12a1cd4cb.avif"
     },
     {
         "franchise": "POR",
@@ -15439,7 +15439,7 @@
             "1977-78",
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e0784257fb7947b5accfe69918e41f79~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e0784257fb7947b5accfe69918e41f79~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e0784257fb7947b5accfe69918e41f79.avif"
     },
     {
         "franchise": "POR",
@@ -15457,7 +15457,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_854e8bdf59ed43479c56b7aa23144e11~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_854e8bdf59ed43479c56b7aa23144e11~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_854e8bdf59ed43479c56b7aa23144e11.avif"
     },
     {
         "franchise": "POR",
@@ -15471,7 +15471,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_da749565e789414b9541be4f0d0ea104~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_da749565e789414b9541be4f0d0ea104~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_da749565e789414b9541be4f0d0ea104.avif"
     },
     {
         "franchise": "POR",
@@ -15485,7 +15485,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f08060db2cb346df8a9a7fb5d2c491f5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f08060db2cb346df8a9a7fb5d2c491f5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f08060db2cb346df8a9a7fb5d2c491f5.avif"
     },
     {
         "franchise": "POR",
@@ -15503,7 +15503,7 @@
             "1989-90",
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_50a172b7e90f4c9784407eec8f8545fc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_50a172b7e90f4c9784407eec8f8545fc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_50a172b7e90f4c9784407eec8f8545fc.avif"
     },
     {
         "franchise": "POR",
@@ -15517,7 +15517,7 @@
         "seasons": [
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0b2b5820d6d3427ab718828022ed9fb4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0b2b5820d6d3427ab718828022ed9fb4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0b2b5820d6d3427ab718828022ed9fb4.avif"
     },
     {
         "franchise": "POR",
@@ -15531,7 +15531,7 @@
         "seasons": [
             "1991-92"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a4ab20a422f84aa2852ad8d8d66d0265~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a4ab20a422f84aa2852ad8d8d66d0265~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a4ab20a422f84aa2852ad8d8d66d0265.avif"
     },
     {
         "franchise": "POR",
@@ -15546,7 +15546,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0b0364a6786a40ea9742ba9e3b18583b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0b0364a6786a40ea9742ba9e3b18583b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0b0364a6786a40ea9742ba9e3b18583b.avif"
     },
     {
         "franchise": "POR",
@@ -15563,7 +15563,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e9cc1d57cd1d44a9a7f527f2c0fd00ef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e9cc1d57cd1d44a9a7f527f2c0fd00ef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e9cc1d57cd1d44a9a7f527f2c0fd00ef.avif"
     },
     {
         "franchise": "POR",
@@ -15577,7 +15577,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ac9dffdb87604af79e97b1c36cc31184~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ac9dffdb87604af79e97b1c36cc31184~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ac9dffdb87604af79e97b1c36cc31184.avif"
     },
     {
         "franchise": "POR",
@@ -15592,7 +15592,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_513f2c3ebe61432c94c3010c26bdbee2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_513f2c3ebe61432c94c3010c26bdbee2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_513f2c3ebe61432c94c3010c26bdbee2.avif"
     },
     {
         "franchise": "POR",
@@ -15606,7 +15606,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_36549dee65ba4b898f3aae4846d0c854~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_36549dee65ba4b898f3aae4846d0c854~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_36549dee65ba4b898f3aae4846d0c854.avif"
     },
     {
         "franchise": "POR",
@@ -15622,7 +15622,7 @@
             "2003-04",
             "2004-05"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_899a9e57051e494d85f849d30abd468b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_899a9e57051e494d85f849d30abd468b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_899a9e57051e494d85f849d30abd468b.avif"
     },
     {
         "franchise": "POR",
@@ -15644,7 +15644,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1d1a397d1bb840e8b9420873041a4056~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1d1a397d1bb840e8b9420873041a4056~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1d1a397d1bb840e8b9420873041a4056.avif"
     },
     {
         "franchise": "POR",
@@ -15660,7 +15660,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4cf5517353f84ff1b9ef4bf0ca85d8e2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4cf5517353f84ff1b9ef4bf0ca85d8e2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4cf5517353f84ff1b9ef4bf0ca85d8e2.avif"
     },
     {
         "franchise": "POR",
@@ -15678,7 +15678,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fbdc83f1979944eaadb91554ad24fca6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fbdc83f1979944eaadb91554ad24fca6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fbdc83f1979944eaadb91554ad24fca6.avif"
     },
     {
         "franchise": "POR",
@@ -15692,7 +15692,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a75c561fdee64653b216ef56d84b000b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a75c561fdee64653b216ef56d84b000b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a75c561fdee64653b216ef56d84b000b.avif"
     },
     {
         "franchise": "POR",
@@ -15706,7 +15706,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8d5ee340aff54407a47bb2d42298163a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8d5ee340aff54407a47bb2d42298163a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8d5ee340aff54407a47bb2d42298163a.avif"
     },
     {
         "franchise": "CHI",
@@ -15722,7 +15722,7 @@
             "1967-68",
             "1968-69"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_66a6fd70685840c4a3b8e22d5a96cf3c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_66a6fd70685840c4a3b8e22d5a96cf3c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_66a6fd70685840c4a3b8e22d5a96cf3c.avif"
     },
     {
         "franchise": "CHI",
@@ -15736,7 +15736,7 @@
         "seasons": [
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a20211117ee34f30b7b75984dedc7527~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a20211117ee34f30b7b75984dedc7527~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a20211117ee34f30b7b75984dedc7527.avif"
     },
     {
         "franchise": "CHI",
@@ -15750,7 +15750,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d6fbf8db8f7e46f1bbcb6da86e6f6ee3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d6fbf8db8f7e46f1bbcb6da86e6f6ee3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d6fbf8db8f7e46f1bbcb6da86e6f6ee3.avif"
     },
     {
         "franchise": "CHI",
@@ -15765,7 +15765,7 @@
             "1971-72",
             "1972-73"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cb3421ad757a43e2acca3339e21525aa~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cb3421ad757a43e2acca3339e21525aa~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cb3421ad757a43e2acca3339e21525aa.avif"
     },
     {
         "franchise": "CHI",
@@ -15780,7 +15780,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8855a0f563d0489cb522eb8d926c126c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8855a0f563d0489cb522eb8d926c126c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8855a0f563d0489cb522eb8d926c126c.avif"
     },
     {
         "franchise": "CHI",
@@ -15794,7 +15794,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_310f586f8f5d40a080b40d25ca17760c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_310f586f8f5d40a080b40d25ca17760c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_310f586f8f5d40a080b40d25ca17760c.avif"
     },
     {
         "franchise": "CHI",
@@ -15808,7 +15808,7 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f1e9170d65f340dcab98c1de8bc60798~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f1e9170d65f340dcab98c1de8bc60798~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f1e9170d65f340dcab98c1de8bc60798.avif"
     },
     {
         "franchise": "CHI",
@@ -15824,7 +15824,7 @@
             "1977-78",
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_00945a7695ac40f68b8bec129f22124d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_00945a7695ac40f68b8bec129f22124d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_00945a7695ac40f68b8bec129f22124d.avif"
     },
     {
         "franchise": "CHI",
@@ -15840,7 +15840,7 @@
             "1981-82",
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f2e3f7426eec4f6f94cef89a705528e6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f2e3f7426eec4f6f94cef89a705528e6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f2e3f7426eec4f6f94cef89a705528e6.avif"
     },
     {
         "franchise": "CHI",
@@ -15854,7 +15854,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_203fe18d34e6416f88eb626a7a01ee1d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_203fe18d34e6416f88eb626a7a01ee1d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_203fe18d34e6416f88eb626a7a01ee1d.avif"
     },
     {
         "franchise": "CHI",
@@ -15869,7 +15869,7 @@
             "1983-84",
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_91b2362430e14d06b7853c676688427a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_91b2362430e14d06b7853c676688427a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_91b2362430e14d06b7853c676688427a.avif"
     },
     {
         "franchise": "CHI",
@@ -15883,7 +15883,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_608b62263e564a0aa2208b192e2044cd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_608b62263e564a0aa2208b192e2044cd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_608b62263e564a0aa2208b192e2044cd.avif"
     },
     {
         "franchise": "CHI",
@@ -15904,7 +15904,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2ec6471aad13438a986a72c115abfff1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2ec6471aad13438a986a72c115abfff1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2ec6471aad13438a986a72c115abfff1.avif"
     },
     {
         "franchise": "CHI",
@@ -15921,7 +15921,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a718ea8f0d1247268163f9c0e214064f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a718ea8f0d1247268163f9c0e214064f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a718ea8f0d1247268163f9c0e214064f.avif"
     },
     {
         "franchise": "CHI",
@@ -15935,7 +15935,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8a5751fe50b449bbbcc24d13e127177b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8a5751fe50b449bbbcc24d13e127177b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8a5751fe50b449bbbcc24d13e127177b.avif"
     },
     {
         "franchise": "CHI",
@@ -15954,7 +15954,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe9ee315a0564be1b2afd28ea5c70619~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe9ee315a0564be1b2afd28ea5c70619~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe9ee315a0564be1b2afd28ea5c70619.avif"
     },
     {
         "franchise": "CHI",
@@ -15968,7 +15968,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1a0bb1d9ade54e129bd72ac57d7e81f4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1a0bb1d9ade54e129bd72ac57d7e81f4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1a0bb1d9ade54e129bd72ac57d7e81f4.avif"
     },
     {
         "franchise": "CHI",
@@ -15989,7 +15989,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6747bf9243f842c9807777091e0b8c1d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6747bf9243f842c9807777091e0b8c1d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6747bf9243f842c9807777091e0b8c1d.avif"
     },
     {
         "franchise": "CHI",
@@ -16005,7 +16005,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e16788636a14479b81632d255ac968a5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e16788636a14479b81632d255ac968a5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e16788636a14479b81632d255ac968a5.avif"
     },
     {
         "franchise": "CHI",
@@ -16023,7 +16023,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6c16792c4e5748d5bf56042a1ef6f54e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6c16792c4e5748d5bf56042a1ef6f54e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6c16792c4e5748d5bf56042a1ef6f54e.avif"
     },
     {
         "franchise": "CHI",
@@ -16037,7 +16037,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2d13b4920c914b7bb18dcc5df9d54abf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2d13b4920c914b7bb18dcc5df9d54abf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2d13b4920c914b7bb18dcc5df9d54abf.avif"
     },
     {
         "franchise": "CHI",
@@ -16051,7 +16051,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c8b156b0079747b1958ab1ded2b07747~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c8b156b0079747b1958ab1ded2b07747~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c8b156b0079747b1958ab1ded2b07747.avif"
     },
     {
         "franchise": "CHI",
@@ -16065,7 +16065,7 @@
         "seasons": [
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_add9df92808941e4af61ccefc688c04f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_add9df92808941e4af61ccefc688c04f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_add9df92808941e4af61ccefc688c04f.avif"
     },
     {
         "franchise": "CHI",
@@ -16079,7 +16079,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c92bf6d5e5cf4810ae0a35a03edc9782~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c92bf6d5e5cf4810ae0a35a03edc9782~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c92bf6d5e5cf4810ae0a35a03edc9782.avif"
     },
     {
         "franchise": "CHI",
@@ -16094,7 +16094,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2e8832087a45442a8922010e670cf00e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2e8832087a45442a8922010e670cf00e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2e8832087a45442a8922010e670cf00e.avif"
     },
     {
         "franchise": "CHI",
@@ -16109,7 +16109,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0d7bc4b9e36a4c268fc542dbb1db83ac~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0d7bc4b9e36a4c268fc542dbb1db83ac~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0d7bc4b9e36a4c268fc542dbb1db83ac.avif"
     },
     {
         "franchise": "CHI",
@@ -16123,7 +16123,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0030cfa6bfc247f39aa9193f329993b0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0030cfa6bfc247f39aa9193f329993b0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0030cfa6bfc247f39aa9193f329993b0.avif"
     },
     {
         "franchise": "CHI",
@@ -16137,7 +16137,7 @@
         "seasons": [
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2e1b4673a4574ad7aafb964394ff496f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2e1b4673a4574ad7aafb964394ff496f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2e1b4673a4574ad7aafb964394ff496f.avif"
     },
     {
         "franchise": "CHI",
@@ -16153,7 +16153,7 @@
             "2004-05",
             "2005-06"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3a4407116a4c4cfc91fa896eb0459f26~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3a4407116a4c4cfc91fa896eb0459f26~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3a4407116a4c4cfc91fa896eb0459f26.avif"
     },
     {
         "franchise": "CHI",
@@ -16174,7 +16174,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c757a8a2d91a4ee497ba481b61d4b181~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c757a8a2d91a4ee497ba481b61d4b181~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c757a8a2d91a4ee497ba481b61d4b181.avif"
     },
     {
         "franchise": "CHI",
@@ -16188,7 +16188,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1835cdf7797346d798adbcc8403d6f18~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1835cdf7797346d798adbcc8403d6f18~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1835cdf7797346d798adbcc8403d6f18.avif"
     },
     {
         "franchise": "CHI",
@@ -16202,7 +16202,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_00a7e2db56a9494e9d41a62b76e9eed8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_00a7e2db56a9494e9d41a62b76e9eed8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_00a7e2db56a9494e9d41a62b76e9eed8.avif"
     },
     {
         "franchise": "CHI",
@@ -16214,7 +16214,7 @@
         "endYear": 2017,
         "years": "2015-16 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_2d3911279b79483185b98406c9f8a24c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2d3911279b79483185b98406c9f8a24c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2d3911279b79483185b98406c9f8a24c.avif"
     },
     {
         "franchise": "CHI",
@@ -16229,7 +16229,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1399661521644fd1b7781452bbe13f00~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1399661521644fd1b7781452bbe13f00~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1399661521644fd1b7781452bbe13f00.avif"
     },
     {
         "franchise": "CHI",
@@ -16243,7 +16243,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_98914baf91bd47ea93d3ddefd0d8e0e5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_98914baf91bd47ea93d3ddefd0d8e0e5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_98914baf91bd47ea93d3ddefd0d8e0e5.avif"
     },
     {
         "franchise": "CHI",
@@ -16258,7 +16258,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e024ea81a09046b2b04da02664293306~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e024ea81a09046b2b04da02664293306~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e024ea81a09046b2b04da02664293306.avif"
     },
     {
         "franchise": "CHI",
@@ -16272,7 +16272,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c78e625db1a485b9558f5f6d03babf1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c78e625db1a485b9558f5f6d03babf1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c78e625db1a485b9558f5f6d03babf1.avif"
     },
     {
         "franchise": "CHI",
@@ -16286,7 +16286,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a58e993168c041ef9ad35eb3790d0453~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a58e993168c041ef9ad35eb3790d0453~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a58e993168c041ef9ad35eb3790d0453.avif"
     },
     {
         "franchise": "ORL",
@@ -16304,7 +16304,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_febddda7a5c84ce8aaa6b0b8c9bcf189~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_febddda7a5c84ce8aaa6b0b8c9bcf189~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_febddda7a5c84ce8aaa6b0b8c9bcf189.avif"
     },
     {
         "franchise": "ORL",
@@ -16319,7 +16319,7 @@
             "1989-90",
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bacbe749726244f996639a5f3fcbe121~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bacbe749726244f996639a5f3fcbe121~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bacbe749726244f996639a5f3fcbe121.avif"
     },
     {
         "franchise": "ORL",
@@ -16335,7 +16335,7 @@
             "1995-96",
             "1997-98"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_65096eac3e5f40db9252a3d899f14bc6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_65096eac3e5f40db9252a3d899f14bc6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_65096eac3e5f40db9252a3d899f14bc6.avif"
     },
     {
         "franchise": "ORL",
@@ -16349,7 +16349,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_595bf94e8c504854b7fc1094dc3067d6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_595bf94e8c504854b7fc1094dc3067d6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_595bf94e8c504854b7fc1094dc3067d6.avif"
     },
     {
         "franchise": "ORL",
@@ -16363,7 +16363,7 @@
         "seasons": [
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a785ccd4215d4b4384c201e9bd4b15fc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a785ccd4215d4b4384c201e9bd4b15fc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a785ccd4215d4b4384c201e9bd4b15fc.avif"
     },
     {
         "franchise": "ORL",
@@ -16377,7 +16377,7 @@
         "seasons": [
             "1999-00"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1bde52b5c97c46eaa632a54435779e80~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1bde52b5c97c46eaa632a54435779e80~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1bde52b5c97c46eaa632a54435779e80.avif"
     },
     {
         "franchise": "ORL",
@@ -16392,7 +16392,7 @@
             "2000-01",
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3d09b3f9ccd54d5696324c99f7873de3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3d09b3f9ccd54d5696324c99f7873de3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3d09b3f9ccd54d5696324c99f7873de3.avif"
     },
     {
         "franchise": "ORL",
@@ -16406,7 +16406,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1732807180534bc698d41b0d806613ce~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1732807180534bc698d41b0d806613ce~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1732807180534bc698d41b0d806613ce.avif"
     },
     {
         "franchise": "ORL",
@@ -16424,7 +16424,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c0bd4138431c4e4fb0ecc7e417fa7155~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c0bd4138431c4e4fb0ecc7e417fa7155~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c0bd4138431c4e4fb0ecc7e417fa7155.avif"
     },
     {
         "franchise": "ORL",
@@ -16443,7 +16443,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3f9bcb9ff8054c359083b9018d083ff3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3f9bcb9ff8054c359083b9018d083ff3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3f9bcb9ff8054c359083b9018d083ff3.avif"
     },
     {
         "franchise": "ORL",
@@ -16459,7 +16459,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8cd2b82bc1ac44bfaf9cc70361728d73~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8cd2b82bc1ac44bfaf9cc70361728d73~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8cd2b82bc1ac44bfaf9cc70361728d73.avif"
     },
     {
         "franchise": "ORL",
@@ -16474,7 +16474,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d713e54c5418425daa822ce75243b971~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d713e54c5418425daa822ce75243b971~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d713e54c5418425daa822ce75243b971.avif"
     },
     {
         "franchise": "ORL",
@@ -16490,7 +16490,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b2644e67c1924e619ecca03ff3a6b6f8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b2644e67c1924e619ecca03ff3a6b6f8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b2644e67c1924e619ecca03ff3a6b6f8.avif"
     },
     {
         "franchise": "ORL",
@@ -16504,7 +16504,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5a1ce9bdc0b04113b4c81f44c040439a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5a1ce9bdc0b04113b4c81f44c040439a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5a1ce9bdc0b04113b4c81f44c040439a.avif"
     },
     {
         "franchise": "ORL",
@@ -16518,7 +16518,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_844233c42966445ab9a4bd2e0fa635a6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_844233c42966445ab9a4bd2e0fa635a6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_844233c42966445ab9a4bd2e0fa635a6.avif"
     },
     {
         "franchise": "ORL",
@@ -16534,7 +16534,7 @@
             "1995-96",
             "1997-98"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fffca3e14ad54c93abc7d00808b243cb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fffca3e14ad54c93abc7d00808b243cb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fffca3e14ad54c93abc7d00808b243cb.avif"
     },
     {
         "franchise": "ORL",
@@ -16548,7 +16548,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1711b9a50a3646c0967abba25962ec18~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1711b9a50a3646c0967abba25962ec18~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1711b9a50a3646c0967abba25962ec18.avif"
     },
     {
         "franchise": "ORL",
@@ -16565,7 +16565,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bfa0a6068e3b4819b52aded467a48e2a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bfa0a6068e3b4819b52aded467a48e2a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bfa0a6068e3b4819b52aded467a48e2a.avif"
     },
     {
         "franchise": "ORL",
@@ -16581,7 +16581,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5f2252432d2b41dcab65323296bdd90e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5f2252432d2b41dcab65323296bdd90e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5f2252432d2b41dcab65323296bdd90e.avif"
     },
     {
         "franchise": "ORL",
@@ -16595,7 +16595,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c1d76ba041448b6bdda725c8961181b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c1d76ba041448b6bdda725c8961181b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c1d76ba041448b6bdda725c8961181b.avif"
     },
     {
         "franchise": "ORL",
@@ -16610,7 +16610,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_567404990ccb47fea87f7f5f289b8857~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_567404990ccb47fea87f7f5f289b8857~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_567404990ccb47fea87f7f5f289b8857.avif"
     },
     {
         "franchise": "ORL",
@@ -16624,7 +16624,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4db4a99d9a464011b469841f2303e8b5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4db4a99d9a464011b469841f2303e8b5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4db4a99d9a464011b469841f2303e8b5.avif"
     },
     {
         "franchise": "ORL",
@@ -16638,7 +16638,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6f3d255e2b2140b8ac5075003fee01ab~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6f3d255e2b2140b8ac5075003fee01ab~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6f3d255e2b2140b8ac5075003fee01ab.avif"
     },
     {
         "franchise": "ORL",
@@ -16652,7 +16652,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_79326ac3f3134ec0ad21382ea1700ff0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_79326ac3f3134ec0ad21382ea1700ff0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_79326ac3f3134ec0ad21382ea1700ff0.avif"
     },
     {
         "franchise": "ORL",
@@ -16666,7 +16666,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_4859f2b0ae39431c8d1c6692f1522843~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4859f2b0ae39431c8d1c6692f1522843~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4859f2b0ae39431c8d1c6692f1522843.avif"
     },
     {
         "franchise": "ORL",
@@ -16680,7 +16680,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4a3246351ff4c8ebd8605f76ec3ec86~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4a3246351ff4c8ebd8605f76ec3ec86~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4a3246351ff4c8ebd8605f76ec3ec86.avif"
     },
     {
         "franchise": "GSW",
@@ -16694,7 +16694,7 @@
         "seasons": [
             "1946-47"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1ecfc1413cb44a6fa29072d665b83b32~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1ecfc1413cb44a6fa29072d665b83b32~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1ecfc1413cb44a6fa29072d665b83b32.avif"
     },
     {
         "franchise": "GSW",
@@ -16708,7 +16708,7 @@
         "seasons": [
             "1947-48"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b531abd50c884aaf946cf7d2fe6e9549~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b531abd50c884aaf946cf7d2fe6e9549~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b531abd50c884aaf946cf7d2fe6e9549.avif"
     },
     {
         "franchise": "GSW",
@@ -16722,7 +16722,7 @@
         "seasons": [
             "1948-49"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d21f1171cb70474488b66440fa2e1898~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d21f1171cb70474488b66440fa2e1898~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d21f1171cb70474488b66440fa2e1898.avif"
     },
     {
         "franchise": "GSW",
@@ -16736,7 +16736,7 @@
         "seasons": [
             "1949-50"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6f54306ae2ab4ae4b222197f355db46e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6f54306ae2ab4ae4b222197f355db46e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6f54306ae2ab4ae4b222197f355db46e.avif"
     },
     {
         "franchise": "GSW",
@@ -16752,7 +16752,7 @@
             "1951-52",
             "1952-53"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1c6d4b2d4a7a48168fc5f3ee51edb687~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1c6d4b2d4a7a48168fc5f3ee51edb687~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1c6d4b2d4a7a48168fc5f3ee51edb687.avif"
     },
     {
         "franchise": "GSW",
@@ -16766,7 +16766,7 @@
         "seasons": [
             "1953-54"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_62d2eb26c7bd4444ac497325ca2356a5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_62d2eb26c7bd4444ac497325ca2356a5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_62d2eb26c7bd4444ac497325ca2356a5.avif"
     },
     {
         "franchise": "GSW",
@@ -16782,7 +16782,7 @@
             "1955-56",
             "1956-57"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c3a31bfc5666402892305f656710a237~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c3a31bfc5666402892305f656710a237~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c3a31bfc5666402892305f656710a237.avif"
     },
     {
         "franchise": "GSW",
@@ -16796,7 +16796,7 @@
         "seasons": [
             "1957-58"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_bfcdbe4545ec4e3a98a3e6846921dbd9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bfcdbe4545ec4e3a98a3e6846921dbd9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bfcdbe4545ec4e3a98a3e6846921dbd9.avif"
     },
     {
         "franchise": "GSW",
@@ -16810,7 +16810,7 @@
         "seasons": [
             "1958-59"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b4ae0af5e2a74d39865e3fffc6392323~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b4ae0af5e2a74d39865e3fffc6392323~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b4ae0af5e2a74d39865e3fffc6392323.avif"
     },
     {
         "franchise": "GSW",
@@ -16824,7 +16824,7 @@
         "seasons": [
             "1959-60"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c6600be8f1bb4ed1b2370e2a92be9081~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c6600be8f1bb4ed1b2370e2a92be9081~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c6600be8f1bb4ed1b2370e2a92be9081.avif"
     },
     {
         "franchise": "GSW",
@@ -16838,7 +16838,7 @@
         "seasons": [
             "1960-61"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ec48a051368f4d4fbd6c15ff0935e88e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ec48a051368f4d4fbd6c15ff0935e88e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ec48a051368f4d4fbd6c15ff0935e88e.avif"
     },
     {
         "franchise": "GSW",
@@ -16852,7 +16852,7 @@
         "seasons": [
             "1961-62"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_93a96b2b229f4d3985042620946f9f49~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_93a96b2b229f4d3985042620946f9f49~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_93a96b2b229f4d3985042620946f9f49.avif"
     },
     {
         "franchise": "GSW",
@@ -16866,7 +16866,7 @@
         "seasons": [
             "1962-63"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_eb58ca6c91cc42cca90acb957fad15db~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_eb58ca6c91cc42cca90acb957fad15db~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_eb58ca6c91cc42cca90acb957fad15db.avif"
     },
     {
         "franchise": "GSW",
@@ -16880,7 +16880,7 @@
         "seasons": [
             "1963-64"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_34a79129ec1447cd87e57e332e563e20~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_34a79129ec1447cd87e57e332e563e20~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_34a79129ec1447cd87e57e332e563e20.avif"
     },
     {
         "franchise": "GSW",
@@ -16895,7 +16895,7 @@
             "1964-65",
             "1965-66"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_6ba41ac9aa2442888c39973bca170752~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6ba41ac9aa2442888c39973bca170752~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6ba41ac9aa2442888c39973bca170752.avif"
     },
     {
         "franchise": "GSW",
@@ -16912,7 +16912,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_24a8235b2fe64480b9df6aad3a828bc3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_24a8235b2fe64480b9df6aad3a828bc3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_24a8235b2fe64480b9df6aad3a828bc3.avif"
     },
     {
         "franchise": "GSW",
@@ -16926,7 +16926,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b0d470b9e7db4f80bdd609be0172899c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b0d470b9e7db4f80bdd609be0172899c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b0d470b9e7db4f80bdd609be0172899c.avif"
     },
     {
         "franchise": "GSW",
@@ -16940,7 +16940,7 @@
         "seasons": [
             "1970-71"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b60013030323473190bc72ebbcf57298~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b60013030323473190bc72ebbcf57298~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b60013030323473190bc72ebbcf57298.avif"
     },
     {
         "franchise": "GSW",
@@ -16957,7 +16957,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e48d48cd73f84e968f43563c95e8459e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e48d48cd73f84e968f43563c95e8459e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e48d48cd73f84e968f43563c95e8459e.avif"
     },
     {
         "franchise": "GSW",
@@ -16972,7 +16972,7 @@
             "1973-74",
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d5817e3a97e44d6494d6744046fe6e71~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d5817e3a97e44d6494d6744046fe6e71~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d5817e3a97e44d6494d6744046fe6e71.avif"
     },
     {
         "franchise": "GSW",
@@ -16989,7 +16989,7 @@
             "1977-78",
             "1978-79"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8c3cdf9cd11544759e93160d4d07d26e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8c3cdf9cd11544759e93160d4d07d26e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8c3cdf9cd11544759e93160d4d07d26e.avif"
     },
     {
         "franchise": "GSW",
@@ -17005,7 +17005,7 @@
             "1981-82",
             "1982-83"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_40fbb3b70a1f43f1bb01adba57c3d450~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_40fbb3b70a1f43f1bb01adba57c3d450~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_40fbb3b70a1f43f1bb01adba57c3d450.avif"
     },
     {
         "franchise": "GSW",
@@ -17019,7 +17019,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f86ef584003648df82baae14e676cf9d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f86ef584003648df82baae14e676cf9d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f86ef584003648df82baae14e676cf9d.avif"
     },
     {
         "franchise": "GSW",
@@ -17033,7 +17033,7 @@
         "seasons": [
             "1983-84"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0d8ffb589e6a49f2a74a0581d5ac35d0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0d8ffb589e6a49f2a74a0581d5ac35d0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0d8ffb589e6a49f2a74a0581d5ac35d0.avif"
     },
     {
         "franchise": "GSW",
@@ -17048,7 +17048,7 @@
             "1984-85",
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b4986beafc3c4cfb81befb2dae7f6f4a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b4986beafc3c4cfb81befb2dae7f6f4a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b4986beafc3c4cfb81befb2dae7f6f4a.avif"
     },
     {
         "franchise": "GSW",
@@ -17062,7 +17062,7 @@
         "seasons": [
             "1986-87"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e79537ddcdf94d8a9e065bcc029996ef~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e79537ddcdf94d8a9e065bcc029996ef~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e79537ddcdf94d8a9e065bcc029996ef.avif"
     },
     {
         "franchise": "GSW",
@@ -17076,7 +17076,7 @@
         "seasons": [
             "1987-88"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_246896b2c5b04561a957776a60659fd6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_246896b2c5b04561a957776a60659fd6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_246896b2c5b04561a957776a60659fd6.avif"
     },
     {
         "franchise": "GSW",
@@ -17095,7 +17095,7 @@
             "1992-93",
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_56d0800ade4445939225de9ec0415bcf~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_56d0800ade4445939225de9ec0415bcf~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_56d0800ade4445939225de9ec0415bcf.avif"
     },
     {
         "franchise": "GSW",
@@ -17110,7 +17110,7 @@
             "1994-95",
             "1995-96"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7f71714eba0846638a40ae2acb161526~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7f71714eba0846638a40ae2acb161526~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7f71714eba0846638a40ae2acb161526.avif"
     },
     {
         "franchise": "GSW",
@@ -17124,7 +17124,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a3533455936040d287fe6f456dfad83b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a3533455936040d287fe6f456dfad83b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a3533455936040d287fe6f456dfad83b.avif"
     },
     {
         "franchise": "GSW",
@@ -17139,7 +17139,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_2ec03d1868bd44a4b2a57596130aa2cc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2ec03d1868bd44a4b2a57596130aa2cc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2ec03d1868bd44a4b2a57596130aa2cc.avif"
     },
     {
         "franchise": "GSW",
@@ -17154,7 +17154,7 @@
             "1999-00",
             "2000-01"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7b6cb281435f45d4a4acd43a53479321~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7b6cb281435f45d4a4acd43a53479321~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7b6cb281435f45d4a4acd43a53479321.avif"
     },
     {
         "franchise": "GSW",
@@ -17168,7 +17168,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e271691586764c2392d4a2267bc7a6c5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e271691586764c2392d4a2267bc7a6c5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e271691586764c2392d4a2267bc7a6c5.avif"
     },
     {
         "franchise": "GSW",
@@ -17189,7 +17189,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_57025fc3bb6a43c99638888f4220d2a2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_57025fc3bb6a43c99638888f4220d2a2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_57025fc3bb6a43c99638888f4220d2a2.avif"
     },
     {
         "franchise": "GSW",
@@ -17206,7 +17206,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_107ed58d68e2438fa2a644c7338504c0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_107ed58d68e2438fa2a644c7338504c0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_107ed58d68e2438fa2a644c7338504c0.avif"
     },
     {
         "franchise": "GSW",
@@ -17222,7 +17222,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b1ac5df8ae844de0a1ddad17dd371553~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b1ac5df8ae844de0a1ddad17dd371553~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b1ac5df8ae844de0a1ddad17dd371553.avif"
     },
     {
         "franchise": "GSW",
@@ -17237,7 +17237,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b42fc6e48bf946f796c33eba1f154250~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b42fc6e48bf946f796c33eba1f154250~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b42fc6e48bf946f796c33eba1f154250.avif"
     },
     {
         "franchise": "GSW",
@@ -17253,7 +17253,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e4c512c1040948299a5abf00dc421281~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e4c512c1040948299a5abf00dc421281~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e4c512c1040948299a5abf00dc421281.avif"
     },
     {
         "franchise": "GSW",
@@ -17267,7 +17267,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f1026ab0dff1461e8101cedf392af992~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f1026ab0dff1461e8101cedf392af992~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f1026ab0dff1461e8101cedf392af992.avif"
     },
     {
         "franchise": "GSW",
@@ -17281,7 +17281,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_77d5692ea9894513a34d7ccc590071c4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_77d5692ea9894513a34d7ccc590071c4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_77d5692ea9894513a34d7ccc590071c4.avif"
     },
     {
         "franchise": "GSW",
@@ -17295,7 +17295,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c4bc354c4b3844bbb44a79a4d6233e58~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c4bc354c4b3844bbb44a79a4d6233e58~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c4bc354c4b3844bbb44a79a4d6233e58.avif"
     },
     {
         "franchise": "GSW",
@@ -17310,7 +17310,7 @@
             "1979-80",
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0b73f97e60d4ff28338d5fc913eff56~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0b73f97e60d4ff28338d5fc913eff56~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0b73f97e60d4ff28338d5fc913eff56.avif"
     },
     {
         "franchise": "GSW",
@@ -17324,7 +17324,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a33b2ce24a654002800b08d63382d4d6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a33b2ce24a654002800b08d63382d4d6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a33b2ce24a654002800b08d63382d4d6.avif"
     },
     {
         "franchise": "GSW",
@@ -17343,7 +17343,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d0a883fd66ec41299b975c8f67249b59~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d0a883fd66ec41299b975c8f67249b59~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d0a883fd66ec41299b975c8f67249b59.avif"
     },
     {
         "franchise": "GSW",
@@ -17357,7 +17357,7 @@
         "seasons": [
             "2012-13"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_112a0c63bc9946cbab56023c2bcc67a5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_112a0c63bc9946cbab56023c2bcc67a5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_112a0c63bc9946cbab56023c2bcc67a5.avif"
     },
     {
         "franchise": "GSW",
@@ -17371,7 +17371,7 @@
         "seasons": [
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_919ac198585349e099a3f730b9fca306~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_919ac198585349e099a3f730b9fca306~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_919ac198585349e099a3f730b9fca306.avif"
     },
     {
         "franchise": "GSW",
@@ -17387,7 +17387,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_30d7c6f0ff24401badf7c05c45f687e6~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_30d7c6f0ff24401badf7c05c45f687e6~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_30d7c6f0ff24401badf7c05c45f687e6.avif"
     },
     {
         "franchise": "GSW",
@@ -17401,7 +17401,7 @@
         "seasons": [
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a50419c0f13f4e7e8859ac1144b0db5f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a50419c0f13f4e7e8859ac1144b0db5f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a50419c0f13f4e7e8859ac1144b0db5f.avif"
     },
     {
         "franchise": "GSW",
@@ -17416,7 +17416,7 @@
             "2017-18",
             "2018-19"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_647d229f9899447684f8c84c1b8c035b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_647d229f9899447684f8c84c1b8c035b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_647d229f9899447684f8c84c1b8c035b.avif"
     },
     {
         "franchise": "GSW",
@@ -17430,7 +17430,7 @@
         "seasons": [
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_84ad7d9e40ec46109055de06210430f0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_84ad7d9e40ec46109055de06210430f0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_84ad7d9e40ec46109055de06210430f0.avif"
     },
     {
         "franchise": "GSW",
@@ -17445,7 +17445,7 @@
             "2020-21",
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_329629a12a3d4dadbf8b0c78ce4660ff~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_329629a12a3d4dadbf8b0c78ce4660ff~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_329629a12a3d4dadbf8b0c78ce4660ff.avif"
     },
     {
         "franchise": "GSW",
@@ -17459,7 +17459,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f0f7a608b15f4bea9f0c413dcd106b39~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f0f7a608b15f4bea9f0c413dcd106b39~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f0f7a608b15f4bea9f0c413dcd106b39.avif"
     },
     {
         "franchise": "GSW",
@@ -17473,7 +17473,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e30fea637e4d4e9183cbf2c7ea80648b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e30fea637e4d4e9183cbf2c7ea80648b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e30fea637e4d4e9183cbf2c7ea80648b.avif"
     },
     {
         "franchise": "GSW",
@@ -17487,7 +17487,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_80198f6f805d49a4ab26199842090abb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_80198f6f805d49a4ab26199842090abb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_80198f6f805d49a4ab26199842090abb.avif"
     },
     {
         "franchise": "GSW",
@@ -17501,7 +17501,7 @@
         "seasons": [
             "2024-25"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c50f3bf6acc74a1c8929c0c62e452688~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c50f3bf6acc74a1c8929c0c62e452688~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c50f3bf6acc74a1c8929c0c62e452688.avif"
     },
     {
         "franchise": "BOS",
@@ -17513,7 +17513,7 @@
         "endYear": 1947,
         "years": "1946-47",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_0dbaa92eb6d04777bcc01d4d011840ca~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0dbaa92eb6d04777bcc01d4d011840ca~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0dbaa92eb6d04777bcc01d4d011840ca.avif"
     },
     {
         "franchise": "BOS",
@@ -17525,7 +17525,7 @@
         "endYear": 1949,
         "years": "1947-48 – 1948-49",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_fa1fd4c3a40f4d66b7c02333a22d2786~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fa1fd4c3a40f4d66b7c02333a22d2786~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fa1fd4c3a40f4d66b7c02333a22d2786.avif"
     },
     {
         "franchise": "BOS",
@@ -17537,7 +17537,7 @@
         "endYear": 1950,
         "years": "1949-50",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_b0534e325289424bb5d05626bf444cd1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b0534e325289424bb5d05626bf444cd1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b0534e325289424bb5d05626bf444cd1.avif"
     },
     {
         "franchise": "BOS",
@@ -17549,7 +17549,7 @@
         "endYear": 1954,
         "years": "1950-51 – 1953-54",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_035d1b772bdb4ceb9129fdbac7563714~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_035d1b772bdb4ceb9129fdbac7563714~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_035d1b772bdb4ceb9129fdbac7563714.avif"
     },
     {
         "franchise": "BOS",
@@ -17561,7 +17561,7 @@
         "endYear": 1965,
         "years": "1954-55 – 1964-65",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_c656e04403ea49de8c4ded5428eef9a4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c656e04403ea49de8c4ded5428eef9a4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c656e04403ea49de8c4ded5428eef9a4.avif"
     },
     {
         "franchise": "BOS",
@@ -17573,7 +17573,7 @@
         "endYear": 1967,
         "years": "1965-66 – 1966-67",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_b1094fa7f1a54c14a44d7fbf7e21124a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b1094fa7f1a54c14a44d7fbf7e21124a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b1094fa7f1a54c14a44d7fbf7e21124a.avif"
     },
     {
         "franchise": "BOS",
@@ -17585,7 +17585,7 @@
         "endYear": 1968,
         "years": "1967-68",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_6a92cb24181e4455ac48b9cd0ceb252f~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6a92cb24181e4455ac48b9cd0ceb252f~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6a92cb24181e4455ac48b9cd0ceb252f.avif"
     },
     {
         "franchise": "BOS",
@@ -17597,7 +17597,7 @@
         "endYear": 1986,
         "years": "1968-69 – 1985-86",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_05ae7d94d58c4dfc81933d1b67c6c63e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_05ae7d94d58c4dfc81933d1b67c6c63e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_05ae7d94d58c4dfc81933d1b67c6c63e.avif"
     },
     {
         "franchise": "BOS",
@@ -17609,7 +17609,7 @@
         "endYear": 1998,
         "years": "1986-87 – 1997-98",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_d2ff2b489f884158a79badeb2d7c1640~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d2ff2b489f884158a79badeb2d7c1640~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d2ff2b489f884158a79badeb2d7c1640.avif"
     },
     {
         "franchise": "BOS",
@@ -17621,7 +17621,7 @@
         "endYear": 2014,
         "years": "1998-99 – 2013-14",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_4bbe3110103c469f8b832831708931fd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_4bbe3110103c469f8b832831708931fd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_4bbe3110103c469f8b832831708931fd.avif"
     },
     {
         "franchise": "BOS",
@@ -17633,7 +17633,7 @@
         "endYear": 2017,
         "years": "2014-15 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_6f76bfe7b54c434b9e69ebfa2cb867cc~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6f76bfe7b54c434b9e69ebfa2cb867cc~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6f76bfe7b54c434b9e69ebfa2cb867cc.avif"
     },
     {
         "franchise": "BOS",
@@ -17645,7 +17645,7 @@
         "endYear": 2026,
         "years": "2017-18 – 2025-26",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_7ebc0427a1e2437f9e2bbfe5d1383499~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7ebc0427a1e2437f9e2bbfe5d1383499~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7ebc0427a1e2437f9e2bbfe5d1383499.avif"
     },
     {
         "franchise": "BOS",
@@ -17657,7 +17657,7 @@
         "endYear": 2017,
         "years": "2014-15 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_286f4c5298e14081802abc9bfadf3d34~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_286f4c5298e14081802abc9bfadf3d34~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_286f4c5298e14081802abc9bfadf3d34.avif"
     },
     {
         "franchise": "BOS",
@@ -17669,7 +17669,7 @@
         "endYear": 2026,
         "years": "2017-18 – 2025-26",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_011de2613b9e481d89f459ee7364c59d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_011de2613b9e481d89f459ee7364c59d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_011de2613b9e481d89f459ee7364c59d.avif"
     },
     {
         "franchise": "BOS",
@@ -17681,7 +17681,7 @@
         "endYear": 2014,
         "years": "2005-06 – 2013-14",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_76b073205aaf4bc389e2f59b018af6e2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_76b073205aaf4bc389e2f59b018af6e2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_76b073205aaf4bc389e2f59b018af6e2.avif"
     },
     {
         "franchise": "BOS",
@@ -17693,7 +17693,7 @@
         "endYear": 2017,
         "years": "2014-15 – 2016-17",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_3dd2097e728e4583ac799ecb41095669~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3dd2097e728e4583ac799ecb41095669~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3dd2097e728e4583ac799ecb41095669.avif"
     },
     {
         "franchise": "BOS",
@@ -17705,7 +17705,7 @@
         "endYear": 2020,
         "years": "2017-18 – 2019-20",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_6d87b2b3885145b894e11192dfdb7e96~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6d87b2b3885145b894e11192dfdb7e96~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6d87b2b3885145b894e11192dfdb7e96.avif"
     },
     {
         "franchise": "BOS",
@@ -17717,7 +17717,7 @@
         "endYear": 2022,
         "years": "2020-21 – 2021-22",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_1f6f4cb7e200400ba44ba64ac3a6d782~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1f6f4cb7e200400ba44ba64ac3a6d782~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1f6f4cb7e200400ba44ba64ac3a6d782.avif"
     },
     {
         "franchise": "BOS",
@@ -17729,7 +17729,7 @@
         "endYear": 2026,
         "years": "2022-23 – 2025-26",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_74934007b346455f882fa1be936afb30~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_74934007b346455f882fa1be936afb30~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_74934007b346455f882fa1be936afb30.avif"
     },
     {
         "franchise": "DEN",
@@ -17741,7 +17741,7 @@
         "endYear": 1971,
         "years": "1967-68 – 1970-71",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_6e44c91f5af24b319cd87770c71984b8~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_6e44c91f5af24b319cd87770c71984b8~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_6e44c91f5af24b319cd87770c71984b8.avif"
     },
     {
         "franchise": "DEN",
@@ -17753,7 +17753,7 @@
         "endYear": 1973,
         "years": "1971-72 – 1972-73",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_c8af9c36b14049ecb934d747ae67b5d1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c8af9c36b14049ecb934d747ae67b5d1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c8af9c36b14049ecb934d747ae67b5d1.avif"
     },
     {
         "franchise": "DEN",
@@ -17765,7 +17765,7 @@
         "endYear": 1974,
         "years": "1973-74",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_c7554c2806ff4d18af783b0abcdbfa23~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c7554c2806ff4d18af783b0abcdbfa23~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c7554c2806ff4d18af783b0abcdbfa23.avif"
     },
     {
         "franchise": "DEN",
@@ -17777,7 +17777,7 @@
         "endYear": 1975,
         "years": "1974-75",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_2a0028755a6f43c486958479ee2ced84~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_2a0028755a6f43c486958479ee2ced84~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_2a0028755a6f43c486958479ee2ced84.avif"
     },
     {
         "franchise": "DEN",
@@ -17789,7 +17789,7 @@
         "endYear": 1976,
         "years": "1975-76",
         "seasons": [],
-        "jersey": "https://static.wixstatic.com/media/31d308_bcb5f84b9ac34b6abf61fce2d11ef44a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_bcb5f84b9ac34b6abf61fce2d11ef44a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_bcb5f84b9ac34b6abf61fce2d11ef44a.avif"
     },
     {
         "franchise": "DEN",
@@ -17803,7 +17803,7 @@
         "seasons": [
             "1976-77"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_63435cc07d8d4862bf7de506594c28e3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_63435cc07d8d4862bf7de506594c28e3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_63435cc07d8d4862bf7de506594c28e3.avif"
     },
     {
         "franchise": "DEN",
@@ -17819,7 +17819,7 @@
             "1978-79",
             "1979-80"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e001250adcbb4e7aa8c57945cb4843d3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e001250adcbb4e7aa8c57945cb4843d3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e001250adcbb4e7aa8c57945cb4843d3.avif"
     },
     {
         "franchise": "DEN",
@@ -17833,7 +17833,7 @@
         "seasons": [
             "1980-81"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_274ef73cfe544a95adca09ae4a1750f0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_274ef73cfe544a95adca09ae4a1750f0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_274ef73cfe544a95adca09ae4a1750f0.avif"
     },
     {
         "franchise": "DEN",
@@ -17847,7 +17847,7 @@
         "seasons": [
             "1981-82"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_90ee2295ec45408fb5540e10b23e3fe9~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_90ee2295ec45408fb5540e10b23e3fe9~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_90ee2295ec45408fb5540e10b23e3fe9.avif"
     },
     {
         "franchise": "DEN",
@@ -17862,7 +17862,7 @@
             "1982-83",
             "1983-84"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_f85f71bb2ee54357956953c12977c803~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_f85f71bb2ee54357956953c12977c803~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_f85f71bb2ee54357956953c12977c803.avif"
     },
     {
         "franchise": "DEN",
@@ -17876,7 +17876,7 @@
         "seasons": [
             "1984-85"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_c0e474df8be8480ba10fc6eb42933f1a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_c0e474df8be8480ba10fc6eb42933f1a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_c0e474df8be8480ba10fc6eb42933f1a.avif"
     },
     {
         "franchise": "DEN",
@@ -17890,7 +17890,7 @@
         "seasons": [
             "1985-86"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_76aedfcf04984186ab9c30b93adc15d7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_76aedfcf04984186ab9c30b93adc15d7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_76aedfcf04984186ab9c30b93adc15d7.avif"
     },
     {
         "franchise": "DEN",
@@ -17908,7 +17908,7 @@
             "1989-90",
             "1990-91"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_ac35d1d0cbbc4be59eb730c13431eee4~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_ac35d1d0cbbc4be59eb730c13431eee4~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_ac35d1d0cbbc4be59eb730c13431eee4.avif"
     },
     {
         "franchise": "DEN",
@@ -17923,7 +17923,7 @@
             "1991-92",
             "1992-93"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_17b49a458fa44e8aa1459df9a1f073ee~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_17b49a458fa44e8aa1459df9a1f073ee~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_17b49a458fa44e8aa1459df9a1f073ee.avif"
     },
     {
         "franchise": "DEN",
@@ -17937,7 +17937,7 @@
         "seasons": [
             "1993-94"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_a89de38b583f4a9e8bdf171add0b250b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_a89de38b583f4a9e8bdf171add0b250b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_a89de38b583f4a9e8bdf171add0b250b.avif"
     },
     {
         "franchise": "DEN",
@@ -17954,7 +17954,7 @@
             "1997-98",
             "1998-99"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_dcd66d50d18b4d1f8d4a3f18f610147b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_dcd66d50d18b4d1f8d4a3f18f610147b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_dcd66d50d18b4d1f8d4a3f18f610147b.avif"
     },
     {
         "franchise": "DEN",
@@ -17968,7 +17968,7 @@
         "seasons": [
             "1996-97"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_949c8781fe904828bc04a9f460bb4e67~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_949c8781fe904828bc04a9f460bb4e67~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_949c8781fe904828bc04a9f460bb4e67.avif"
     },
     {
         "franchise": "DEN",
@@ -17984,7 +17984,7 @@
             "2000-01",
             "2002-03"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8ee97b9e685847308d483a13839b6001~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8ee97b9e685847308d483a13839b6001~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8ee97b9e685847308d483a13839b6001.avif"
     },
     {
         "franchise": "DEN",
@@ -17998,7 +17998,7 @@
         "seasons": [
             "2001-02"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_47a082a699ab4d7f9eb2824e68087ee5~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_47a082a699ab4d7f9eb2824e68087ee5~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_47a082a699ab4d7f9eb2824e68087ee5.avif"
     },
     {
         "franchise": "DEN",
@@ -18016,7 +18016,7 @@
             "2006-07",
             "2007-08"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fe1ba3280c084705957191c7f519f33c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fe1ba3280c084705957191c7f519f33c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fe1ba3280c084705957191c7f519f33c.avif"
     },
     {
         "franchise": "DEN",
@@ -18031,7 +18031,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_e4781e9579a24a2e85931ae362593791~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_e4781e9579a24a2e85931ae362593791~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_e4781e9579a24a2e85931ae362593791.avif"
     },
     {
         "franchise": "DEN",
@@ -18048,7 +18048,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_abb4b3d11d614235ab949aea258d438e~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_abb4b3d11d614235ab949aea258d438e~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_abb4b3d11d614235ab949aea258d438e.avif"
     },
     {
         "franchise": "DEN",
@@ -18062,7 +18062,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fed47ba6adb14dce82e42e0c0adc97e1~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fed47ba6adb14dce82e42e0c0adc97e1~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fed47ba6adb14dce82e42e0c0adc97e1.avif"
     },
     {
         "franchise": "DEN",
@@ -18077,7 +18077,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9b6a4089638b432f8bb278a4331ca4f2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9b6a4089638b432f8bb278a4331ca4f2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9b6a4089638b432f8bb278a4331ca4f2.avif"
     },
     {
         "franchise": "DEN",
@@ -18091,7 +18091,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_cd7d3194b3004e2b84ad61cd1409fe8b~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_cd7d3194b3004e2b84ad61cd1409fe8b~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_cd7d3194b3004e2b84ad61cd1409fe8b.avif"
     },
     {
         "franchise": "DEN",
@@ -18108,7 +18108,7 @@
             "2020-21",
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_0d16542ba8c3469fb7d6b04a7b0cc930~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_0d16542ba8c3469fb7d6b04a7b0cc930~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_0d16542ba8c3469fb7d6b04a7b0cc930.avif"
     },
     {
         "franchise": "DEN",
@@ -18122,7 +18122,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_d473d509801d42e489faed78220bb2c3~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_d473d509801d42e489faed78220bb2c3~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_d473d509801d42e489faed78220bb2c3.avif"
     },
     {
         "franchise": "DEN",
@@ -18136,7 +18136,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7da24eb15bdd46dd9f98ccade58e36ab~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7da24eb15bdd46dd9f98ccade58e36ab~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7da24eb15bdd46dd9f98ccade58e36ab.avif"
     },
     {
         "franchise": "DEN",
@@ -18154,7 +18154,7 @@
             "2008-09",
             "2009-10"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_503bf11693b34126b8c3cf5ae9bebce2~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_503bf11693b34126b8c3cf5ae9bebce2~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_503bf11693b34126b8c3cf5ae9bebce2.avif"
     },
     {
         "franchise": "DEN",
@@ -18169,7 +18169,7 @@
             "2010-11",
             "2011-12"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_502ea3b48d404f7eb0b1bf2d1364ce04~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_502ea3b48d404f7eb0b1bf2d1364ce04~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_502ea3b48d404f7eb0b1bf2d1364ce04.avif"
     },
     {
         "franchise": "DEN",
@@ -18184,7 +18184,7 @@
             "2012-13",
             "2013-14"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3d2e21264bc24716af4a0118bce301de~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3d2e21264bc24716af4a0118bce301de~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3d2e21264bc24716af4a0118bce301de.avif"
     },
     {
         "franchise": "DEN",
@@ -18198,7 +18198,7 @@
         "seasons": [
             "2014-15"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_3322e1dc21834b0fb2f61a5fb0949782~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_3322e1dc21834b0fb2f61a5fb0949782~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_3322e1dc21834b0fb2f61a5fb0949782.avif"
     },
     {
         "franchise": "DEN",
@@ -18213,7 +18213,7 @@
             "2015-16",
             "2016-17"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_fb37b348b33344dbb1bfac4c539e7217~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_fb37b348b33344dbb1bfac4c539e7217~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_fb37b348b33344dbb1bfac4c539e7217.avif"
     },
     {
         "franchise": "DEN",
@@ -18227,7 +18227,7 @@
         "seasons": [
             "2017-18"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b43de644170241e4aeac524651d7c4e0~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b43de644170241e4aeac524651d7c4e0~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b43de644170241e4aeac524651d7c4e0.avif"
     },
     {
         "franchise": "DEN",
@@ -18242,7 +18242,7 @@
             "2018-19",
             "2019-20"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_090676b92aa646cea04102386ee4d27a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_090676b92aa646cea04102386ee4d27a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_090676b92aa646cea04102386ee4d27a.avif"
     },
     {
         "franchise": "DEN",
@@ -18256,7 +18256,7 @@
         "seasons": [
             "2020-21"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b8efd4df30564a3d9b976989f56a30b7~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b8efd4df30564a3d9b976989f56a30b7~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b8efd4df30564a3d9b976989f56a30b7.avif"
     },
     {
         "franchise": "DEN",
@@ -18270,7 +18270,7 @@
         "seasons": [
             "2021-22"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_1bf5565491ed4ac2bcd82632ee5b55cd~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_1bf5565491ed4ac2bcd82632ee5b55cd~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_1bf5565491ed4ac2bcd82632ee5b55cd.avif"
     },
     {
         "franchise": "DEN",
@@ -18284,7 +18284,7 @@
         "seasons": [
             "2022-23"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_9baa35d2ecf945499f36b16bb471b3eb~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_9baa35d2ecf945499f36b16bb471b3eb~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_9baa35d2ecf945499f36b16bb471b3eb.avif"
     },
     {
         "franchise": "DEN",
@@ -18298,7 +18298,7 @@
         "seasons": [
             "2023-24"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_5db08747807a46f2926db413f14a7332~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_5db08747807a46f2926db413f14a7332~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_5db08747807a46f2926db413f14a7332.avif"
     },
     {
         "franchise": "UTS",
@@ -18312,7 +18312,7 @@
         "seasons": [
             "1967-68"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_da6fb62f231e4e6ca28d32433ecaa85d~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_da6fb62f231e4e6ca28d32433ecaa85d~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_da6fb62f231e4e6ca28d32433ecaa85d.avif"
     },
     {
         "franchise": "UTS",
@@ -18327,7 +18327,7 @@
             "1968-69",
             "1969-70"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_262c5b1bd51a4c328a0b3bb25542b20a~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_262c5b1bd51a4c328a0b3bb25542b20a~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_262c5b1bd51a4c328a0b3bb25542b20a.avif"
     },
     {
         "franchise": "UTS",
@@ -18342,7 +18342,7 @@
             "1970-71",
             "1971-72"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_7ba7627e30e742f5a2bfb85656b6976c~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_7ba7627e30e742f5a2bfb85656b6976c~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_7ba7627e30e742f5a2bfb85656b6976c.avif"
     },
     {
         "franchise": "UTS",
@@ -18357,7 +18357,7 @@
             "1972-73",
             "1973-74"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_156850969df24e45990ce2b1bc1f7699~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_156850969df24e45990ce2b1bc1f7699~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_156850969df24e45990ce2b1bc1f7699.avif"
     },
     {
         "franchise": "UTS",
@@ -18371,7 +18371,7 @@
         "seasons": [
             "1974-75"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_8fd96e77f7ac4f3296b1514d740326fe~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_8fd96e77f7ac4f3296b1514d740326fe~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_8fd96e77f7ac4f3296b1514d740326fe.avif"
     },
     {
         "franchise": "UTS",
@@ -18385,6 +18385,6 @@
         "seasons": [
             "1975-76"
         ],
-        "jersey": "https://static.wixstatic.com/media/31d308_b1ec55f60fbd491ab738d18dd0216172~mv2.png/v1/fit/w_400,h_400,q_85,enc_avif,quality_auto/31d308_b1ec55f60fbd491ab738d18dd0216172~mv2.png"
+        "jersey": "https://d2s6ea2hcvgd9x.cloudfront.net/jerseys/historical/31d308_b1ec55f60fbd491ab738d18dd0216172.avif"
     }
 ]


### PR DESCRIPTION
## Summary

`TeamBuilderAssetsCdn` is now deployed to production. This is the first real
(non-`--check`) run of `refresh-historical-jerseys` against it, and it
correctly refused to write three times before succeeding — each refusal was
a genuine bug, not a false alarm from an overly strict check.

## Bugs found and fixed

1. **`franchiseName` wrongly required.** `REQUIRED_FIELDS` demanded it
   non-empty, contradicting `resolveFranchise`'s own documented design —
   it's `""` on purpose for a handful of defunct teams with no
   `historicalLogos.json` entry to join against. Blocked on the same known
   13 rows every run. Removed from the required list.
2. **Transient 400s + a format lie.** Wix's image transform CDN occasionally
   400s momentarily — verified by hand that the exact same URL returns 200
   seconds later — and, separately, sometimes serves plain **PNG** bytes
   while still claiming `Content-Type: image/avif` and honoring the
   `enc_avif` request param. `fetchJerseyImage` now retries on 400 as well
   as 429, and detects the actual format from the bytes (S3 key extension
   and `Content-Type` follow suit) instead of assuming AVIF and rejecting a
   perfectly good image.
3. **One permanently blank gallery item treated as a layout-change signal.**
   `buildParsedJersey`'s doc comment claimed an unparseable season span
   "should never happen on a real page" — it does, permanently, for one
   title-less item in the `aba-sounds` gallery. Blank-titled items are now
   skipped silently; a *titled* item with no parseable span still blocks the
   write, which is the actual signal that contract is for.

## Result

`historicalJerseys.json`'s `jersey` URLs now point at the real CloudFront
distribution (`d2s6ea2hcvgd9x.cloudfront.net`) instead of bballjerseys.com's
own CDN. Same 1236 rows as before. Spot-checked 3 at random over HTTP: all
200, correct `Content-Type`.

## Verification

- `pnpm --filter cdk build/lint/test` (183 passed, +3 new tests covering the
  season-boundary helper and the blank-title skip)
- `pnpm --filter web type-check/test/check:styles`
- Live `curl` against 3 random rows' CloudFront URLs — 200, `image/avif`,
  real byte counts.

https://claude.ai/code/session_01N96ZpD1vHb2m4WEA36C9sz