### PR TITLE
fix(web): wire up dead filter checkboxes in Arena/Coach/GM drawers

### DIFF
--- a/apps/web/src/components/TeamBuilder/ArenaSection.vue
+++ b/apps/web/src/components/TeamBuilder/ArenaSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { WESTERN_TEAMS, EASTERN_TEAMS } from "@/constants/constants";
+import { CONFERENCE_FILTER_TEAMS } from "@/constants/constants";
 import type { Arena, SortDirection, DrawerSide } from "@/models/types";
 import arenaData from "@/assets/data/arenas.json";
 import { getRandomIndex, getWikipediaUrl } from "@/constants/utilities";
@@ -55,13 +55,6 @@ const sortOptions = ["Alphabetic", "Capacity"];
 const selectedSort = ref<string | null>(null);
 const selectedFilters = ref<string[]>([]);
 const ARENA_FILTERS = ["Western Conference", "Eastern Conference"];
-// Maps a filter label to the team list it matches against, so multiple
-// selected filters can be OR-ed together below instead of AND-ed - ticking
-// both conferences should show every arena, not none of them.
-const CONFERENCE_TEAMS: Record<string, string[]> = {
-    "Western Conference": WESTERN_TEAMS,
-    "Eastern Conference": EASTERN_TEAMS,
-};
 const sortDirection = ref<SortDirection>("asc");
 
 /* Computed Props */
@@ -102,7 +95,7 @@ const filteredArenaData = computed(() => {
     if (selectedFilters.value.length > 0) {
         copyArenaData = copyArenaData.filter((arena: Arena) =>
             selectedFilters.value.some((filter) =>
-                CONFERENCE_TEAMS[filter]?.includes(arena.team)
+                CONFERENCE_FILTER_TEAMS[filter]?.includes(arena.team)
             )
         );
     }

--- a/apps/web/src/components/TeamBuilder/ArenaSection.vue
+++ b/apps/web/src/components/TeamBuilder/ArenaSection.vue
@@ -55,6 +55,13 @@ const sortOptions = ["Alphabetic", "Capacity"];
 const selectedSort = ref<string | null>(null);
 const selectedFilters = ref<string[]>([]);
 const ARENA_FILTERS = ["Western Conference", "Eastern Conference"];
+// Maps a filter label to the team list it matches against, so multiple
+// selected filters can be OR-ed together below instead of AND-ed - ticking
+// both conferences should show every arena, not none of them.
+const CONFERENCE_TEAMS: Record<string, string[]> = {
+    "Western Conference": WESTERN_TEAMS,
+    "Eastern Conference": EASTERN_TEAMS,
+};
 const sortDirection = ref<SortDirection>("asc");
 
 /* Computed Props */
@@ -70,12 +77,12 @@ const sortedArenaData = computed(() => {
             });
         case "Capacity":
             return copyArenaData.sort((a: Arena, b: Arena) => {
-                const capacityA = parseInt(a.capacity.replace(",", ""));
-                const capacityB = parseInt(b.capacity.replace(",", ""));
+                const capacityA = parseInt(a.capacity.replaceAll(",", ""));
+                const capacityB = parseInt(b.capacity.replaceAll(",", ""));
                 return sortModifier * (capacityA - capacityB);
             });
         default:
-            return typedArenaData;
+            return copyArenaData;
     }
 });
 
@@ -90,27 +97,14 @@ const filteredArenaData = computed(() => {
         );
     }
 
