### PR TITLE
fix(web): serve the hero video from the assets CDN, not Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ pnpm --filter cdk refresh-execs             # rewrite execs.json from Basketball
 pnpm --filter cdk refresh-historical-logos  # rewrite historicalLogos.json + public/logos/historical/
 pnpm --filter cdk refresh-historical-jerseys  # rewrite historicalJerseys.json, upload images to S3
 pnpm --filter cdk run refresh-<name> -- --check  # validate against the live source, write nothing
+pnpm --filter cdk upload-hero-video             # upload apps/web's hero clip, rewrite heroMedia.json
+pnpm --filter cdk run upload-hero-video -- --check  # validate the local file, upload nothing
 
 pnpm -r test                    # both packages' test suites
 ```

--- a/apps/cdk/CLAUDE.md
+++ b/apps/cdk/CLAUDE.md
@@ -24,12 +24,16 @@ pnpm refresh-historical-logos  # rewrite historicalLogos.json + public/logos/his
 pnpm rekey-historical-logos    # re-key the transparent background on already-checked-in PNGs
 pnpm refresh-historical-jerseys  # rewrite historicalJerseys.json, upload images to S3/CloudFront
 pnpm run refresh-<name> -- --check  # validate against the live source, write nothing
+pnpm upload-hero-video          # upload apps/web's hero clip, rewrite heroMedia.json
+pnpm run upload-hero-video -- --check  # validate the local file, upload nothing
 ```
 
-`refresh-historical-jerseys --check` needs no AWS access - it only scrapes and
-parses. A real (non-`--check`) run uploads to the `assets` S3 bucket and needs
-`TeamBuilderAssetsCdn` already deployed (`cdk deploy`) plus AWS credentials
-able to write to that bucket.
+`refresh-historical-jerseys --check` and `upload-hero-video --check` need no
+AWS access - they only read/parse locally. A real (non-`--check`) run of
+either uploads to the `assets` S3 bucket and needs `TeamBuilderAssetsCdn`
+already deployed (`cdk deploy`) plus AWS credentials able to write to that
+bucket. Both share that upload/CloudFront-lookup logic via
+`scripts/lib/assetsCdn.ts`.
 
 Requires a `.env` file with: `account`, `region`, `appName`, `deploymentType`.
 `deploymentType` (`"development"` or `"production"`) is not optional for a

--- a/apps/cdk/package.json
+++ b/apps/cdk/package.json
@@ -19,6 +19,7 @@
         "refresh-historical-logos": "ts-node -r tsconfig-paths/register scripts/refresh-historical-logos.ts",
         "rekey-historical-logos": "ts-node -r tsconfig-paths/register scripts/rekey-historical-logos.ts",
         "refresh-historical-jerseys": "ts-node -r tsconfig-paths/register scripts/refresh-historical-jerseys.ts",
