### PR TITLE
ci(deploy): add workflow_dispatch as a manual fallback trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,11 @@
 name: deploy
 
+# workflow_dispatch exists for when a push to main doesn't trigger this
+# workflow - GitHub occasionally drops a push event's Actions trigger
+# entirely (no run of any kind, not even ci.yml, which has no path filter -
+# confirmed happened for 43ef6d15). There is no way to "re-run" a workflow
+# that never ran, so the fallback is to trigger it manually for the commit
+# that should have deployed.
 on:
   push:
     branches: [main]
@@ -8,6 +14,7 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".github/workflows/deploy.yml"
+  workflow_dispatch:
 
 permissions:
   id-token: write # required for aws-actions/configure-aws-credentials OIDC


### PR DESCRIPTION
## Summary

Investigating why the jersey drawing feature (#87, merged as `43ef6d15`)
wasn't showing up on https://nba.yusufaf.dev/teambuilder: that commit never
triggered **any** GitHub Actions run. Confirmed via the API —
`GET /commits/43ef6d15/check-runs` returns `total_count: 0`, and
`GET /commits/43ef6d15/status` returns `state: pending` with `total_count: 0`.

That's not `deploy.yml`'s path filter excluding it (the PR touched
`apps/web/src/**`, well inside the filter) and it's not `ci.yml` either,
which has no path filter at all and still didn't run. Actions are enabled
repo-wide and every workflow is `active`. This looks like a one-off dropped
push-event delivery on GitHub's side — rare, but with nothing in the repo
to blame and nothing to "re-run" since no run was ever created.

`deploy.yml` had no `workflow_dispatch` trigger, so there was no manual
fallback when this happened. This PR adds one.

## Verification

Infra-only change (one `on:` trigger added to a workflow file, no app code
touched) - no build/test/lint impact. YAML structure checked by hand.

Once merged, I'll also manually run `workflow_dispatch` for `main`'s current
HEAD to actually push the jersey drawing feature live, in case this push
also fails to auto-trigger.