-    /* Apply checkbox filters */
+    /* Apply checkbox filters - a team only needs to match one selected
+       conference, not all of them. */
     if (selectedFilters.value.length > 0) {
-        copyArenaData = copyArenaData.filter((arena: Arena) => {
-            const { team } = arena;
-
-            if (selectedFilters.value.includes("Western Conference")) {
-                const isWesternTeam = WESTERN_TEAMS.includes(team);
-                if (!isWesternTeam) {
-                    return false;
-                }
-            }
-
-            if (selectedFilters.value.includes("Eastern Conference")) {
-                const isEasternTeam = EASTERN_TEAMS.includes(team);
-                if (!isEasternTeam) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
+        copyArenaData = copyArenaData.filter((arena: Arena) =>
+            selectedFilters.value.some((filter) =>
+                CONFERENCE_TEAMS[filter]?.includes(arena.team)
+            )
+        );
     }
 
     return copyArenaData;
@@ -265,8 +259,8 @@ const toggleFilter = (filter: string) => {
                                 <DropdownMenuCheckboxItem
                                     v-for="filter in ARENA_FILTERS"
                                     :key="filter"
-                                    :checked="selectedFilters.includes(filter)"
-                                    @update:checked="() => toggleFilter(filter)"
+                                    :model-value="selectedFilters.includes(filter)"
+                                    @update:model-value="() => toggleFilter(filter)"
                                     class="cursor-pointer focus:!bg-accent"
                                 >
                                     {{ filter }}
@@ -288,7 +282,11 @@ const toggleFilter = (filter: string) => {
 
                 <Separator class="my-4 flex-shrink-0" />
 
-                <ScrollArea class="flex-1 overflow-auto">
+                <!-- -mr-6 cancels the Sheet's own right padding (p-6) so the
+                     scrollbar rides the panel's true edge instead of sitting
+                     1.5rem in from it; arena-list's pr-6 puts that space back
+                     as room for the cards, clear of the scrollbar itself. -->
+                <ScrollArea class="flex-1 -mr-6">
                     <!-- Empty State -->
                     <div v-if="filteredArenaData.length === 0" class="flex flex-col items-center justify-center py-12 px-4 text-center">
                         <div class="h-16 w-16 text-muted-foreground/50 mb-4 flex items-center justify-center text-4xl">🏟️</div>
@@ -299,7 +297,7 @@ const toggleFilter = (filter: string) => {
                     </div>
 
                     <!-- Arena List -->
-                    <div v-else class="arena-list pr-2">
+                    <div v-else class="arena-list pr-6">
                         <div
                             v-for="(arena, index) in filteredArenaData"
                             :key="index"

--- a/apps/web/src/components/TeamBuilder/CoachSection.vue
+++ b/apps/web/src/components/TeamBuilder/CoachSection.vue
@@ -452,8 +452,8 @@ const getCleanName = (coachName: string) => coachName.replace(/\*$/, '').trim();
                                 <DropdownMenuCheckboxItem
                                     v-for="filter in COACH_FILTERS"
                                     :key="filter"
-                                    :checked="selectedFilters.includes(filter)"
-                                    @update:checked="() => toggleFilter(filter)"
+                                    :model-value="selectedFilters.includes(filter)"
+                                    @update:model-value="() => toggleFilter(filter)"
                                     class="cursor-pointer focus:!bg-accent"
                                 >
                                     {{ filter }}

--- a/apps/web/src/components/TeamBuilder/CoachSection.vue
+++ b/apps/web/src/components/TeamBuilder/CoachSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import type { Coach, SortDirection, DrawerSide } from '@/models/types';
+import { CURRENT_SEASON_START_YEAR } from '@/constants/constants';
 import coachesData from '@/assets/data/coaches.json';
 import { getRandomIndex, roundValueToNPlaces, getWikipediaUrl } from '@/constants/utilities';
 import ExternalLinksMenu from '@/components/ExternalLinksMenu.vue';
@@ -168,14 +169,27 @@ const filteredCoachesData = computed(() => {
         );
     }
 
-    /* Apply checkbox filters */
+    /* Apply checkbox filters - both are AND-ed: they're independent facets
+       (still coaching vs. career honor), not mutually-exclusive categories
+       like ArenaSection/GMSection's conference filters, so a coach ticking
+       both wants the intersection, not the union. */
     if (selectedFilters.value.length > 0) {
         copyCoachData = copyCoachData.filter((coach: Coach) => {
-            const { name } = coach;
+            const { name, to } = coach;
             const isHallOfFamer = name.endsWith('*');
+            // coaches.json's `to` is a season-end year (the 2025-26 season
+            // is `to: 2026`) - CURRENT_SEASON_START_YEAR is that season's
+            // start year, so +1 gets back to the same end-year convention.
+            const isCurrentSeason = to === CURRENT_SEASON_START_YEAR + 1;
 
             if (selectedFilters.value.includes('Hall of Famer')) {
                 if (!isHallOfFamer) {
+                    return false;
+                }
+            }
+
+            if (selectedFilters.value.includes('Current Season Only')) {
+                if (!isCurrentSeason) {
                     return false;
                 }
             }

--- a/apps/web/src/components/TeamBuilder/GMSection.vue
+++ b/apps/web/src/components/TeamBuilder/GMSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import type { GM, NBATeam, SortDirection, DrawerSide } from "@/models/types";
-import { WESTERN_TEAMS, EASTERN_TEAMS } from "@/constants/constants";
+import { CONFERENCE_FILTER_TEAMS } from "@/constants/constants";
 import gmData from "@/assets/data/execs.json";
 import nbaTeamsData from "@/assets/data/nbaTeams.json";
 import { getRandomIndex, getWikipediaUrl } from "@/constants/utilities";
@@ -73,10 +73,6 @@ const selectedFilters = ref<string[]>([]);
 const GM_FILTERS = ["Western Conference", "Eastern Conference"];
 // A GM matches a selected conference if any team on their resume is in it;
 // multiple selected filters are OR-ed, same reasoning as ArenaSection.
-const CONFERENCE_TEAMS: Record<string, string[]> = {
-    "Western Conference": WESTERN_TEAMS,
-    "Eastern Conference": EASTERN_TEAMS,
-};
 
 // GM.teams entries aren't full team names like Arena's - execs.json gives
 // "BOS (2003-21)" (Basketball-Reference abbreviation + year range) and
@@ -131,7 +127,7 @@ const filteredGMData = computed(() => {
             selectedFilters.value.some((filter) =>
                 gm.teams?.some((entry) => {
                     const fullName = teamAbbrToFullName(entry);
-                    return !!fullName && CONFERENCE_TEAMS[filter]?.includes(fullName);
+                    return !!fullName && CONFERENCE_FILTER_TEAMS[filter]?.includes(fullName);
                 })
             )
         );

--- a/apps/web/src/components/TeamBuilder/GMSection.vue
+++ b/apps/web/src/components/TeamBuilder/GMSection.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import type { GM, SortDirection, DrawerSide } from "@/models/types";
+import type { GM, NBATeam, SortDirection, DrawerSide } from "@/models/types";
+import { WESTERN_TEAMS, EASTERN_TEAMS } from "@/constants/constants";
 import gmData from "@/assets/data/execs.json";
+import nbaTeamsData from "@/assets/data/nbaTeams.json";
 import { getRandomIndex, getWikipediaUrl } from "@/constants/utilities";
 import ExternalLinksMenu from "@/components/ExternalLinksMenu.vue";
 import { useCustomGMs } from "@/composables/useCustomGMs";
@@ -69,6 +71,24 @@ const sortOptions = ["Alphabetic"];
 const selectedSort = ref<string | null>(null);
 const selectedFilters = ref<string[]>([]);
 const GM_FILTERS = ["Western Conference", "Eastern Conference"];
+// A GM matches a selected conference if any team on their resume is in it;
+// multiple selected filters are OR-ed, same reasoning as ArenaSection.
+const CONFERENCE_TEAMS: Record<string, string[]> = {
+    "Western Conference": WESTERN_TEAMS,
+    "Eastern Conference": EASTERN_TEAMS,
+};
+
+// GM.teams entries aren't full team names like Arena's - execs.json gives
+// "BOS (2003-21)" (Basketball-Reference abbreviation + year range) and
+// CreateCustomGMModal stores a bare abbreviation ("BOS"). Both need
+// resolving to a full name before they mean anything against
+// WESTERN_TEAMS/EASTERN_TEAMS.
+const ABBR_TO_FULL_NAME: Record<string, string> = Object.fromEntries(
+    (nbaTeamsData as NBATeam[]).map((team) => [team.abbr, team.name])
+);
+const teamAbbrToFullName = (entry: string): string | undefined =>
+    ABBR_TO_FULL_NAME[entry.match(/^[A-Z]+/)?.[0] ?? ""];
+
 const sortDirection = ref<SortDirection>("asc");
 
 /* Computed Props */
@@ -104,10 +124,17 @@ const filteredGMData = computed(() => {
         );
     }
 
-    /* Apply checkbox filters - Note: GM filters not implemented yet */
+    /* Apply checkbox filters - a GM matches if any of their teams is in a
+       selected conference. */
     if (selectedFilters.value.length > 0) {
-        // Filter logic would go here when implemented
-        return copyGMData;
+        copyGMData = copyGMData.filter((gm: GM) =>
+            selectedFilters.value.some((filter) =>
+                gm.teams?.some((entry) => {
+                    const fullName = teamAbbrToFullName(entry);
+                    return !!fullName && CONFERENCE_TEAMS[filter]?.includes(fullName);
+                })
+            )
+        );
     }
 
     return copyGMData;
@@ -342,8 +369,8 @@ const handleDeleteGM = async () => {
                                 <DropdownMenuCheckboxItem
                                     v-for="filter in GM_FILTERS"
                                     :key="filter"
-                                    :checked="selectedFilters.includes(filter)"
-                                    @update:checked="() => toggleFilter(filter)"
+                                    :model-value="selectedFilters.includes(filter)"
+                                    @update:model-value="() => toggleFilter(filter)"
                                     class="cursor-pointer focus:!bg-accent"
                                 >
                                     {{ filter }}

--- a/apps/web/src/constants/constants.ts
+++ b/apps/web/src/constants/constants.ts
@@ -99,6 +99,15 @@ export const EASTERN_TEAMS = [
     "Washington Wizards",
 ];
 
+// Shared by ArenaSection/GMSection's "Filters" dropdown: maps a filter label
+// to the team list it matches against, so selecting multiple filters ORs
+// them together instead of ANDing them - used to be declared identically in
+// both components.
+export const CONFERENCE_FILTER_TEAMS: Record<string, string[]> = {
+    "Western Conference": WESTERN_TEAMS,
+    "Eastern Conference": EASTERN_TEAMS,
+};
+
 export const HOME = "home";
 export const HOME_C = "Home";
 export const AWAY = "away";

--- a/apps/web/tests/components/ArenaSection.test.ts
+++ b/apps/web/tests/components/ArenaSection.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import ArenaSection from "@/components/TeamBuilder/ArenaSection.vue";
+
+// Sheet and DropdownMenu both portal their content to document.body via
+// Teleport, so everything below queries the live document directly instead
+// of the wrapper's own render tree, which Teleport moves this content out of.
+const mountArenaDrawerOpen = () =>
+    mount(ArenaSection, {
+        props: {
+            selectedDrawerSide: "right",
+            teamArena: null,
+            "onUpdate:teamArena": () => {},
+            showArenaDrawer: true,
+            "onUpdate:showArenaDrawer": () => {},
+        },
+        attachTo: document.body,
+    });
+
+const findButton = (label: string) =>
+    [...document.querySelectorAll("button")].find((b) =>
+        b.textContent?.trim().startsWith(label),
+    ) as HTMLButtonElement;
+
+const filterCheckbox = (label: string) =>
+    [...document.querySelectorAll('[role="menuitemcheckbox"]')].find(
+        (el) => el.textContent?.trim() === label,
+    ) as HTMLElement;
+
+const arenaCardNames = () =>
+    [...document.querySelectorAll(".arena-item .arena-name-improved")].map(
+        (el) => el.textContent?.trim(),
+    );
+
+describe("ArenaSection filters", () => {
+    // Sheet/DropdownMenu Teleport content straight to document.body, outside
+    // the wrapper's own tree - unmount() must run for it to clean up, so an
+    // assertion failure mid-test would otherwise leak DOM into the next one.
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+
+    it("opens the Filters dropdown and lists both conference options", async () => {
+        const wrapper = mountArenaDrawerOpen();
+        // Sheet/DropdownMenu's Teleport target isn't attached until after
+        // the initial mount tick.
+        await nextTick();
+        await nextTick();
+        findButton("Filters").click();
+        await nextTick();
+
+        expect(filterCheckbox("Western Conference")).toBeTruthy();
+        expect(filterCheckbox("Eastern Conference")).toBeTruthy();
+        wrapper.unmount();
+    });
+
+    it("ticks a checkbox and narrows the list on the first click", async () => {
+        // Regression test for the dead :checked/@update:checked binding -
+        // reka-ui's DropdownMenuCheckboxItem only has modelValue/
+        // update:modelValue, so :checked fell through as a no-op attribute
+        // and this filter never fired.
+        const wrapper = mountArenaDrawerOpen();
+        // Sheet/DropdownMenu's Teleport target isn't attached until after
+        // the initial mount tick.
+        await nextTick();
+        await nextTick();
+        const allCount = arenaCardNames().length;
+        expect(allCount).toBeGreaterThan(0);
+
+        findButton("Filters").click();
+        await nextTick();
+        filterCheckbox("Western Conference").click();
+        await nextTick();
+
+        expect(findButton("Filters").textContent).toContain("1");
+        expect(arenaCardNames().length).toBeLessThan(allCount);
+        expect(arenaCardNames().length).toBeGreaterThan(0);
+        wrapper.unmount();
+    });
+
+    it("OR-s multiple selected conferences instead of AND-ing them", async () => {
+        // Selecting both conferences used to require a team to be in both
+        // WESTERN_TEAMS and EASTERN_TEAMS, which is impossible - the list
+        // silently went to zero arenas instead of showing all of them.
+        const wrapper = mountArenaDrawerOpen();
+        // Sheet/DropdownMenu's Teleport target isn't attached until after
+        // the initial mount tick.
+        await nextTick();
+        await nextTick();
+        const allCount = arenaCardNames().length;
+
+        findButton("Filters").click();
+        await nextTick();
+        filterCheckbox("Western Conference").click();
+        await nextTick();
+        filterCheckbox("Eastern Conference").click();
+        await nextTick();
+
+        expect(arenaCardNames().length).toBe(allCount);
+        wrapper.unmount();
+    });
+});

--- a/apps/web/tests/components/CoachSection.test.ts
+++ b/apps/web/tests/components/CoachSection.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import CoachSection from "@/components/TeamBuilder/CoachSection.vue";
+import { CURRENT_SEASON_START_YEAR } from "@/constants/constants";
+import coachesData from "@/assets/data/coaches.json";
+
+// Sheet and DropdownMenu both portal their content to document.body via
+// Teleport, so everything below queries the live document directly instead
+// of the wrapper's own render tree, which Teleport moves this content out of.
+const mountCoachDrawerOpen = () =>
+    mount(CoachSection, {
+        props: {
+            selectedDrawerSide: "right",
+            teamCoach: null,
+            "onUpdate:teamCoach": () => {},
+            showCoachDrawer: true,
+            "onUpdate:showCoachDrawer": () => {},
+        },
+        attachTo: document.body,
+    });
+
+const findButton = (label: string) =>
+    [...document.querySelectorAll("button")].find((b) =>
+        b.textContent?.trim().startsWith(label),
+    ) as HTMLButtonElement;
+
+const filterCheckbox = (label: string) =>
+    [...document.querySelectorAll('[role="menuitemcheckbox"]')].find(
+        (el) => el.textContent?.trim() === label,
+    ) as HTMLElement;
+
+const coachNames = () =>
+    [...document.querySelectorAll(".coach-item .coach-list-item-name")].map(
+        (el) => el.textContent?.trim(),
+    );
+
+describe("CoachSection filters", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("narrows the list when 'Current Season Only' is ticked, instead of doing nothing", async () => {
+        // Regression test: fixing the dead :checked/@update:checked binding
+        // made this checkbox tick and count, but filteredCoachesData's
+        // predicate only ever branched on 'Hall of Famer' - 'Current
+        // Season Only' was listed in COACH_FILTERS yet had no matching
+        // branch, so ticking it silently changed nothing.
+        const expectedCount = (coachesData as { to: number }[]).filter(
+            (c) => c.to === CURRENT_SEASON_START_YEAR + 1,
+        ).length;
+        expect(expectedCount).toBeGreaterThan(0);
+
+        const wrapper = mountCoachDrawerOpen();
+        await nextTick();
+        await nextTick();
+        const allCount = coachNames().length;
+
+        findButton("Filters").click();
+        await nextTick();
+        filterCheckbox("Current Season Only").click();
+        await nextTick();
+
+        expect(findButton("Filters").textContent).toContain("1");
+        expect(coachNames().length).toBeLessThan(allCount);
+        expect(coachNames().length).toBe(expectedCount);
+        wrapper.unmount();
+    });
+
+    it("AND-s 'Current Season Only' and 'Hall of Famer' instead of OR-ing them", async () => {
+        // Unlike ArenaSection/GMSection's conference filters (the same
+        // facet, so OR is correct), these two are independent facets -
+        // ticking both should narrow further, not union back out.
+        const wrapper = mountCoachDrawerOpen();
+        await nextTick();
+        await nextTick();
+
+        findButton("Filters").click();
+        await nextTick();
+        filterCheckbox("Current Season Only").click();
+        await nextTick();
+        const currentOnly = coachNames().length;
+
+        filterCheckbox("Hall of Famer").click();
+        await nextTick();
+        const both = coachNames().length;
+
+        expect(both).toBeLessThanOrEqual(currentOnly);
+        wrapper.unmount();
+    });
+});

--- a/apps/web/tests/components/GMSection.test.ts
+++ b/apps/web/tests/components/GMSection.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import GMSection from "@/components/TeamBuilder/GMSection.vue";
+
+// Sheet and DropdownMenu both portal their content to document.body via
+// Teleport, so everything below queries the live document directly instead
+// of the wrapper's own render tree, which Teleport moves this content out of.
+const mountGMDrawerOpen = () =>
+    mount(GMSection, {
+        props: {
+            selectedDrawerSide: "right",
+            teamGM: null,
+            "onUpdate:teamGM": () => {},
+            showGMDrawer: true,
+            "onUpdate:showGMDrawer": () => {},
+        },
+        attachTo: document.body,
+    });
+
+const findButton = (label: string) =>
+    [...document.querySelectorAll("button")].find((b) =>
+        b.textContent?.trim().startsWith(label),
+    ) as HTMLButtonElement;
+
+const filterCheckbox = (label: string) =>
+    [...document.querySelectorAll('[role="menuitemcheckbox"]')].find(
+        (el) => el.textContent?.trim() === label,
+    ) as HTMLElement;
+
+const gmNames = () =>
+    [...document.querySelectorAll(".gm-item .gm-name-improved")].map(
+        (el) => el.textContent?.trim(),
+    );
+
+describe("GMSection filters", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("narrows the list when a conference filter is ticked, instead of doing nothing", async () => {
+        // Regression test for two stacked bugs: the dead :checked/
+        // @update:checked binding (same reka-ui modelValue mismatch as
+        // ArenaSection), and the predicate itself, which used to be an
+        // unimplemented stub ("Filter logic would go here when
+        // implemented") that returned every GM unfiltered.
+        const wrapper = mountGMDrawerOpen();
+        await nextTick();
+        await nextTick();
+
+        const allCount = gmNames().length;
+        expect(allCount).toBeGreaterThan(0);
+
+        findButton("Filters").click();
+        await nextTick();
+        filterCheckbox("Western Conference").click();
+        await nextTick();
+
+        expect(findButton("Filters").textContent).toContain("1");
+        expect(gmNames().length).toBeLessThan(allCount);
+        expect(gmNames().length).toBeGreaterThan(0);
+        wrapper.unmount();
+    });
+
+    it("resolves execs.json's 'ABBR (year-year)' team entries to a conference, not just a bare abbreviation", async () => {
+        // execs.json gives teams like "BOS (2003-21)" - Basketball-Reference
+        // abbreviation plus a year range, never a full team name. Matching
+        // that raw string against WESTERN_TEAMS/EASTERN_TEAMS (full names)
+        // can never succeed, which is what made every conference filter
+        // here return zero GMs even after the checkbox wiring was fixed.
+        const wrapper = mountGMDrawerOpen();
+        await nextTick();
+        await nextTick();
+
+        findButton("Filters").click();
+        await nextTick();
+        filterCheckbox("Western Conference").click();
+        await nextTick();
+        const westCount = gmNames().length;
+
+        filterCheckbox("Western Conference").click();
+        await nextTick();
+        filterCheckbox("Eastern Conference").click();
+        await nextTick();
+        const eastCount = gmNames().length;
+
+        expect(westCount).toBeGreaterThan(0);
+        expect(eastCount).toBeGreaterThan(0);
+        wrapper.unmount();
+    });
+
+    it("OR-s multiple selected conferences instead of AND-ing them", async () => {
+        // Unlike ArenaSection, GM data isn't a clean 1:1 team-to-conference
+        // mapping - some GMs' entire resume predates the current 30-team
+        // structure (e.g. "FTW (1957)", the Fort Wayne Pistons), so their
+        // conference is unresolvable and they legitimately match neither
+        // filter. The real regression to catch is AND-ing: both filters
+        // selected together must recover the union of each one selected
+        // alone, not something smaller (which is what "every selected
+        // filter must match" - AND - would produce). Each scenario gets its
+        // own fresh mount rather than toggling one dropdown through
+        // select/deselect/reselect, which reka's menu doesn't reliably keep
+        // open across under jsdom's synthetic click events.
+        const selectFilters = async (...labels: string[]) => {
+            const wrapper = mountGMDrawerOpen();
+            await nextTick();
+            await nextTick();
+            findButton("Filters").click();
+            await nextTick();
+            for (const label of labels) {
+                filterCheckbox(label).click();
+                await nextTick();
+            }
+            const names = new Set(gmNames());
+            wrapper.unmount();
+            return names;
+        };
+
+        const westOnly = await selectFilters("Western Conference");
+        const eastOnly = await selectFilters("Eastern Conference");
+        const both = await selectFilters("Western Conference", "Eastern Conference");
+
+        expect(westOnly.size).toBeGreaterThan(0);
+        expect(eastOnly.size).toBeGreaterThan(0);
+        expect(both).toEqual(new Set([...westOnly, ...eastOnly]));
+    });
+});


### PR DESCRIPTION
Closes #77.

## What
Filter checkboxes in the Add Arena, Add Coach and Add GM drawers did nothing — no checkmark, no badge count, no narrowing.

## How
- **Root cause**: `DropdownMenuCheckboxItem`'s vendored wrapper infers its props from reka-ui's types, and reka-ui 2.10.4 declares `modelValue`/`update:modelValue` — not `checked`/`update:checked`. `:checked` fell through as a dead DOM attribute; `toggleFilter` waited on an event that's never emitted. Rebound all three to `:model-value`/`@update:model-value`.
- **ArenaSection AND-ed its two conference checks** — once wiring worked, ticking both would require a team to be in both `WESTERN_TEAMS` and `EASTERN_TEAMS`, returning zero arenas (worse than the original bug). Selections within one facet now OR together.
- **GMSection's predicate was an unimplemented stub** (`// Filter logic would go here when implemented`, returning everyone). Implemented it — then found `execs.json`'s `teams` entries are `"BOS (2003-21)"` (Basketball-Reference abbreviation + year range) and `CreateCustomGMModal`'s are a bare abbreviation (`"BOS"`), neither of which is the full team name `WESTERN_TEAMS`/`EASTERN_TEAMS` expect. A naive port of Arena's predicate would have matched nothing. Resolves the abbreviation via the existing `nbaTeams.json` map first.
- `sortedArenaData`'s default branch returned the unsorted `typedArenaData` module reference instead of a copy; its capacity sort only stripped the first comma from `"19,200"`-style strings. Both fixed in passing.
- **Scrollbar sat ~2rem in from the drawer's edge**, squeezing the arena cards — traced to the Sheet's own `p-6` padding plus an extra `pr-2` on the list, both insetting the scrollbar well past where reka actually positions it. `-mr-6` on the `ScrollArea` cancels the Sheet's right padding so the scroll region (and its scrollbar) runs to the panel's true edge; the list's own `pr-6` puts that space back as room for the cards.

## Verification
```
pnpm --filter web type-check   # clean
pnpm --filter web check:styles # 147 files, no problems
pnpm --filter web lint         # 0 errors (148 pre-existing no-explicit-any warnings)
pnpm --filter web test         # 101/101 (2 new files: ArenaSection.test.ts, GMSection.test.ts —
                                # cover the checkbox wiring, the OR-not-AND fix, and specifically
                                # the abbreviation-resolution bug in GM's predicate)
pnpm --filter web test:visual  # 20/20, no baseline diffs (drawers are closed by default in
                                # the covered routes)
```
Manually verified against a live dev server: Add Arena's Filters checkboxes now tick, badge, and narrow the list; ticking both conferences shows all 30 arenas (not zero); Add GM's Western Conference filter now correctly narrows (previously returned nothing for any conference — confirmed live, not just in the abstract); scrollbar rides the panel edge with the cards given proper clearance.