+        "upload-hero-video": "ts-node -r tsconfig-paths/register scripts/upload-hero-video.ts",
         "cdk": "cdk"
     },
     "dependencies": {

--- a/apps/cdk/scripts/lib/assetsCdn.ts
+++ b/apps/cdk/scripts/lib/assetsCdn.ts
@@ -1,0 +1,49 @@
+/**
+ * Resolves the assets S3 bucket and the CloudFront distribution
+ * TeamBuilderAssetsCdn puts in front of it, for scripts that upload into that
+ * bucket. Originally lived only in refresh-historical-jerseys.ts; pulled out
+ * here so upload-hero-video.ts (and any future asset uploader) shares it
+ * instead of copying it.
+ */
+import { S3Client } from "@aws-sdk/client-s3";
+import { CloudFrontClient, ListDistributionsCommand } from "@aws-sdk/client-cloudfront";
+
+export interface AssetsCdnUpload {
+	s3Client: S3Client;
+	bucketName: string;
+	distributionDomain: string;
+}
+
+export const setupAssetsCdnUpload = async (): Promise<AssetsCdnUpload> => {
+	const { region, appName, deploymentType } = process.env;
+	if (!region || !appName || !deploymentType) {
+		throw new Error(
+			"Uploading requires apps/cdk's .env (region, appName, deploymentType) - see apps/cdk/CLAUDE.md. Pass --check to validate without uploading.",
+		);
+	}
+
+	const bucketName = `${appName}-${deploymentType}-assets`;
+	const s3Client = new S3Client({ region });
+
+	// CloudFront is a global service fronted by a single us-east-1 API
+	// endpoint, regardless of where the origin bucket lives.
+	const cloudFrontClient = new CloudFrontClient({ region: "us-east-1" });
+	let marker: string | undefined;
+	let distribution;
+	do {
+		const { DistributionList } = await cloudFrontClient.send(
+			new ListDistributionsCommand({ Marker: marker }),
+		);
+		distribution = DistributionList?.Items?.find((item) =>
+			item.Origins?.Items?.some((origin) => origin.DomainName?.startsWith(`${bucketName}.s3.`)),
+		);
+		marker = DistributionList?.IsTruncated ? DistributionList?.NextMarker : undefined;
+	} while (!distribution && marker);
+	if (!distribution?.DomainName) {
+		throw new Error(
+			`No CloudFront distribution found fronting ${bucketName} - deploy TeamBuilderAssetsCdn first (cdk deploy)`,
+		);
+	}
+
+	return { s3Client, bucketName, distributionDomain: distribution.DomainName };
+};

--- a/apps/cdk/scripts/refresh-historical-jerseys.ts
+++ b/apps/cdk/scripts/refresh-historical-jerseys.ts
@@ -25,8 +25,7 @@
  */
 import * as fs from "fs";
 import { config as dotEnvConfig } from "dotenv";
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
-import { CloudFrontClient, ListDistributionsCommand } from "@aws-sdk/client-cloudfront";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import {
 	buildParsedJersey,
 	extractGalleryIds,
@@ -45,6 +44,7 @@ import {
 	writeIfClean,
 	type Row,
 } from "./lib/refresh";
+import { setupAssetsCdnUpload } from "./lib/assetsCdn";
 
 dotEnvConfig();
 
@@ -208,40 +208,6 @@ const fetchJerseyImage = async (
 const jerseyKey = (mediaUrl: string): string | null =>
 	mediaUrl.match(/\/media\/([a-z0-9_]+)~mv2\.\w+$/i)?.[1] ?? null;
 
-const setupUpload = async () => {
-	const { region, appName, deploymentType } = process.env;
-	if (!region || !appName || !deploymentType) {
-		throw new Error(
-			"Uploading requires apps/cdk's .env (region, appName, deploymentType) - see apps/cdk/CLAUDE.md. Pass --check to validate the scrape without uploading.",
-		);
-	}
-
-	const bucketName = `${appName}-${deploymentType}-assets`;
-	const s3Client = new S3Client({ region });
-
-	// CloudFront is a global service fronted by a single us-east-1 API
-	// endpoint, regardless of where the origin bucket lives.
-	const cloudFrontClient = new CloudFrontClient({ region: "us-east-1" });
-	let marker: string | undefined;
-	let distribution;
-	do {
-		const { DistributionList } = await cloudFrontClient.send(
-			new ListDistributionsCommand({ Marker: marker }),
-		);
-		distribution = DistributionList?.Items?.find((item) =>
-			item.Origins?.Items?.some((origin) => origin.DomainName?.startsWith(`${bucketName}.s3.`)),
-		);
-		marker = DistributionList?.IsTruncated ? DistributionList?.NextMarker : undefined;
-	} while (!distribution && marker);
-	if (!distribution?.DomainName) {
-		throw new Error(
-			`No CloudFront distribution found fronting ${bucketName} - deploy TeamBuilderAssetsCdn first (cdk deploy)`,
-		);
-	}
-
-	return { s3Client, bucketName, distributionDomain: distribution.DomainName };
-};
-
 const main = async () => {
 	const checkOnly = isCheckOnly();
 	const problems: string[] = [];
@@ -258,7 +224,7 @@ const main = async () => {
 	}
 
 	const instanceToken = await fetchInstanceToken();
-	const upload = checkOnly ? null : await setupUpload();
+	const upload = checkOnly ? null : await setupAssetsCdnUpload();
 
 	const collected: (ParsedJersey & { mediaUrl: string })[] = [];
 

--- a/apps/cdk/scripts/upload-hero-video.ts
+++ b/apps/cdk/scripts/upload-hero-video.ts
@@ -1,0 +1,90 @@
+/**
+ * Uploads apps/web's hero video to the assets S3 bucket behind
+ * TeamBuilderAssetsCdn and writes apps/web/src/assets/data/heroMedia.json
+ * with the resulting CDN URL - same pattern as historicalJerseys.json.
+ *
+ *   pnpm run upload-hero-video
+ *   pnpm run upload-hero-video -- --check    # validate the local file only, upload nothing
+ *
+ * The clip used to be Git LFS-tracked and served straight from apps/web's
+ * public/ dir, but CI's checkout never fetched LFS objects, so production
+ * served the ~130-byte LFS pointer text labeled video/mp4 - the browser's
+ * decoder failed silently and the poster just never went away. Moving it off
+ * LFS and behind the CDN (the manifest is a real file the build can't get
+ * wrong) removes that dependency entirely, and matches how
+ * historicalJerseys.json's images are already served.
+ *
+ * The S3 key is content-hashed (hero-loop.<sha256 prefix>.mp4), so a future
+ * re-run that changes the video gets a new URL under CACHING_OPTIMIZED
+ * without needing a CloudFront invalidation - same reasoning as any
+ * content-hashed build asset.
+ */
+import * as fs from "fs";
+import * as crypto from "crypto";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { config as dotEnvConfig } from "dotenv";
+import { dataPath, isCheckOnly, nbaCentralPath, run } from "./lib/refresh";
+import { setupAssetsCdnUpload } from "./lib/assetsCdn";
+
+dotEnvConfig();
+
+const SOURCE_PATH = nbaCentralPath("public/hero/hero-loop.mp4");
+const MANIFEST_PATH = dataPath("heroMedia.json");
+const HASH_PREFIX_LENGTH = 12;
+
+/** ISO Base Media (mp4/mov/...) starts with a 4-byte size then "ftyp". */
+const isMp4 = (bytes: Uint8Array): boolean =>
+	bytes.length > 8 &&
+	bytes[4] === 0x66 && // f
+	bytes[5] === 0x74 && // t
+	bytes[6] === 0x79 && // y
+	bytes[7] === 0x70; // p
+
+const main = async () => {
+	const checkOnly = isCheckOnly();
+
+	if (!fs.existsSync(SOURCE_PATH)) {
+		throw new Error(`No hero video at ${SOURCE_PATH}`);
+	}
+	const bytes = new Uint8Array(fs.readFileSync(SOURCE_PATH));
+
+	if (bytes.length < 1000) {
+		// Exactly what a Git LFS pointer looks like if `git lfs pull` was
+		// never run for this checkout - a few hundred bytes of text, not a
+		// video. Catch it here instead of uploading it as one.
+		throw new Error(
+			`${SOURCE_PATH} is only ${bytes.length} bytes - looks like an unfetched Git LFS pointer, not a real video. Run "git lfs pull".`,
+		);
+	}
+	if (!isMp4(bytes)) {
+		throw new Error(`${SOURCE_PATH} doesn't look like an MP4 (no ftyp box)`);
+	}
+
+	const hash = crypto.createHash("sha256").update(bytes).digest("hex").slice(0, HASH_PREFIX_LENGTH);
+	const objectKey = `hero/hero-loop.${hash}.mp4`;
+	console.log(`hero-loop.mp4: ${bytes.length} bytes, key ${objectKey}`);
+
+	if (checkOnly) {
+		console.log("--check passed, nothing uploaded");
+		return;
+	}
+
+	const upload = await setupAssetsCdnUpload();
+	await upload.s3Client.send(
+		new PutObjectCommand({
+			Bucket: upload.bucketName,
+			Key: objectKey,
+			Body: bytes,
+			ContentType: "video/mp4",
+			// The hash is the whole cache-busting mechanism - this object's
+			// content never changes at this key, so cache it hard.
+			CacheControl: "public, max-age=31536000, immutable",
+		}),
+	);
+
+	const heroLoopUrl = `https://${upload.distributionDomain}/${objectKey}`;
+	fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify({ heroLoop: heroLoopUrl }, null, 4)}\n`, "utf8");
+	console.log(`Uploaded and wrote ${MANIFEST_PATH}`);
+};
+
+run(main);

--- a/apps/cdk/scripts/upload-hero-video.ts
+++ b/apps/cdk/scripts/upload-hero-video.ts
@@ -18,6 +18,16 @@
  * re-run that changes the video gets a new URL under CACHING_OPTIMIZED
  * without needing a CloudFront invalidation - same reasoning as any
  * content-hashed build asset.
+ *
+ * apps/web/public/hero/hero-loop.mp4 (this script's source file) was
+ * deleted from the working tree along with its Git LFS tracking - it is
+ * NOT checked in anywhere going forward. To re-run this script (e.g. to
+ * swap in a new clip), either supply a new file at that path, or recover
+ * the original from history: `git log -- apps/web/public/hero/hero-loop.mp4`
+ * finds the last commit that had it, then `git checkout <that commit> --
+ * apps/web/public/hero/hero-loop.mp4` restores it there (the LFS object
+ * itself is untouched, so this needs a working `git lfs` install to smudge
+ * it back into a real file rather than another pointer).
  */
 import * as fs from "fs";
 import * as crypto from "crypto";
@@ -44,16 +54,20 @@ const main = async () => {
 	const checkOnly = isCheckOnly();
 
 	if (!fs.existsSync(SOURCE_PATH)) {
-		throw new Error(`No hero video at ${SOURCE_PATH}`);
+		throw new Error(
+			`No hero video at ${SOURCE_PATH} - it is not checked in (see the ` +
+				`module comment at the top of this file for how to recover the ` +
+				`original from git history, or supply a new clip at that path).`,
+		);
 	}
 	const bytes = new Uint8Array(fs.readFileSync(SOURCE_PATH));
 
 	if (bytes.length < 1000) {
-		// Exactly what a Git LFS pointer looks like if `git lfs pull` was
-		// never run for this checkout - a few hundred bytes of text, not a
-		// video. Catch it here instead of uploading it as one.
+		// A recovered-from-history file whose LFS object didn't actually
+		// smudge (e.g. no `git lfs` installed) looks exactly like this - a
+		// few hundred bytes of pointer text, not a video.
 		throw new Error(
-			`${SOURCE_PATH} is only ${bytes.length} bytes - looks like an unfetched Git LFS pointer, not a real video. Run "git lfs pull".`,
+			`${SOURCE_PATH} is only ${bytes.length} bytes - looks like an unsmudged Git LFS pointer, not a real video.`,
 		);
 	}
 	if (!isMp4(bytes)) {

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -92,8 +92,13 @@ to put classes on.
   referenced by plain URL so ~230 images stay out of Vite's import graph.
   Historical jerseys are NOT checked in the same way - `historicalJerseys.json`'s
   `jersey` field is a full CloudFront URL (see root CLAUDE.md).
-- The Home hero is a short loop plus poster in `public/hero/`, deliberately
-  outside `src/assets` so it does not pass through the bundler.
+- The Home hero's poster lives in `public/hero/`, deliberately outside
+  `src/assets` so it does not pass through the bundler. The loop itself is
+  NOT checked in the same way - it used to be, via Git LFS, but CI's checkout
+  never fetched LFS objects and production silently served the pointer text.
+  `heroMedia.json`'s `heroLoop` field is a full CDN URL, same pattern as
+  `historicalJerseys.json` - see `apps/cdk/scripts/upload-hero-video.ts` and
+  root CLAUDE.md.
 
 ## Verifying UI work
 

--- a/apps/web/public/hero/hero-loop.mp4
+++ b/apps/web/public/hero/hero-loop.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b0b7598e5b01342c122aad20afbadba063570827d7b8eb21e0e1a0eec16f78f
-size 2064116

--- a/apps/web/src/assets/data/heroMedia.json
+++ b/apps/web/src/assets/data/heroMedia.json
@@ -1,0 +1,3 @@
+{
+    "heroLoop": "https://d2s6ea2hcvgd9x.cloudfront.net/hero/hero-loop.5b0b7598e5b0.mp4"
+}

--- a/apps/web/src/views/Home.vue
+++ b/apps/web/src/views/Home.vue
@@ -11,11 +11,13 @@ const router = useRouter();
 // hero-loop.mp4 used to be Git LFS-tracked and served straight from public/ -
 // CI's checkout never fetched LFS objects, so production served the LFS
 // pointer text labeled video/mp4, and the browser's decoder failed with no
-// visible error. Logging here is the safety net that was missing.
+// visible error. Logging here (unconditionally - this app has no error
+// reporting service, just console.error, everywhere else it handles a
+// failure) is the safety net that was missing; a DEV-only version would
+// have stayed silent for exactly the environment - production - the
+// original bug happened in.
 const onVideoError = (event: Event) => {
-  if (import.meta.env.DEV) {
-    console.error("Hero video failed to load, poster will show instead:", event);
-  }
+  console.error("Hero video failed to load, poster will show instead:", event);
 };
 </script>
 

--- a/apps/web/src/views/Home.vue
+++ b/apps/web/src/views/Home.vue
@@ -4,17 +4,34 @@ import { TYPE_WRITER_PROPS } from "@/constants/constants";
 import { Button } from "@/components/ui/button";
 import { ChevronsDown } from "lucide-vue-next";
 import { useRouter } from "vue-router";
+import heroMedia from "@/assets/data/heroMedia.json";
 
 const router = useRouter();
+
+// hero-loop.mp4 used to be Git LFS-tracked and served straight from public/ -
+// CI's checkout never fetched LFS objects, so production served the LFS
+// pointer text labeled video/mp4, and the browser's decoder failed with no
+// visible error. Logging here is the safety net that was missing.
+const onVideoError = (event: Event) => {
+  if (import.meta.env.DEV) {
+    console.error("Hero video failed to load, poster will show instead:", event);
+  }
+};
 </script>
 
 <template>
   <main class="home-page">
     <div class="relative w-full h-full overflow-hidden">
-      <!-- Video Background. Served from /public rather than imported so the
-           clip stays out of the Vite graph. The poster paints immediately and
-           covers the gap before the loop starts, or stands in entirely where
-           autoplay is refused. playsinline is required for iOS to autoplay. -->
+      <!-- Video Background. The clip is served from the assets CDN (see
+           apps/cdk/scripts/upload-hero-video.ts) rather than public/, which
+           used to Git-LFS-track it - CI's checkout never fetched the LFS
+           object, so production silently served a ~130-byte pointer file
+           labeled video/mp4. The poster stays local: it's not LFS-tracked,
+           it paints immediately and covers the gap before the loop starts
+           (or stands in entirely where autoplay is refused or the CDN
+           request fails), and the prefers-reduced-motion rule below
+           references it directly, which a JSON import can't do.
+           playsinline is required for iOS to autoplay. -->
       <video
         class="video"
         poster="/hero/hero-poster.jpg"
@@ -24,8 +41,9 @@ const router = useRouter();
         playsinline
         preload="metadata"
         aria-hidden="true"
+        @error="onVideoError"
       >
-        <source src="/hero/hero-loop.mp4" type="video/mp4" />
+        <source :src="heroMedia.heroLoop" type="video/mp4" />
       </video>
 
       <!-- Scrim: the hero copy is white over live footage, which has no


### PR DESCRIPTION
Closes #78.

## What
The landing page hero video never played in production — it showed the poster indefinitely, no error anywhere.

## Root cause
`hero-loop.mp4` was Git LFS-tracked. None of the `actions/checkout@v5` steps in `deploy.yml`/`ci.yml` set `lfs: true` (the action defaults to `false`), so CI checked out the ~130-byte LFS pointer text instead of the real file, Vite copied `public/` verbatim into the build, and production served that pointer labeled `Content-Type: video/mp4`. The browser's decoder failed silently — there was no `@error` handler on the `<video>` at all — so the poster (not LFS-tracked) just never went away.

## Fix
Moved the clip to the assets S3 bucket behind `TeamBuilderAssetsCdn`, same pattern as `historicalJerseys.json`:
- `apps/cdk/scripts/upload-hero-video.ts` uploads it under a content-hashed key (`hero-loop.<sha256 prefix>.mp4`, so a future replacement needs no CloudFront invalidation) and writes `apps/web/src/assets/data/heroMedia.json` with the resulting CDN URL.
- `Home.vue` imports that manifest instead of a static `/hero/hero-loop.mp4` path, and now has an `@error` handler so a broken source is never silent again.
- The uploader's CloudFront-lookup logic was previously private to `refresh-historical-jerseys.ts` — pulled out to `scripts/lib/assetsCdn.ts` so both scripts share it instead of duplicating it.
- The poster stays in `public/`: not LFS-tracked, paints before any CDN round-trip, and is referenced directly from scoped CSS (`prefers-reduced-motion`) which can't read a JSON import.
- `.gitattributes` is deleted along with `hero-loop.mp4` — the `*.mp4` LFS rule was its only line, and no other LFS-tracked file remains. The LFS object stays in git history; no rewrite needed.

## Verification
```
pnpm --filter web type-check   # clean
pnpm --filter web check:styles # 147 files, no problems
pnpm --filter web lint         # 0 errors (148 pre-existing no-explicit-any warnings)
pnpm --filter web test         # 95/95
pnpm --filter web test:visual  # 20/20, no baseline diffs (the suite hides the video via
                                # CSS before screenshotting, per its own docstring)
pnpm --filter cdk build        # clean
pnpm --filter cdk test         # 183/183
```

**Uploaded for real** to `team-builder-production-assets` (with your go-ahead) and confirmed live:
- `curl -I https://d2s6ea2hcvgd9x.cloudfront.net/hero/hero-loop.5b0b7598e5b0.mp4` → `Content-Length: 2064116` (not 132), `Content-Type: video/mp4`.
- A real browser session against a local dev server loading that URL shows the `<video>` element's `readyState: 4` and `currentTime` actively advancing (5.8s and climbing), with a screenshot showing genuinely different in-motion footage from the poster frame — not a static image.

This upload doesn't affect the live site until this PR is merged and deployed; `heroMedia.json` in this PR already has the real URL rather than a placeholder.