### PR TITLE
chore(web): type src/models, src/network, and useTeamPersistence (#43)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -37,9 +37,11 @@ pnpm test:visual     # Playwright screenshots of every route
 
 Two things it deliberately does not fail on:
 
-- `@typescript-eslint/no-explicit-any` is a warning, not an error. 150
-  occurrences predate the gate and each needs a type chosen by hand — see #43.
-  Flip it to `error` once they are gone.
+- `@typescript-eslint/no-explicit-any` is a warning, not an error. 137
+  occurrences remain, each needing a type chosen by hand — see #43.
+  `src/models/`, `src/network/`, and `useTeamPersistence.ts` are already at
+  zero and ratcheted to `error` per-directory in `eslint.config.mjs`; the
+  rest flip the same way as their own slice lands.
 - `vue/multi-word-component-names` is off for `src/components/ui/**` (vendored
   shadcn-vue) and `src/views/**` (route components), where single-word names
   are the convention.

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -29,9 +29,12 @@ export default defineConfigWithVueTs(
   {
     name: "app/rule-tuning",
     rules: {
-      // 150 occurrences here, 116 more in apps/cdk. Each needs a
+      // 137 occurrences here, 155 more in apps/cdk. Each needs a
       // real type chosen by hand, so they are tracked in #43 rather than
       // blocking the lint gate this config finally makes runnable.
+      // src/models/, src/network/, and useTeamPersistence.ts are already at
+      // zero and ratcheted to "error" below - don't undo that by scoping
+      // this rule wider than "warn" default for the rest.
       "@typescript-eslint/no-explicit-any": "warn",
 
       // A leading underscore is how this codebase marks a binding it is
@@ -54,6 +57,18 @@ export default defineConfigWithVueTs(
     name: "app/single-word-component-names",
     files: ["src/components/ui/**/*.vue", "src/views/**/*.vue"],
     rules: { "vue/multi-word-component-names": "off" },
+  },
+
+  {
+    // #43's ratchet: these are at zero, so keep them there. Everything
+    // else stays "warn" until its own slice lands - see app/rule-tuning.
+    name: "app/no-explicit-any-ratchet",
+    files: [
+      "src/models/**/*.ts",
+      "src/network/**/*.ts",
+      "src/composables/useTeamPersistence.ts",
+    ],
+    rules: { "@typescript-eslint/no-explicit-any": "error" },
   },
 
   {

--- a/apps/web/src/components/Scores/ScoreCard.vue
+++ b/apps/web/src/components/Scores/ScoreCard.vue
@@ -36,7 +36,7 @@ const isGameFollowed = computed(() => isFollowed(props.game.uid));
 const fullGameName = computed(() => props.game.name);
 const shortGameName = computed(() => props.game.shortName);
 const gameNameToDisplay = computed(() => {
-    const useShortNames: boolean = props.customizationState.get("shortNames");
+    const useShortNames = props.customizationState.get("shortNames") ?? false;
     const nameToUse = useShortNames ? shortGameName : fullGameName;
     return nameToUse.value.replace('"', "");
 });

--- a/apps/web/src/composables/useTeamPersistence.ts
+++ b/apps/web/src/composables/useTeamPersistence.ts
@@ -1,4 +1,4 @@
-import type { Player } from "@/models/types";
+import type { Arena, Coach, GM, Player } from "@/models/types";
 import type {
     EntityRef,
     PlayerSnapshot,
@@ -15,17 +15,17 @@ interface BuilderState {
     teamCountry: string;
     teamLogo: string;
     teamJersey: string;
-    selectedPlayersData: Map<number, any>;
-    teamCoach: any;
-    teamArena: any;
-    teamGM: any;
+    selectedPlayersData: Map<number, Player>;
+    teamCoach: Coach | null;
+    teamArena: Arena | null;
+    teamGM: GM | null;
 }
 
 // Career stats/rating history are fetched per slot (getPlayerStats) rather
 // than saved on the team - they're derived from the player's id, not part
 // of the roster choice, and re-fetching keeps a saved team from going stale
 // the moment a player's career continues.
-const toSnapshot = (player: any): PlayerSnapshot => {
+const toSnapshot = (player: Player): PlayerSnapshot => {
     const {
         playerStats: _playerStats,
         ratingHistory: _ratingHistory,
@@ -35,16 +35,16 @@ const toSnapshot = (player: any): PlayerSnapshot => {
     return snapshot as PlayerSnapshot;
 };
 
-const toEntityRef = (entity: any): EntityRef | null => {
+const toEntityRef = (entity: Coach | GM | null): EntityRef | null => {
     if (!entity) return null;
     return {
         name: entity.name,
         isCustom: !!entity.isCustom,
-        uuid: entity.coachUUID || entity.gmUUID || entity.playerUUID || undefined,
+        uuid: ("coachUUID" in entity && entity.coachUUID) || ("gmUUID" in entity && entity.gmUUID) || undefined,
     };
 };
 
-const toArenaRef = (arena: any): TeamArenaRef | null => {
+const toArenaRef = (arena: Arena | null): TeamArenaRef | null => {
     if (!arena) return null;
     return { name: arena.name, imgLink: arena.imgLink };
 };

--- a/apps/web/src/models/api.ts
+++ b/apps/web/src/models/api.ts
@@ -59,7 +59,7 @@ export interface DeleteFileResponse {
 // payload and stores everything else in `...userData` as-is, so the index
 // signature genuinely is an open bag - `unknown` rather than a named shape.
 export interface SaveUserDataPayload {
-    userId: string;
+    clerkUserId: string;
     [key: string]: unknown;
 }
 

--- a/apps/web/src/models/api.ts
+++ b/apps/web/src/models/api.ts
@@ -53,6 +53,22 @@ export interface DeleteFileResponse {
 }
 // #endregion
 
+//#region Users API Types
+
+// The saveUserData Lambda's own body only destructures `clerkUserId` off the
+// payload and stores everything else in `...userData` as-is, so the index
+// signature genuinely is an open bag - `unknown` rather than a named shape.
+export interface SaveUserDataPayload {
+    userId: string;
+    [key: string]: unknown;
+}
+
+export interface SaveUserDataResponse {
+    message: string;
+    userData: Record<string, unknown>;
+}
+// #endregion
+
 //#region Team API Types
 
 // A player as stored on a saved team - the same `Player` union already used

--- a/apps/web/src/models/types.ts
+++ b/apps/web/src/models/types.ts
@@ -3,19 +3,9 @@ export type CustomizationKey =
     | "hideScores"
     | "hideFinishedGames";
 
-export type CustomizationState = Map<CustomizationKey, any>;
+export type CustomizationState = Map<CustomizationKey, boolean>;
 
 export type DrawerSide = "left" | "right";
-
-export type Team = {
-    uuid: string;
-    name: string;
-    description: string;
-    players: any;
-    logo?: string;
-    city?: string;
-    country?: string;
-};
 
 export type Coach = {
     championships: number;
@@ -134,6 +124,11 @@ export type Player = {
     rating?: number;
     ratingSource?: RatingSource;
     ratingHistory?: NBA2KRating[];
+    // Populated when a roster slot's full career stats are fetched
+    // (TeamBuilder.vue's getPlayerStats) - not part of the roster choice
+    // itself, so useTeamPersistence's toSnapshot drops it again before save.
+    playerStats?: unknown[];
+    heightAndWeight?: string;
     // Custom player fields (camelCase)
     isCustom?: boolean;
     playerUUID?: string;
@@ -402,7 +397,11 @@ export type ESPNCompetition = {
     recent: boolean;
     venue: ESPNVenue;
     competitors: ESPNCompetitor[];
-    notes: any[];
+    // Not read anywhere in this repo today; ESPN's actual shape is
+    // `{ type: string; headline: string }[]`, but typing it without a live
+    // payload to confirm would be inventing an interface, so `unknown[]`
+    // is the honest placeholder until something needs it.
+    notes: unknown[];
     status: ESPNStatus;
     broadcasts?: ESPNBroadcast[];
     format: ESPNFormat;

--- a/apps/web/src/network/api.ts
+++ b/apps/web/src/network/api.ts
@@ -8,6 +8,8 @@ import type {
     GetMultipartSignedUrlsResponse,
     DeleteFilePayload,
     DeleteFileResponse,
+    SaveUserDataPayload,
+    SaveUserDataResponse,
     SaveTeamPayload,
     UpdateTeamPayload,
     CreateTeamResponse,
@@ -89,10 +91,9 @@ export const fileApi = {
 
 // Users API - matches USERS_ROUTES in CDK
 export const userApi = {
-    saveUserData: async (payload: {
-        userId: string;
-        [key: string]: any;
-    }): Promise<any> => {
+    saveUserData: async (
+        payload: SaveUserDataPayload,
+    ): Promise<SaveUserDataResponse> => {
         const response = await api.post('/api/users/save-data', payload);
         return response.data;
     },


### PR DESCRIPTION
## Summary

First slice of #43. Types the highest-value bucket the issue names —
`src/network/` + `src/models/` — folded together with `useTeamPersistence.ts`
since that's where the untyped values in `models/types.ts` actually enter and
leave the app, and the target types (`PlayerSnapshot`, `EntityRef`,
`TeamArenaRef`) are already defined in its own signatures. 12 sites total.

- `CustomizationState`'s value type → `boolean`, matching how `ScoreCard.vue`
  actually reads it. This surfaced a real bug the `any` was masking:
  `Map.get()` returns `V | undefined`, so `ScoreCard.vue`'s
  `const useShortNames: boolean = ...get("shortNames")` was unsound — fixed
  with `?? false`.
- Dropped the unused `Team` type (`players: any`) — nothing imports it; the
  real saved-team shape is `SavedTeam` in `models/api.ts`.
- `ESPNCompetition.notes` → `unknown[]`. Nothing in the repo reads it, so
  `unknown` is the honest placeholder rather than inventing an interface for
  a field that's never consumed.
- Added `playerStats`/`heightAndWeight` to `Player` — the augmented shape
  `TeamBuilder.vue` actually builds for a roster slot (career stats fetched
  per-slot, plus a display string), needed so `toSnapshot`'s rest-sibling
  destructure type-checks.
- `userApi.saveUserData`: typed payload/response against what the
  `saveUserData` Lambda actually reads (`clerkUserId` destructured off,
  everything else passed through — so the payload index signature stays an
  open `unknown` bag on purpose) and returns.
- `useTeamPersistence`'s `to*Ref` helpers now take `Player`/`Coach | GM`/`Arena`
  instead of `any`, matching what `TeamBuilder.vue` actually binds to
  `teamCoach`/`teamArena`/`teamGM`.

Ratchets `@typescript-eslint/no-explicit-any` to `error` for
`src/models/**`, `src/network/**`, and `useTeamPersistence.ts` in
`eslint.config.mjs`, in the same `{name, files, rules}` idiom already used
for `vue/multi-word-component-names`. Corrected both files' stale any-count
comments — real counts on `origin/main` were 149 (web) / 155 (cdk), not the
150/116 the config comments claimed.

Also posted the corrected counts as a comment on #43, since the issue body's
266 and its own comment's 289 are both stale, and its `src/stores/` slice is
empty (the 17 store-related violations live in `apps/web/tests/stores/`, a
sibling of `src/`, unmatched by any `src/stores/**` glob).

`apps/cdk/utilities/` (6 sites, `team-validation.ts` +
`custom-entities-validation.ts` — textbook `unknown` + type-predicate
narrowing) is the obvious next slice, left out here to keep this PR to one
package.

## Verification

- `pnpm --filter web lint` — 0 errors, 137 warnings (down from 149)
- `pnpm --filter web type-check`
- `pnpm --filter web test` — 129 passed
- `pnpm --filter web check:styles` — 147 files, no problems
- `pnpm --filter web build`
- Manually added a stray `any` to `src/models/types.ts` and confirmed
  `pnpm --filter web lint` fails (1 error) — the ratchet is live, not
  decorative — then reverted it.
- Pre-commit hook (`type-check`, `check:styles`, `pnpm -r test`) passed on
  commit, including `apps/cdk`'s 196 tests (untouched by this PR).

Closes nothing on its own — #43 stays open for the remaining slices.
