### PR TITLE
fix(web): show login/logout state in Header

### DIFF
--- a/apps/web/src/composables/useLogtoSignIn.ts
+++ b/apps/web/src/composables/useLogtoSignIn.ts
@@ -14,18 +14,31 @@ interface SignInOptions {
 // otherwise show up here as a false "sign-in failed". We only treat it as
 // our own failure if this call is the one that just set it.
 export function useLogtoSignIn(buildOptions: () => SignInOptions) {
-    const { signIn, isAuthenticated, error: logtoError } = useLogto();
+    const { signIn, isAuthenticated, getAccessToken, error: logtoError } = useLogto();
     const router = useRouter();
     const error = ref<string>();
     const isSigningIn = ref(false);
 
     async function startSignIn() {
-        if (isAuthenticated.value) {
-            router.push('/');
-            return;
-        }
         if (isSigningIn.value) {
             return;
+        }
+
+        if (isAuthenticated.value) {
+            // isAuthenticated only reflects token presence, not expiry — a
+            // stale session with a dead refresh token would otherwise land
+            // here and bounce home instead of ever reaching a real sign-in.
+            // getAccessToken() refreshes on demand and resolves undefined
+            // (rather than throwing) if that refresh fails. Probe the same
+            // API-resource token App.vue actually needs — the default-resource
+            // token has its own refresh entry and can be valid independently.
+            isSigningIn.value = true;
+            const accessToken = await getAccessToken(import.meta.env.VITE_LOGTO_API_RESOURCE);
+            isSigningIn.value = false;
+            if (accessToken) {
+                router.push('/');
+                return;
+            }
         }
 
         isSigningIn.value = true;

--- a/apps/web/src/views/Header.vue
+++ b/apps/web/src/views/Header.vue
@@ -1,10 +1,22 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { RouterLink } from 'vue-router';
+import { useLogto } from '@logto/vue';
 import { ROUTES } from '@/constants/constants';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Separator } from '@/components/ui/separator';
 import { Menu } from 'lucide-vue-next';
+
+const { isAuthenticated, signOut } = useLogto();
+
+// Login is rendered separately below so it can swap for Logout once
+// isAuthenticated flips — the plain route loop has no notion of auth state.
+const navRoutes = computed(() => ROUTES.filter((route) => route.path !== '/login'));
+
+function handleSignOut() {
+    signOut(window.location.origin);
+}
 </script>
 
 <template>
@@ -23,11 +35,15 @@ import { Menu } from 'lucide-vue-next';
             <!-- Desktop Nav -->
             <nav class="md:flex flex-1 ml-8">
                 <ul>
-                    <template v-for="route in ROUTES" :key="route.id">
+                    <template v-for="route in navRoutes" :key="route.id">
                         <RouterLink :class="route?.class" :to="route.path">
                             {{ route.name }}
                         </RouterLink>
                     </template>
+                    <RouterLink v-if="!isAuthenticated" class="login" to="/login">
+                        Login
+                    </RouterLink>
+                    <button v-else class="login" @click="handleSignOut">Logout</button>
                 </ul>
             </nav>
 
@@ -40,7 +56,7 @@ import { Menu } from 'lucide-vue-next';
                 </SheetTrigger>
                 <SheetContent>
                     <nav class="flex flex-col gap-4 mt-8">
-                        <template v-for="route in ROUTES" :key="route.id">
+                        <template v-for="route in navRoutes" :key="route.id">
                             <RouterLink
                                 :class="['text-lg font-semibold', route?.class]"
                                 :to="route.path"
@@ -49,6 +65,16 @@ import { Menu } from 'lucide-vue-next';
                             </RouterLink>
                             <Separator />
                         </template>
+                        <RouterLink
+                            v-if="!isAuthenticated"
+                            class="text-lg font-semibold login"
+                            to="/login"
+                        >
+                            Login
+                        </RouterLink>
+                        <button v-else class="text-lg font-semibold login text-left" @click="handleSignOut">
+                            Logout
+                        </button>
                     </nav>
                 </SheetContent>
             </Sheet>
@@ -75,15 +101,20 @@ ul {
     gap: 2rem;
 }
 
-nav a {
+nav a,
+nav button {
     font-weight: 600;
     text-decoration: none;
     font-size: 1.15rem;
     color: hsl(var(--primary-foreground));
     padding: 0.5rem 0;
+    background: none;
+    border: none;
+    cursor: pointer;
 }
 
-nav a:hover {
+nav a:hover,
+nav button:hover {
     opacity: 0.8;
 }
 


### PR DESCRIPTION
## Problem

Clicking "Login" in the navbar did nothing for a signed-in user. Two compounding bugs:

1. `Header.vue` had no auth-aware UI — it always rendered a static "Login" link regardless of session state.
2. `useLogtoSignIn.ts`'s `startSignIn()` sent an authenticated user straight back to `/` whenever `isAuthenticated` was true, but that flag only reflects token presence, not expiry/validity — so a stale session with a dead refresh token would silently no-op on `/login` instead of ever reaching a real sign-in.

## Fix

- `Header.vue`: nav now renders Login (signed out) or Logout (signed in), in both the desktop nav and mobile sheet menu, styled consistently.
- `useLogtoSignIn.ts`: `startSignIn()` now probes `getAccessToken(VITE_LOGTO_API_RESOURCE)` — the same resource-scoped token the rest of the app actually uses (see `App.vue`) — and only redirects home if that refresh succeeds. Otherwise it falls through to a real sign-in.

## Testing

- `pnpm --filter web type-check`, `check:styles`, and the full test suite (via pre-commit hook) all pass.
- Verified locally: logged-out state shows Login and clicking it now navigates to `/login` (previously did nothing from `/`); logged-in state was verified to render Logout and call `signOut`.

https://claude.ai/code/session_01B36sapHap7PpE3e621Mis1