### PR TITLE
feat(cdk): send feedback email via SES

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ Entry point: `bin/team-builder-cdk.ts` loads env vars from dotenv.
 - `getTeamLogos`: fetch ESPN API for NBA team logos
 - `getPlayers`, `getPlayerStats`: player data + 2K ratings, merged from `players.json` and `player-ratings.json`
 - `getNews`: reads news articles fetched by `fetchNewsCron`
-- `sendFeedback`: email via SES
+- `sendFeedback`: emails the site owner via SES (sending identity is in
+  us-east-1, not this stack's own us-west-2 — see apps/cdk/CLAUDE.md)
 
 **Data ETL Lambdas** (EventBridge triggers):
 - `setArenasData`, `setCoachesData`, `setExecsData`: scrape Wikipedia / Basketball-Reference

--- a/apps/cdk/CLAUDE.md
+++ b/apps/cdk/CLAUDE.md
@@ -66,6 +66,23 @@ package's pin) and 0.21.5 (via the old `vitest@2` → `vite@5` chain), and synth
 kept working only because pnpm happened to hoist the right one. Bump the
 override and this package's `esbuild` together, never one alone.
 
+## SES (sendFeedback)
+
+`sendFeedback` sends via a verified identity (`auth.yusufaf.dev`) in
+**us-east-1**, chosen because that's the only region with SES production
+access on this account today — the stack itself deploys to us-west-2, which
+is still SES sandbox. Addresses/region live in `constants/index.ts`
+(`FEEDBACK_SES_REGION`, `FEEDBACK_FROM_ADDRESS`, `FEEDBACK_TO_ADDRESS`), and
+the shared `main-lambda-role` carries a scoped `ses:SendEmail` grant on that
+one identity ARN.
+
+None of the identity's setup is IaC: verification, DKIM, the custom MAIL FROM
+domain (`mail.auth.yusufaf.dev`), and DMARC were all done by hand (AWS
+console/API calls plus Porkbun DNS records), shared with the Logto deployment
+that also sends from this identity. A fresh AWS account would not have any of
+this — `cdk deploy` alone will not recreate a working sender, and `cdk synth`
+does not validate that the identity actually exists.
+
 ## Architecture
 
 See the root `CLAUDE.md` for the full stack list (constructs, Lambda

--- a/apps/cdk/constants/index.ts
+++ b/apps/cdk/constants/index.ts
@@ -23,3 +23,13 @@ export const BBREF_BASE_URL = "https://www.basketball-reference.com";
 // endpoint needs no API key and allows 60 req/min per IP; /players/bulk is
 // one call but 401s without a key.
 export const NBA2K_API_BASE_URL = "https://api.nba2kapi.com/api";
+
+// sendFeedback sends via SES from us-east-1: that's the only region with SES
+// production access and a verified sending identity today (auth.yusufaf.dev,
+// shared with Logto — see apps/cdk/CLAUDE.md). The stack itself is
+// us-west-2, which is still SES sandbox, so the client must pin this region
+// explicitly rather than infer it from the Lambda's own AWS_REGION.
+export const FEEDBACK_SES_REGION = "us-east-1";
+export const FEEDBACK_SES_IDENTITY = "auth.yusufaf.dev";
+export const FEEDBACK_FROM_ADDRESS = `feedback@${FEEDBACK_SES_IDENTITY}`;
+export const FEEDBACK_TO_ADDRESS = "yusufafzal12@gmail.com";

--- a/apps/cdk/models/api/feedback-api.ts
+++ b/apps/cdk/models/api/feedback-api.ts
@@ -1,0 +1,13 @@
+import { ApiResponse } from "./custom-entities-api";
+
+export interface SendFeedbackPayload {
+	message: string;
+	subject?: string;
+	email?: string;
+}
+
+export interface SendFeedbackData {
+	messageId: string;
+}
+
+export type SendFeedbackResponse = ApiResponse<SendFeedbackData>;

--- a/apps/cdk/service/lambdas/sendFeedback/index.ts
+++ b/apps/cdk/service/lambdas/sendFeedback/index.ts
@@ -1,6 +1,11 @@
 import { Duration } from "aws-cdk-lib";
 import { LambdaProps } from "../../../models/stack";
 import { TeamBuilderLambda } from "../../constructs/TeamBuilderLambda";
+import {
+	FEEDBACK_SES_REGION,
+	FEEDBACK_FROM_ADDRESS,
+	FEEDBACK_TO_ADDRESS,
+} from "../../../constants";
 
 export default ({ props, construct }: LambdaProps) => {
 	const functionName = "sendFeedback";
@@ -13,8 +18,9 @@ export default ({ props, construct }: LambdaProps) => {
 			memorySize: 1000,
 			timeout: Duration.seconds(30),
 			environment: {
-				mainDynamoDBTable: `${props.appName}-${props.deploymentType}-main-table`,
-				mainBucket: `${props.appName}-${props.deploymentType}-main-bucket`,
+				FEEDBACK_SES_REGION,
+				FEEDBACK_FROM_ADDRESS,
+				FEEDBACK_TO_ADDRESS,
 			},
 		},
 	);

--- a/apps/cdk/service/lambdas/sendFeedback/src/sendFeedback.ts
+++ b/apps/cdk/service/lambdas/sendFeedback/src/sendFeedback.ts
@@ -1,47 +1,142 @@
 import {
-    APIGatewayProxyEvent,
-    APIGatewayProxyResult,
+    APIGatewayProxyEventV2WithLambdaAuthorizer,
+    APIGatewayProxyResultV2,
     Handler,
 } from "aws-lambda";
-import { S3Client, DeleteObjectCommand } from "@aws-sdk/client-s3";
+import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import { AuthorizerContext } from "models/auth";
+import { SendFeedbackPayload, SendFeedbackResponse } from "models/api/feedback-api";
+import { parseRequestBody } from "utilities/request-body";
 
-const { mainBucket = "" } = process.env;
+const {
+    FEEDBACK_SES_REGION = "",
+    FEEDBACK_FROM_ADDRESS = "",
+    FEEDBACK_TO_ADDRESS = "",
+} = process.env;
 
-const s3Client = new S3Client();
+const MAX_MESSAGE_LENGTH = 5000;
+const MAX_SUBJECT_LENGTH = 200;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-type Body = {
-    key: string;
-};
+// The sending identity (auth.yusufaf.dev) is only verified in us-east-1, not
+// this Lambda's own region, so the client can't infer it from AWS_REGION.
+const sesClient = new SESClient({ region: FEEDBACK_SES_REGION });
 
 export const handler: Handler = async (
-    event: APIGatewayProxyEvent,
+    event: APIGatewayProxyEventV2WithLambdaAuthorizer<AuthorizerContext>,
     context
-): Promise<APIGatewayProxyResult> => {
+): Promise<APIGatewayProxyResultV2> => {
     console.log(JSON.stringify({ event, context }, null, 4));
 
-    const body: Body = JSON.parse(event.body ?? "");
-    const { key } = body;
-
     try {
-        const deleteCommand = new DeleteObjectCommand({
-            Bucket: mainBucket,
-            Key: key,
+        const parsed = parseRequestBody<SendFeedbackPayload>(event.body, {
+            message: "string",
         });
-        await s3Client.send(deleteCommand);
+        if (!parsed.valid) {
+            const response: SendFeedbackResponse = {
+                success: false,
+                error: parsed.error,
+            };
+            return {
+                statusCode: 400,
+                body: JSON.stringify(response),
+            };
+        }
+        const { message, subject, email } = parsed.body;
 
+        const sub = event.requestContext?.authorizer?.lambda?.sub;
+        const username = event.requestContext?.authorizer?.lambda?.username;
+        if (!sub) {
+            const response: SendFeedbackResponse = {
+                success: false,
+                error: "Forbidden",
+            };
+            return {
+                statusCode: 403,
+                body: JSON.stringify(response),
+            };
+        }
+
+        if (message.length > MAX_MESSAGE_LENGTH) {
+            const response: SendFeedbackResponse = {
+                success: false,
+                error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer`,
+            };
+            return {
+                statusCode: 400,
+                body: JSON.stringify(response),
+            };
+        }
+        if (subject !== undefined && subject.length > MAX_SUBJECT_LENGTH) {
+            const response: SendFeedbackResponse = {
+                success: false,
+                error: `subject must be ${MAX_SUBJECT_LENGTH} characters or fewer`,
+            };
+            return {
+                statusCode: 400,
+                body: JSON.stringify(response),
+            };
+        }
+        // SES rejects the whole send on a malformed ReplyToAddresses entry,
+        // which would otherwise surface as a confusing 500 further down. An
+        // empty string is treated as "not provided" (matching the `email ?`
+        // check below), not as an invalid address.
+        if (email && !EMAIL_PATTERN.test(email)) {
+            const response: SendFeedbackResponse = {
+                success: false,
+                error: "email must be a valid email address",
+            };
+            return {
+                statusCode: 400,
+                body: JSON.stringify(response),
+            };
+        }
+
+        const bodyText = [
+            `From user: ${username ?? "unknown"} (${sub})`,
+            email ? `Reply-to: ${email}` : undefined,
+            "",
+            message,
+        ]
+            .filter((line) => line !== undefined)
+            .join("\n");
+
+        const sendEmailCommand = new SendEmailCommand({
+            Source: FEEDBACK_FROM_ADDRESS,
+            Destination: {
+                ToAddresses: [FEEDBACK_TO_ADDRESS],
+            },
+            ReplyToAddresses: email ? [email] : undefined,
+            Message: {
+                Subject: {
+                    Data: `[NBA Central] ${subject ?? "Feedback"}`,
+                },
+                Body: {
+                    Text: {
+                        Data: bodyText,
+                    },
+                },
+            },
+        });
+        const result = await sesClient.send(sendEmailCommand);
+
+        const response: SendFeedbackResponse = {
+            success: true,
+            data: { messageId: result.MessageId ?? "" },
+        };
         return {
             statusCode: 200,
-            body: JSON.stringify({
-                message: "Successfully deleted file",
-            }),
+            body: JSON.stringify(response),
         };
-    } catch (err) {
-        console.error(err);
+    } catch (err: any) {
+        console.error("Error sending feedback:", err);
+        const response: SendFeedbackResponse = {
+            success: false,
+            error: err.message || "Failed to send feedback",
+        };
         return {
             statusCode: 500,
-            body: JSON.stringify({
-                message: "Error deleting file",
-            }),
+            body: JSON.stringify(response),
         };
     }
 };

--- a/apps/cdk/service/team-builder-stack/team-builder-api-routes.ts
+++ b/apps/cdk/service/team-builder-stack/team-builder-api-routes.ts
@@ -11,6 +11,7 @@ const USERS_PREFIX = `/api/users`;
 const TEAMS_PREFIX = `/api/teams`;
 const DATA_PREFIX = `/api/data`;
 const CUSTOM_ENTITIES_PREFIX = `/api/custom-entities`;
+const FEEDBACK_PREFIX = `/api/feedback`;
 
 export const FILES_ROUTES: ApiRoute[] = [
 	{
@@ -157,6 +158,14 @@ export const CUSTOM_ENTITIES_ROUTES: ApiRoute[] = [
 	},
 ];
 
+export const FEEDBACK_ROUTES: ApiRoute[] = [
+	{
+		route: `${FEEDBACK_PREFIX}/send`,
+		lambdaName: "sendFeedback",
+		methods: [HttpMethod.POST],
+	},
+];
+
 // DATA_ROUTES and NEWS_ROUTES are read-only reference data the frontend
 // fetches on every page load for signed-out visitors too (e.g. App.vue's
 // team-logo fetch on mount) — gating them behind the authorizer would 403
@@ -168,4 +177,5 @@ export const PRIVATE_ROUTES: ApiRoute[] = [
 	...USERS_ROUTES,
 	...TEAMS_ROUTES,
 	...CUSTOM_ENTITIES_ROUTES,
+	...FEEDBACK_ROUTES,
 ];

--- a/apps/cdk/service/team-builder-stack/team-builder-api.ts
+++ b/apps/cdk/service/team-builder-stack/team-builder-api.ts
@@ -27,7 +27,11 @@ import {
 import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { DEFAULT_ALLOWED_ORIGINS } from "../../constants";
+import {
+	DEFAULT_ALLOWED_ORIGINS,
+	FEEDBACK_SES_REGION,
+	FEEDBACK_SES_IDENTITY,
+} from "../../constants";
 import apiAuthorizer from "../lambdas/apiAuthorizer/index";
 import setCoachesData from "../lambdas/setCoachesData";
 import setExecsData from "../lambdas/setExecsData";
@@ -269,6 +273,19 @@ export class TeamBuilderAPI extends Construct {
 			resources: s3BucketResources,
 		});
 		mainLambdaRole.addToPolicy(s3PolicyStatement);
+
+		// The verified sending identity lives in us-east-1 (the only region
+		// with SES production access); the stack itself is us-west-2, so this
+		// ARN can't be built from this.region.
+		const sesPolicyStatement = new PolicyStatement({
+			effect: Effect.ALLOW,
+			actions: ["ses:SendEmail"],
+			resources: [
+				`arn:aws:ses:${FEEDBACK_SES_REGION}:${this.account}:identity/${FEEDBACK_SES_IDENTITY}`,
+			],
+		});
+		mainLambdaRole.addToPolicy(sesPolicyStatement);
+
 		addRole(mainLambdaRoleNameAndID, mainLambdaRole);
 	};
 

--- a/apps/cdk/test/lambdas/sendFeedback.test.ts
+++ b/apps/cdk/test/lambdas/sendFeedback.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const send = vi.fn();
+
+vi.mock("@aws-sdk/client-ses", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@aws-sdk/client-ses")>();
+	return {
+		...actual,
+		SESClient: class {
+			send = send;
+		},
+	};
+});
+
+process.env.FEEDBACK_SES_REGION = "us-east-1";
+process.env.FEEDBACK_FROM_ADDRESS = "feedback@auth.yusufaf.dev";
+process.env.FEEDBACK_TO_ADDRESS = "owner@example.com";
+
+const { handler } = await import("lambdas/sendFeedback/src/sendFeedback");
+
+const invoke = (
+	body: string | undefined,
+	auth: { sub?: string; username?: string } = {
+		sub: "user-1",
+		username: "yusuf",
+	},
+) =>
+	handler(
+		{ body, requestContext: { authorizer: { lambda: auth } } } as any,
+		{} as any,
+		{} as any,
+	) as Promise<any>;
+
+beforeEach(() => {
+	send.mockReset();
+});
+
+describe("sendFeedback", () => {
+	it("sends the feedback email", async () => {
+		send.mockResolvedValueOnce({ MessageId: "msg-1" });
+
+		const result = await invoke(
+			JSON.stringify({
+				message: "Love the app",
+				subject: "Compliment",
+				email: "fan@example.com",
+			}),
+		);
+
+		expect(result.statusCode).toBe(200);
+		expect(JSON.parse(result.body)).toEqual({
+			success: true,
+			data: { messageId: "msg-1" },
+		});
+
+		const input = send.mock.calls[0][0].input;
+		expect(input.Source).toBe("feedback@auth.yusufaf.dev");
+		expect(input.Destination.ToAddresses).toEqual(["owner@example.com"]);
+		expect(input.ReplyToAddresses).toEqual(["fan@example.com"]);
+		expect(input.Message.Subject.Data).toBe("[NBA Central] Compliment");
+		expect(input.Message.Body.Text.Data).toContain("Love the app");
+		expect(input.Message.Body.Text.Data).toContain("yusuf");
+		expect(input.Message.Body.Text.Data).toContain("user-1");
+	});
+
+	it("omits ReplyToAddresses when no email is given", async () => {
+		send.mockResolvedValueOnce({ MessageId: "msg-2" });
+
+		const result = await invoke(JSON.stringify({ message: "No reply needed" }));
+
+		expect(result.statusCode).toBe(200);
+		expect(send.mock.calls[0][0].input.ReplyToAddresses).toBeUndefined();
+	});
+
+	it("treats an empty-string email as not provided, not invalid", async () => {
+		send.mockResolvedValueOnce({ MessageId: "msg-3" });
+
+		const result = await invoke(
+			JSON.stringify({ message: "Blank email field", email: "" }),
+		);
+
+		expect(result.statusCode).toBe(200);
+		expect(send.mock.calls[0][0].input.ReplyToAddresses).toBeUndefined();
+	});
+
+	it("400s when the request body is missing", async () => {
+		const result = await invoke(undefined);
+
+		expect(result.statusCode).toBe(400);
+		expect(JSON.parse(result.body)).toEqual({
+			success: false,
+			error: "Invalid request body",
+		});
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when the request body is not valid JSON", async () => {
+		const result = await invoke("{oops");
+
+		expect(result.statusCode).toBe(400);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when the request body parses to null", async () => {
+		const result = await invoke("null");
+
+		expect(result.statusCode).toBe(400);
+		expect(JSON.parse(result.body)).toEqual({
+			success: false,
+			error: "Invalid request body",
+		});
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when message is missing", async () => {
+		const result = await invoke(JSON.stringify({ subject: "Hi" }));
+
+		expect(result.statusCode).toBe(400);
+		expect(JSON.parse(result.body)).toEqual({
+			success: false,
+			error: "Missing or invalid field(s): message",
+		});
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when message is over the length cap", async () => {
+		const result = await invoke(
+			JSON.stringify({ message: "a".repeat(5001) }),
+		);
+
+		expect(result.statusCode).toBe(400);
+		expect(JSON.parse(result.body).error).toBe(
+			"message must be 5000 characters or fewer",
+		);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when subject is over the length cap", async () => {
+		const result = await invoke(
+			JSON.stringify({ message: "hi", subject: "a".repeat(201) }),
+		);
+
+		expect(result.statusCode).toBe(400);
+		expect(JSON.parse(result.body).error).toBe(
+			"subject must be 200 characters or fewer",
+		);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("400s when email is malformed", async () => {
+		const result = await invoke(
+			JSON.stringify({ message: "hi", email: "not-an-email" }),
+		);
+
+		expect(result.statusCode).toBe(400);
+		expect(JSON.parse(result.body).error).toBe(
+			"email must be a valid email address",
+		);
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("403s when the caller has no sub", async () => {
+		const result = await invoke(JSON.stringify({ message: "hi" }), {});
+
+		expect(result.statusCode).toBe(403);
+		expect(JSON.parse(result.body)).toEqual({
+			success: false,
+			error: "Forbidden",
+		});
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("500s when the send fails", async () => {
+		send.mockRejectedValueOnce(new Error("MessageRejected"));
+
+		const result = await invoke(JSON.stringify({ message: "hi" }));
+
+		expect(result.statusCode).toBe(500);
+		expect(JSON.parse(result.body)).toEqual({
+			success: false,
+			error: "MessageRejected",
+		});
+	});
+});

--- a/apps/cdk/test/stack/team-builder-api.test.ts
+++ b/apps/cdk/test/stack/team-builder-api.test.ts
@@ -8,6 +8,7 @@ import {
 	DATA_ROUTES,
 	NEWS_ROUTES,
 	CUSTOM_ENTITIES_ROUTES,
+	FEEDBACK_ROUTES,
 } from "../../service/team-builder-stack/team-builder-api-routes";
 
 // Locks in the public/private route split team-builder-api.ts uses to
@@ -35,12 +36,13 @@ describe("team-builder-api-routes", () => {
 		);
 	});
 
-	it("PRIVATE_ROUTES covers files, users, teams, and custom-entities — nothing else", () => {
+	it("PRIVATE_ROUTES covers files, users, teams, custom-entities, and feedback — nothing else", () => {
 		const expectedCount =
 			FILES_ROUTES.length +
 			USERS_ROUTES.length +
 			TEAMS_ROUTES.length +
-			CUSTOM_ENTITIES_ROUTES.length;
+			CUSTOM_ENTITIES_ROUTES.length +
+			FEEDBACK_ROUTES.length;
 		expect(PRIVATE_ROUTES).toHaveLength(expectedCount);
 
 		for (const publicPath of PUBLIC_ROUTE_PATHS) {
@@ -57,10 +59,17 @@ describe("team-builder-api-routes", () => {
 		for (const path of publicPaths) {
 			expect(privatePaths.has(path)).toBe(false);
 		}
-		// 26 routes total: 22 confirmed via cdk synth when the authorizer was
+		// 27 routes total: 22 confirmed via cdk synth when the authorizer was
 		// first wired to every route (commit c1e8738), plus the 4 team
-		// list/get/update/delete routes added alongside createTeam.
-		expect(publicPaths.size + privatePaths.size).toBe(26);
+		// list/get/update/delete routes added alongside createTeam, plus
+		// /api/feedback/send.
+		expect(publicPaths.size + privatePaths.size).toBe(27);
+	});
+
+	it("the feedback route is private", () => {
+		expect(
+			PRIVATE_ROUTES.some((r) => r.route === "/api/feedback/send"),
+		).toBe(true);
 	});
 
 	it("a representative write route (createTeam) is private", () => {


### PR DESCRIPTION
Implements the `sendFeedback` Lambda, which was a verbatim copy-paste of `deleteFile`'s S3-delete handler and unreachable — no route wired it into `team-builder-api-routes.ts`.

## Changes

- **Handler** (`sendFeedback.ts`): full rewrite. Sends via `SendEmailCommand` from the `auth.yusufaf.dev` identity — verified, SES production access, but only in **us-east-1**; the stack itself deploys to us-west-2, which is still SES sandbox. `SESClient` is constructed with an explicit `region` override for that reason.
- **Body parsing**: moved inside the `try` via `parseRequestBody` (`utilities/request-body.ts`), fixing the pre-#52 shape that 502'd on a malformed body instead of 400ing. Only `message` is required; `subject`/`email` are optional with length/format checks.
- **Response shape**: the `ApiResponse` envelope (`{success, data|error}`) used by `createTeam`/custom-entities, not the files lambdas' `{message}` shape — matches what #59's frontend composables will expect.
- **Route**: new `FEEDBACK_ROUTES` array, `POST /api/feedback/send`, spread into `PRIVATE_ROUTES` (behind `apiAuthorizer`).
- **IAM**: a scoped `ses:SendEmail` statement on the shared `main-lambda-role`, targeting only the `auth.yusufaf.dev` identity ARN in us-east-1.
- **Docs**: root `CLAUDE.md` and `apps/cdk/CLAUDE.md` updated — the SES identity, DKIM, MAIL FROM domain and DMARC are all manual (console/API + Porkbun DNS), not IaC, shared with the Logto deployment that also sends from this identity.

## Note on the shared role

Every Lambda uses one IAM role (`createLambdaRoles()`), so this `ses:SendEmail` grant becomes available to all of them, not just `sendFeedback` — inherent to the existing single-role design, not something this PR introduces or fixes.

## Out of scope

- The web feedback form (#59) — separate milestone, explicitly depends on this endpoint.
- Any SES identity for `nba.yusufaf.dev`, a configuration set, or bounce/complaint handling — not needed when the only recipient is the site owner's own inbox.
- No `cdk deploy` was run — `apps/cdk/.env` doesn't exist in the tree; infra deploys are manual, and CI's `cdk synth --quiet` (dummy env) covers synth correctness.

## Testing

- New `test/lambdas/sendFeedback.test.ts` — happy path (with/without email), empty-string email treated as absent (a bug caught by a self-review pass and fixed before this PR), 400s (missing/malformed body, missing/over-length message, over-length subject, malformed email), 403 (no `sub`), 500 (SES rejects).
- `test/stack/team-builder-api.test.ts` updated for the new route (26 → 27 total, private-route coverage sum).
- `pnpm --filter cdk lint` — 0 errors (pre-existing `no-explicit-any` warnings only, tracked by #43).
- `pnpm --filter cdk build` — clean.
- `pnpm --filter cdk test` — 196/196.
- `pnpm -r test` (what `.husky/pre-commit` runs) — cdk 196/196, web 129/129.

Closes #54

https://claude.ai/code/session_01B36sapHap7PpE3e621Mis1