### PR TITLE
fix(web): stop jersey picker's selected checkmark clipping at tile border

### DIFF
--- a/apps/web/src/components/TeamBuilder/HistoricalJerseyPicker.vue
+++ b/apps/web/src/components/TeamBuilder/HistoricalJerseyPicker.vue
@@ -164,12 +164,12 @@ const handleJerseyClick = (jersey: HistoricalJersey) => {
                                 height="400"
                                 loading="lazy"
                             />
-                            <span v-if="jersey.jersey === teamJersey" class="team-jersey-check">
-                                <Check class="h-3 w-3" />
-                            </span>
                             <span v-if="jersey.slot === 'alternate'" class="team-jersey-badge">
                                 Alternate
                             </span>
+                        </span>
+                        <span v-if="jersey.jersey === teamJersey" class="team-jersey-check">
+                            <Check class="h-3 w-3" />
                         </span>
                         <span class="team-jersey-caption">
                             <span class="team-jersey-name">{{ jersey.franchiseName }}</span>
@@ -310,6 +310,7 @@ const handleJerseyClick = (jersey: HistoricalJersey) => {
 }
 
 .team-jersey-tile {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -362,9 +363,12 @@ const handleJerseyClick = (jersey: HistoricalJersey) => {
 }
 
 .team-jersey-check {
+    /* Positioned relative to the tile, not the plate - the plate clips
+       overflow for its artwork, which cut this badge off at the corner
+       when it lived inside it. */
     position: absolute;
-    top: -0.375rem;
-    right: -0.375rem;
+    top: 0.125rem;
+    right: 0.125rem;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Problem
The selected-jersey checkmark badge was barely visible, clipped under the tile's orange border — in both the normal grid and fullscreen jersey browser.

## Cause
`.team-jersey-check` lived inside `.team-jersey-plate`, which sets `overflow: hidden` to round off the artwork's corners. The badge's negative `top`/`right` offset pushed part of it outside the plate's bounds, so that corner got clipped.

## Fix
Moved the badge to be a sibling of the plate (a direct child of the tile) and repositioned it against the tile instead, so it's no longer inside the clipped element.

## Testing
- `pnpm --filter web type-check`, `check:styles`, and both packages' test suites pass (via pre-commit hook)
- Verified live in the running app (Playwright): checkmark now renders fully in the corner, no clipping

https://claude.ai/code/session_01B36sapHap7PpE3e621Mis1