### PR TITLE
fix(web): put Scores date/conference/view in the URL, fix line score overflow

### DIFF
--- a/apps/web/src/components/Scores/LineScore.vue
+++ b/apps/web/src/components/Scores/LineScore.vue
@@ -37,7 +37,7 @@ const lineScore = computed(() => {
     </div>
 </template>
 
-<style>
+<style scoped>
 .score-value {
     font-size: 1.5rem;
 }

--- a/apps/web/src/components/Scores/ScoreCard.vue
+++ b/apps/web/src/components/Scores/ScoreCard.vue
@@ -256,7 +256,11 @@ const toggleGameNotification = (): void => {
                     </div>
                 </div>
             </div>
-            <div class="scores-section" v-if="showScoresSection">
+            <div
+                class="scores-section"
+                v-if="showScoresSection"
+                :style="{ '--period-count': timePeriodLabels.length - 1 }"
+            >
                 <div class="time-periods">
                     <template
                         v-for="(
@@ -521,13 +525,17 @@ const toggleGameNotification = (): void => {
     flex-direction: column;
     gap: 0.5rem;
     flex-shrink: 0;
-    min-width: 12rem;
+    /* An explicit width, not just min-width: flex-shrink: 0 keeps a flex
+       item at its max-content size regardless of min-width, so a long
+       "(62-20, 29-12 Away)" record forced this section - and the score
+       grid it was squeezing - wider than intended unless the box is
+       actually constrained enough to wrap. */
+    width: 10rem;
 }
 
 .team-info {
     display: flex;
     flex-direction: column;
-    white-space: nowrap;
 }
 
 .game-status {
@@ -547,18 +555,35 @@ const toggleGameNotification = (): void => {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    margin-left: 1rem;
+    margin-left: 0.75rem;
+    /* Lets the grid below shrink past its own min-content instead of
+       forcing the card wider than its 1fr grid column - the scroll
+       fallback below is what actually catches an OT-heavy game. */
+    min-width: 0;
+    overflow-x: auto;
 }
 
 .scores-container,
 .time-periods {
     display: grid;
-    grid-auto-flow: column;
-    grid-auto-columns: 2rem;
+    /* Explicit tracks, not grid-auto-columns: a fixed 2rem column was
+       narrower than a 3-digit total ever needed to be, so the score just
+       rendered outside the card border. --period-count comes from the
+       template (timePeriodLabels.length - 1); the trailing 2.75rem track
+       is sized for the total, which runs larger (1.5rem/600) than a
+       per-quarter score. */
+    grid-template-columns: repeat(var(--period-count, 4), 1.75rem) 2.75rem;
     align-items: center;
     text-align: center;
-    justify-content: right;
-    gap: 1rem;
+    /* "safe" - plain `right` pins the grid's right edge to the container
+       even when the grid is wider than it, which pushes the overflow off
+       the *left* (start) edge. In a scrollable LTR container that's
+       negative scroll space - unreachable, so Q1 silently disappeared
+       instead of the total spilling out. `safe` falls back to start
+       alignment exactly when it would otherwise clip like that, so the
+       overflow lands on the right and overflow-x: auto above can reach it. */
+    justify-content: safe right;
+    gap: 0.75rem;
 }
 
 .score {
@@ -687,12 +712,18 @@ const toggleGameNotification = (): void => {
 
     .scores-container,
     .time-periods {
-        grid-auto-columns: 1.5rem;
-        gap: 0.25rem;
+        /* Below the 900px breakpoint .main-section is already a column, so
+           the score grid has the card's full width to itself - no need to
+           squeeze tracks the way the desktop 3-up grid does. Kept wide
+           enough for LineScore's own 1.1rem override below (it doesn't
+           inherit this font-size - see the :deep() rule). */
+        grid-template-columns: repeat(var(--period-count, 4), 1.75rem) 2.5rem;
+        gap: 0.5rem;
         font-size: 0.85rem;
     }
 
-    .score {
+    .score,
+    .scores-container :deep(.score-value) {
         font-size: 1.1rem;
     }
 

--- a/apps/web/src/composables/useScoresRouteState.ts
+++ b/apps/web/src/composables/useScoresRouteState.ts
@@ -1,0 +1,105 @@
+import { computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useScoresPreferences } from "./useScoresPreferences";
+import { toIsoDate, parseIsoDate } from "@/utils/date";
+import { VIEWS } from "@/constants/constants";
+
+const CONFERENCE_VALUES = ["ALL", "EAST", "WEST", "CROSS"];
+const VIEW_VALUES = [VIEWS.DEFAULT, VIEWS.LIST];
+
+export interface ScoresRouteStateBounds {
+    minDate: Date;
+    maxDate: Date;
+}
+
+/**
+ * Puts the Scores page's selected date, conference filter and view mode in
+ * the URL (?date=YYYY-MM-DD&conf=EAST&view=List), so a scoreboard for a
+ * specific day/filter combination can be linked or bookmarked. A query
+ * param wins when present; useScoresPreferences (localStorage) supplies the
+ * default when it's absent, and stays the source of truth for conf/view
+ * across visits that don't carry a query at all.
+ *
+ * Uses router.replace, not push, matching TeamBuilder.vue's ?team= sync -
+ * stepping through dates shouldn't fill the back-button stack. Reads via a
+ * route.query watcher rather than onMounted for the same reason
+ * TeamBuilder.vue does: navigating between /scores?date=A and a bare
+ * /scores (e.g. the nav bar link) reuses this component instance, so
+ * onMounted alone would miss it.
+ */
+export const useScoresRouteState = (bounds: ScoresRouteStateBounds) => {
+    const route = useRoute();
+    const router = useRouter();
+    const { preferences } = useScoresPreferences();
+
+    const setQuery = (patch: Record<string, string>) => {
+        router.replace({ query: { ...route.query, ...patch } });
+    };
+
+    const selectedDate = computed<Date>({
+        get: () => {
+            const raw = route.query.date;
+            if (typeof raw === "string") {
+                const parsed = parseIsoDate(raw);
+                if (parsed && parsed >= bounds.minDate && parsed <= bounds.maxDate) {
+                    return parsed;
+                }
+            }
+            return bounds.maxDate;
+        },
+        set: (value) => setQuery({ date: toIsoDate(value) }),
+    });
+
+    // An absent or invalid ?date= falls back to today silently in the
+    // getter above - write it back so the URL a user is actually looking
+    // at is always the shareable one, not just today's default.
+    watch(
+        () => route.query.date,
+        (raw) => {
+            const valid =
+                typeof raw === "string" &&
+                (() => {
+                    const parsed = parseIsoDate(raw);
+                    return !!parsed && parsed >= bounds.minDate && parsed <= bounds.maxDate;
+                })();
+            if (!valid) {
+                setQuery({ date: toIsoDate(bounds.maxDate) });
+            }
+        },
+        { immediate: true },
+    );
+
+    const conferenceFilter = computed<string>({
+        get: () => {
+            const raw = route.query.conf;
+            if (typeof raw === "string" && CONFERENCE_VALUES.includes(raw)) {
+                return raw;
+            }
+            return preferences.value.conferenceFilter;
+        },
+        set: (value) => {
+            preferences.value.conferenceFilter = value;
+            setQuery({ conf: value });
+        },
+    });
+
+    const selectedView = computed<string>({
+        get: () => {
+            const raw = route.query.view;
+            if (typeof raw === "string" && VIEW_VALUES.includes(raw)) {
+                return raw;
+            }
+            return preferences.value.selectedView;
+        },
+        set: (value) => {
+            preferences.value.selectedView = value;
+            setQuery({ view: value });
+        },
+    });
+
+    return {
+        selectedDate,
+        conferenceFilter,
+        selectedView,
+    };
+};

--- a/apps/web/src/composables/useScoresRouteState.ts
+++ b/apps/web/src/composables/useScoresRouteState.ts
@@ -47,7 +47,17 @@ export const useScoresRouteState = (bounds: ScoresRouteStateBounds) => {
             }
             return bounds.maxDate;
         },
-        set: (value) => setQuery({ date: toIsoDate(value) }),
+        set: (value) => {
+            // v-calendar's DatePicker emits null through v-model when a
+            // day without `is-required` is re-clicked to deselect it -
+            // toIsoDate(null) throws, so fall back to today rather than
+            // crashing the page on a second click of the selected date.
+            if (!(value instanceof Date)) {
+                setQuery({ date: toIsoDate(bounds.maxDate) });
+                return;
+            }
+            setQuery({ date: toIsoDate(value) });
+        },
     });
 
     // An absent or invalid ?date= falls back to today silently in the

--- a/apps/web/src/utils/date.ts
+++ b/apps/web/src/utils/date.ts
@@ -1,0 +1,56 @@
+/**
+ * Date helpers shared by anything that talks to ESPN's scoreboard/summary
+ * endpoints or puts a date in the URL. Lifted out of Scores.vue, which used
+ * to hand-roll its own formatDateForEspn/isSameDay - every other date format
+ * in the app (NewsCard, GameHeader, ...) is still inline, but the Scores
+ * page and its route-query composable both need these.
+ */
+
+/** ESPN's `dates=YYYYMMDD` query param format - no dashes. */
+export const formatDateForEspn = (d: Date): string => {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${year}${month}${day}`;
+};
+
+/** ISO 8601 calendar date (YYYY-MM-DD), for the ?date= query param. */
+export const toIsoDate = (d: Date): string => {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+};
+
+/**
+ * Parses a YYYY-MM-DD string as a *local* calendar date. Deliberately not
+ * `new Date(str)` - the string constructor parses ISO dates as UTC
+ * midnight, which renders as the previous day in any timezone west of
+ * Greenwich. Returns null for anything that doesn't parse to a real date.
+ */
+export const parseIsoDate = (value: string): Date | null => {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) return null;
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(year, month - 1, day);
+
+    // Catches both non-numeric input (NaN propagates) and calendar
+    // overflow, e.g. 2026-02-30 - Date silently rolls it into March.
+    if (
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day
+    ) {
+        return null;
+    }
+
+    return date;
+};
+
+export const isSameDay = (a: Date, b: Date): boolean =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();

--- a/apps/web/src/views/BoxScore.vue
+++ b/apps/web/src/views/BoxScore.vue
@@ -15,7 +15,7 @@
                 <Button @click="() => fetchGameSummary()" variant="outline" class="mt-4">
                     Try Again
                 </Button>
-                <Button @click="() => router.push('/scores')" variant="ghost" class="mt-2 ml-2">
+                <Button @click="() => backToScores()" variant="ghost" class="mt-2 ml-2">
                     Back to Scores
                 </Button>
             </div>
@@ -27,7 +27,7 @@
             <GameHeader
                 :game-summary="gameSummary"
                 :is-live="isLive"
-                @back="() => router.push('/scores')"
+                @back="() => backToScores()"
             />
 
             <!-- Quarter Scores -->
@@ -122,6 +122,7 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router';
 import { useGameSummary } from '@/composables/useGameSummary';
+import { toIsoDate } from '@/utils/date';
 import PageShell from '@/layouts/PageShell.vue';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
@@ -138,6 +139,19 @@ const router = useRouter();
 const gameId = route.params.gameId as string;
 
 const { gameSummary, loading, error, isLive, fetchGameSummary } = useGameSummary(gameId);
+
+// Carries the game's date back to /scores so the scoreboard reopens on the
+// same day rather than resetting to today - falls back to a bare navigation
+// if the game's date isn't loaded yet (e.g. the error state before any
+// fetch has succeeded).
+const backToScores = () => {
+    const gameDate = gameSummary.value?.header?.competitions?.[0]?.date;
+    if (!gameDate) {
+        router.push('/scores');
+        return;
+    }
+    router.push({ name: 'scores', query: { date: toIsoDate(new Date(gameDate)) } });
+};
 </script>
 
 <style scoped>

--- a/apps/web/src/views/Scores.vue
+++ b/apps/web/src/views/Scores.vue
@@ -16,6 +16,8 @@ import GameReplaysWarning from "@/components/Scores/GameReplaysWarning.vue";
 import ManageNotifications from "@/components/Scores/ManageNotifications.vue";
 import { useGameNotifications } from "@/composables/useGameNotifications";
 import { useScoresPreferences } from "@/composables/useScoresPreferences";
+import { useScoresRouteState } from "@/composables/useScoresRouteState";
+import { formatDateForEspn, isSameDay } from "@/utils/date";
 import OptionsMenu from "@/components/Scores/OptionsMenu.vue";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -32,7 +34,10 @@ const scoreData = ref<ESPNScoreboardResponse | null>(null);
 const today = new Date();
 const minDate = new Date("2000/01/01");
 
-const selectedDate = ref<Date>(today);
+const { selectedDate, conferenceFilter, selectedView } = useScoresRouteState({
+    minDate,
+    maxDate: today,
+});
 
 const gameCounts = ref<Map<string, number>>(new Map());
 const fetchedMonths = ref<Set<string>>(new Set());
@@ -81,13 +86,6 @@ const primaryDateString = computed(() =>
     })
 );
 
-const formatDateForEspn = (d: Date): string => {
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    return `${year}${month}${day}`;
-};
-
 // const gameStatus = ref([] as any[]);
 const gameData = ref<ESPNEvent[]>([]);
 const games = ref<any[]>([]);
@@ -103,14 +101,6 @@ const hideScores = computed({
 const hideFinishedGames = computed({
     get: () => scoresPreferences.value.hideFinishedGames,
     set: (value) => { scoresPreferences.value.hideFinishedGames = value; },
-});
-const selectedView = computed({
-    get: () => scoresPreferences.value.selectedView,
-    set: (value) => { scoresPreferences.value.selectedView = value; },
-});
-const conferenceFilter = computed({
-    get: () => scoresPreferences.value.conferenceFilter,
-    set: (value) => { scoresPreferences.value.conferenceFilter = value; },
 });
 
 const handleConferenceFilterChange = (value: string | undefined) => {
@@ -319,11 +309,6 @@ const sortedGameData = computed(() => {
 
 const displayedGamesCount = computed(() => filteredGameData.value.length);
 
-const isSameDay = (a: Date, b: Date) =>
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
-
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
 
 const startScorePolling = (events: ESPNEvent[], forDate: Date) => {
@@ -343,7 +328,11 @@ const startScorePolling = (events: ESPNEvent[], forDate: Date) => {
     }, SCOREBOARD_INTERVAL);
 };
 
-watch(selectedDate, async (newDate) => {
+watch(selectedDate, async (newDate, oldDate) => {
+    // useScoresRouteState writes a default ?date= into the URL on mount,
+    // which re-derives selectedDate as a new Date instance for the same
+    // calendar day - skip the refetch when nothing actually changed.
+    if (oldDate && isSameDay(newDate, oldDate)) return;
     const scoresData = await fetchCurrentScores(newDate);
     startScorePolling(scoresData.events ?? [], newDate);
 });

--- a/apps/web/tests/composables/useScoresRouteState.test.ts
+++ b/apps/web/tests/composables/useScoresRouteState.test.ts
@@ -88,6 +88,22 @@ describe("useScoresRouteState", () => {
         expect(router.currentRoute.value.query.date).toBe("2026-06-01");
     });
 
+    it("falls back to maxDate instead of throwing when the date picker emits null", async () => {
+        // v-calendar's DatePicker emits null through v-model when a day is
+        // re-clicked to deselect it, since Scores.vue doesn't set
+        // is-required - the setter has to tolerate that even though the
+        // type says Date.
+        const { state, router } = await mountWithRoute();
+        await flushPromises();
+
+        expect(() => {
+            state.selectedDate.value = null as unknown as Date;
+        }).not.toThrow();
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.date).toBe("2026-06-08");
+    });
+
     it("reads a valid conference filter from the query", async () => {
         const { state } = await mountWithRoute({ conf: "EAST" });
         expect(state.conferenceFilter.value).toBe("EAST");

--- a/apps/web/tests/composables/useScoresRouteState.test.ts
+++ b/apps/web/tests/composables/useScoresRouteState.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { defineComponent } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { useScoresRouteState } from "@/composables/useScoresRouteState";
+
+// Fixed "today" so assertions don't depend on when the suite runs.
+const TODAY = new Date(2026, 5, 8);
+const MIN_DATE = new Date(2000, 0, 1);
+
+const mountWithRoute = async (initialQuery: Record<string, string> = {}) => {
+    const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [{ path: "/scores", name: "scores", component: { template: "<div/>" } }],
+    });
+
+    let state!: ReturnType<typeof useScoresRouteState>;
+    const TestComponent = defineComponent({
+        setup() {
+            state = useScoresRouteState({ minDate: MIN_DATE, maxDate: TODAY });
+            return () => null;
+        },
+    });
+
+    const search = new URLSearchParams(initialQuery).toString();
+    await router.push(`/scores${search ? `?${search}` : ""}`);
+
+    const wrapper = mount(TestComponent, { global: { plugins: [router] } });
+    await flushPromises();
+
+    return { wrapper, router, state };
+};
+
+describe("useScoresRouteState", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("defaults to maxDate and writes it into the URL when ?date is absent", async () => {
+        const { router, state } = await mountWithRoute();
+        await flushPromises();
+
+        expect(state.selectedDate.value.getFullYear()).toBe(2026);
+        expect(state.selectedDate.value.getMonth()).toBe(5);
+        expect(state.selectedDate.value.getDate()).toBe(8);
+        expect(router.currentRoute.value.query.date).toBe("2026-06-08");
+    });
+
+    it("reads a valid ?date= param as a local date, not UTC", async () => {
+        const { state } = await mountWithRoute({ date: "2026-05-20" });
+
+        expect(state.selectedDate.value.getFullYear()).toBe(2026);
+        expect(state.selectedDate.value.getMonth()).toBe(4);
+        expect(state.selectedDate.value.getDate()).toBe(20);
+    });
+
+    it("falls back to maxDate and rewrites the URL for an unparseable date", async () => {
+        const { state, router } = await mountWithRoute({ date: "not-a-date" });
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.date).toBe("2026-06-08");
+        expect(state.selectedDate.value.getDate()).toBe(8);
+    });
+
+    it("clamps a date past maxDate back to maxDate", async () => {
+        const { state, router } = await mountWithRoute({ date: "2030-01-01" });
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.date).toBe("2026-06-08");
+        expect(state.selectedDate.value.getDate()).toBe(8);
+    });
+
+    it("clamps a date before minDate back to maxDate", async () => {
+        const { state, router } = await mountWithRoute({ date: "1990-01-01" });
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.date).toBe("2026-06-08");
+        expect(state.selectedDate.value.getDate()).toBe(8);
+    });
+
+    it("writing selectedDate updates the URL", async () => {
+        const { state, router } = await mountWithRoute();
+        await flushPromises();
+
+        state.selectedDate.value = new Date(2026, 5, 1);
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.date).toBe("2026-06-01");
+    });
+
+    it("reads a valid conference filter from the query", async () => {
+        const { state } = await mountWithRoute({ conf: "EAST" });
+        expect(state.conferenceFilter.value).toBe("EAST");
+    });
+
+    it("ignores an invalid conference value and falls back to preferences", async () => {
+        const { state } = await mountWithRoute({ conf: "NOT_A_CONF" });
+        expect(state.conferenceFilter.value).toBe("ALL");
+    });
+
+    it("writing conferenceFilter updates both the URL and localStorage", async () => {
+        const { state, router } = await mountWithRoute();
+        state.conferenceFilter.value = "WEST";
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.conf).toBe("WEST");
+        const stored = JSON.parse(localStorage.getItem("nba-scores-preferences")!);
+        expect(stored.conferenceFilter).toBe("WEST");
+    });
+
+    it("ignores an invalid view value and falls back to preferences", async () => {
+        const { state } = await mountWithRoute({ view: "Grid" });
+        expect(state.selectedView.value).toBe("Default");
+    });
+
+    it("writing selectedView updates both the URL and localStorage", async () => {
+        const { state, router } = await mountWithRoute();
+        state.selectedView.value = "List";
+        await flushPromises();
+
+        expect(router.currentRoute.value.query.view).toBe("List");
+        const stored = JSON.parse(localStorage.getItem("nba-scores-preferences")!);
+        expect(stored.selectedView).toBe("List");
+    });
+});

--- a/apps/web/tests/utils/date.test.ts
+++ b/apps/web/tests/utils/date.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { formatDateForEspn, toIsoDate, parseIsoDate, isSameDay } from "@/utils/date";
+
+describe("formatDateForEspn", () => {
+    it("formats as YYYYMMDD with no separators", () => {
+        expect(formatDateForEspn(new Date(2026, 5, 8))).toBe("20260608");
+    });
+
+    it("pads single-digit months and days", () => {
+        expect(formatDateForEspn(new Date(2026, 0, 5))).toBe("20260105");
+    });
+});
+
+describe("toIsoDate", () => {
+    it("formats as YYYY-MM-DD", () => {
+        expect(toIsoDate(new Date(2026, 5, 8))).toBe("2026-06-08");
+    });
+
+    it("pads single-digit months and days", () => {
+        expect(toIsoDate(new Date(2026, 0, 5))).toBe("2026-01-05");
+    });
+});
+
+describe("parseIsoDate", () => {
+    it("round-trips with toIsoDate", () => {
+        const original = new Date(2026, 5, 8);
+        expect(parseIsoDate(toIsoDate(original))!.getTime()).toBe(original.getTime());
+    });
+
+    it("parses as a local date, not UTC", () => {
+        // new Date("2026-06-08") parses as UTC midnight and renders as
+        // June 7th in any timezone west of Greenwich - this is the bug
+        // parseIsoDate exists to avoid.
+        const parsed = parseIsoDate("2026-06-08")!;
+        expect(parsed.getFullYear()).toBe(2026);
+        expect(parsed.getMonth()).toBe(5);
+        expect(parsed.getDate()).toBe(8);
+    });
+
+    it("returns null for a malformed string", () => {
+        expect(parseIsoDate("not-a-date")).toBeNull();
+        expect(parseIsoDate("2026/06/08")).toBeNull();
+        expect(parseIsoDate("")).toBeNull();
+    });
+
+    it("returns null for a calendar date that doesn't exist", () => {
+        // Date silently rolls Feb 30 into March - reject rather than
+        // silently accepting the wrong day.
+        expect(parseIsoDate("2026-02-30")).toBeNull();
+    });
+});
+
+describe("isSameDay", () => {
+    it("is true for the same calendar day at different times", () => {
+        expect(
+            isSameDay(new Date(2026, 5, 8, 1, 0), new Date(2026, 5, 8, 23, 59)),
+        ).toBe(true);
+    });
+
+    it("is false across a day boundary", () => {
+        expect(isSameDay(new Date(2026, 5, 8), new Date(2026, 5, 9))).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #71, closes #72.

## What
- `?date=YYYY-MM-DD&conf=EAST&view=List` on `/scores` — query param wins, `useScoresPreferences` (localStorage) supplies the default when it's absent, and changing a control writes both. Follows the `?team=` sync pattern already used in `TeamBuilder.vue` (`router.replace`, watching `route.query` rather than `onMounted`, since navigating between `/scores?date=A` and a bare `/scores` reuses the component instance).
- `BoxScore.vue`'s "Back to Scores" now carries the game's date back with it, so it reopens the scoreboard on the same day instead of resetting to today.
- Fixed a game card's total score rendering outside its card border (`ScoreCard.vue`). Root cause was two-fold: `grid-auto-columns: 2rem` was a fixed track narrower than a 3-digit total ever needed, and nothing in the flex chain constrained the card to its grid column, so the row simply overflowed.

## How
- New `apps/web/src/utils/date.ts` — `toIsoDate`/`parseIsoDate` (local-date-safe, not the UTC-parsing `new Date(str)` footgun) plus `formatDateForEspn`/`isSameDay` lifted out of `Scores.vue`.
- New `apps/web/src/composables/useScoresRouteState.ts` — the date/conf/view read-URL-else-preferences-write-both logic, unit tested.
- `ScoreCard.vue`: explicit `grid-template-columns` sized from a `--period-count` CSS var (handles OT), `overflow-x: auto` fallback, and `justify-content: safe right` instead of plain `right`. Plain `right` pins the grid's right edge even when it's wider than the container, pushing overflow off the *unreachable* start edge in a scrollable container — confirmed live, it silently hid Q1 entirely instead of letting the total spill right. `safe` falls back to start-alignment exactly when it would otherwise clip.
- A long team record string (`"(62-20, 29-12 Away)"`) was also forcing the teams column wider than its `min-width` under `flex-shrink: 0` (a min-width is a floor, not a cap — `flex-shrink:0` keeps a flex item at its max-content size regardless), squeezing the score grid further. Given an explicit `width` instead so it wraps onto two lines.
- `LineScore.vue`'s `<style>` block was unscoped, leaking `.score-value` globally — scoped it.

## Verification
```
pnpm --filter web type-check   # clean
pnpm --filter web check:styles # 147 files, no problems
pnpm --filter web lint         # 0 errors (148 pre-existing no-explicit-any warnings)
pnpm --filter web test         # 116/116 (14 new: date.test.ts, useScoresRouteState.test.ts)
pnpm --filter web test:visual  # 20/20, no baseline diffs (Scores route stub has 0 games, so the card grid change isn't exercised by that fixture)
```
Manually verified against a real game (401859965, Spurs @ Knicks, 2026-06-08) via a live dev server at 1440/1280/900/640px and in List view: total fits inside the card border at every width, `?date=`/`?conf=`/`?view=` round-trip through reload and through a game's "Back to Scores".