### PR TITLE
Cut LOGTO_ENDPOINT over to auth.yusufaf.dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ first (see apps/cdk/CLAUDE.md).
 
 ### Authentication Flow
 
-Auth is [Logto](https://logto.io) (self-hosted OIDC, `logto-af.fly.dev`) — a
+Auth is [Logto](https://logto.io) (self-hosted OIDC, `auth.yusufaf.dev`) — a
 shared identity provider also used by Quizaroni. No Cognito, no Clerk.
 
 1. Frontend redirects to Logto's hosted sign-in page (`@logto/vue`'s `signIn()`)

--- a/apps/cdk/resources/logto/index.ts
+++ b/apps/cdk/resources/logto/index.ts
@@ -1,14 +1,12 @@
 // Logto endpoint and per-project API resource identifier, by deploymentType.
 // Mirrors resources/cognito/index.ts's shape, which this replaces for auth.
 //
-// endpoint starts pointed at the Fly-provided hostname (logto-flyio isn't
-// cut over to auth.yusufaf.dev yet — see that repo's README). Update both
-// entries to "https://auth.yusufaf.dev" once the DNS cutover lands; nothing
-// else in the authorizer needs to change, since it derives issuer/JWKS URI
-// from this value.
+// Cut over to auth.yusufaf.dev now that logto-flyio's DNS/cert cutover is
+// done; nothing else in the authorizer needs to change, since it derives
+// issuer/JWKS URI from this value.
 export const LOGTO_ENDPOINT: { [key: string]: string } = {
-    development: "https://logto-af.fly.dev",
-    production: "https://logto-af.fly.dev",
+    development: "https://auth.yusufaf.dev",
+    production: "https://auth.yusufaf.dev",
 };
 
 // The API resource identifier created in the Logto console (Authorization >

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,8 +5,8 @@
 VITE_API_BASE_URL=
 
 # Logto SPA app config — from the Logto console (fly proxy 3002:3002 -a
-# logto-af, then http://localhost:3002). See resources/logto/index.ts in
-# team-builder-cdk for the matching backend-side values.
-VITE_LOGTO_ENDPOINT=https://logto-af.fly.dev
+# logto-af, then http://localhost:3002). See apps/cdk/resources/logto/index.ts
+# for the matching backend-side values.
+VITE_LOGTO_ENDPOINT=https://auth.yusufaf.dev
 VITE_LOGTO_APP_ID=
 VITE_LOGTO_API_RESOURCE=https://api.nba.yusufaf.dev


### PR DESCRIPTION
logto-flyio's DNS/cert cutover for `auth.yusufaf.dev` is done (cert Issued). Flips both `LOGTO_ENDPOINT` entries in `apps/cdk/resources/logto/index.ts` from the temporary `logto-af.fly.dev` hostname to the custom domain, per #31. Also fixes two stale `logto-af.fly.dev` / `team-builder-cdk` references (env example, CLAUDE.md) left over from before the monorepo merge.

Needs a real `cdk deploy` from apps/cdk to take effect in AWS — no `.env` in this checkout, so not run as part of this PR.

https://claude.ai/code/session_01Qs6kL6qSgxnV1g244tJrej