### PR TITLE
feat(web): let jersey drawing take any color, not just five swatches

### DIFF
--- a/apps/web/src/components/TeamBuilder/JerseyDrawingCanvas.vue
+++ b/apps/web/src/components/TeamBuilder/JerseyDrawingCanvas.vue
@@ -260,6 +260,7 @@ const startOver = () => {
                     :class="{ selected: isCustomColor }"
                     :value="strokeColor"
                     aria-label="Custom color"
+                    :aria-current="isCustomColor"
                     title="Custom color"
                     @input="strokeColor = ($event.target as HTMLInputElement).value"
                 />

--- a/apps/web/src/components/TeamBuilder/JerseyDrawingCanvas.vue
+++ b/apps/web/src/components/TeamBuilder/JerseyDrawingCanvas.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { Eraser, Undo2 } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -22,17 +22,20 @@ const CANVAS_HEIGHT = 1253;
 // drawing, not a normal one.
 const MAX_JERSEY_DATA_URL_BYTES = 200 * 1024;
 
-// Literal HSL, not `hsl(var(--primary))` - Canvas2D's strokeStyle/fillStyle
+// Literal hex, not `hsl(var(--primary))` - Canvas2D's strokeStyle/fillStyle
 // parses its own value directly and does not resolve CSS custom properties,
 // so a var() assignment is silently ignored and the ink stays whatever
-// color was last validly set. "Team orange" mirrors --primary's current
-// value (35 100% 50%, see DESIGN.md) as a plain literal for that reason.
+// color was last validly set. Hex specifically (not hsl()) because the
+// custom-color control below is a native <input type="color">, which only
+// accepts and emits #rrggbb - keeping every entry in that same format means
+// strokeColor never needs a conversion step. "Team orange" mirrors
+// --primary's current value (35 100% 50%, see DESIGN.md) converted to hex.
 const STROKE_COLORS = [
-    { label: "White", value: "hsl(0 0% 100%)" },
-    { label: "Black", value: "hsl(0 0% 0%)" },
-    { label: "Team orange", value: "hsl(35 100% 50%)" },
-    { label: "Sky blue", value: "hsl(205 90% 55%)" },
-    { label: "Crimson", value: "hsl(355 75% 50%)" },
+    { label: "White", value: "#ffffff" },
+    { label: "Black", value: "#000000" },
+    { label: "Team orange", value: "#ff9500" },
+    { label: "Sky blue", value: "#259df4" },
+    { label: "Crimson", value: "#df2030" },
 ];
 
 const WIDTH_OPTIONS = [
@@ -98,6 +101,8 @@ watch(selectedWidthOption, (value) => {
     const option = WIDTH_OPTIONS.find((candidate) => candidate.value === value);
     if (option) strokeWidth.value = option.width;
 });
+
+const isCustomColor = computed(() => !STROKE_COLORS.some((swatch) => swatch.value === strokeColor.value));
 
 const redraw = () => {
     const canvas = canvasEl.value;
@@ -249,6 +254,15 @@ const startOver = () => {
                     :aria-pressed="strokeColor === swatch.value"
                     @click="strokeColor = swatch.value"
                 />
+                <input
+                    type="color"
+                    class="jersey-swatch jersey-swatch-custom"
+                    :class="{ selected: isCustomColor }"
+                    :value="strokeColor"
+                    aria-label="Custom color"
+                    title="Custom color"
+                    @input="strokeColor = ($event.target as HTMLInputElement).value"
+                />
             </div>
 
             <ToggleGroup
@@ -364,6 +378,27 @@ const startOver = () => {
 .jersey-swatch.selected {
     border-color: hsl(var(--primary));
     box-shadow: 0 0 0 0.125rem hsl(var(--primary) / 0.3);
+}
+
+.jersey-swatch-custom {
+    appearance: none;
+    padding: 0;
+    background: none;
+    cursor: pointer;
+}
+
+.jersey-swatch-custom::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+.jersey-swatch-custom::-webkit-color-swatch {
+    border: none;
+    border-radius: 9999px;
+}
+
+.jersey-swatch-custom::-moz-color-swatch {
+    border: none;
+    border-radius: 9999px;
 }
 
 .jersey-width-item {

--- a/apps/web/src/composables/useJerseyDrawing.ts
+++ b/apps/web/src/composables/useJerseyDrawing.ts
@@ -18,7 +18,7 @@ export interface CanvasRect {
     height: number;
 }
 
-export const DEFAULT_STROKE_COLOR = "hsl(0 0% 100%)";
+export const DEFAULT_STROKE_COLOR = "#ffffff";
 export const DEFAULT_STROKE_WIDTH = 6;
 
 /**

--- a/apps/web/tests/components/JerseyDrawingCanvas.test.ts
+++ b/apps/web/tests/components/JerseyDrawingCanvas.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import JerseyDrawingCanvas from "@/components/TeamBuilder/JerseyDrawingCanvas.vue";
+
+// jsdom has no Canvas2D context and no setPointerCapture, so these assertions
+// stay DOM-only - the swatch/custom-input wiring, not stroke rendering.
+const mountCanvas = () =>
+    mount(JerseyDrawingCanvas, {
+        props: {
+            teamJersey: "",
+            "onUpdate:teamJersey": () => {},
+        },
+        attachTo: document.body,
+    });
+
+const swatchButtons = (wrapper: ReturnType<typeof mountCanvas>) =>
+    wrapper.findAll(".jersey-swatch:not(.jersey-swatch-custom)");
+
+const customInput = (wrapper: ReturnType<typeof mountCanvas>) =>
+    wrapper.get<HTMLInputElement>(".jersey-swatch-custom");
+
+describe("JerseyDrawingCanvas stroke color", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("starts on the White preset, with the custom input matching it", () => {
+        const wrapper = mountCanvas();
+
+        const selected = swatchButtons(wrapper).filter((btn) => btn.classes("selected"));
+        expect(selected).toHaveLength(1);
+        expect(selected[0].attributes("aria-label")).toBe("White");
+        expect(customInput(wrapper).element.value).toBe("#ffffff");
+        expect(customInput(wrapper).classes("selected")).toBe(false);
+
+        wrapper.unmount();
+    });
+
+    it("clicking a preset moves the ring to it and syncs the custom input", async () => {
+        const wrapper = mountCanvas();
+
+        const crimson = swatchButtons(wrapper).find(
+            (btn) => btn.attributes("aria-label") === "Crimson",
+        );
+        await crimson?.trigger("click");
+
+        expect(crimson?.classes("selected")).toBe(true);
+        expect(customInput(wrapper).element.value).toBe("#df2030");
+        expect(customInput(wrapper).classes("selected")).toBe(false);
+        expect(swatchButtons(wrapper).filter((btn) => btn.classes("selected"))).toHaveLength(1);
+
+        wrapper.unmount();
+    });
+
+    it("picking an off-palette color deselects every preset and selects the custom control", async () => {
+        const wrapper = mountCanvas();
+
+        const input = customInput(wrapper);
+        input.element.value = "#123456";
+        await input.trigger("input");
+
+        expect(swatchButtons(wrapper).some((btn) => btn.classes("selected"))).toBe(false);
+        expect(input.classes("selected")).toBe(true);
+
+        wrapper.unmount();
+    });
+});

--- a/apps/web/tests/composables/useJerseyDrawing.test.ts
+++ b/apps/web/tests/composables/useJerseyDrawing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clientToCanvasPoint, useJerseyDrawing } from "@/composables/useJerseyDrawing";
+import { clientToCanvasPoint, DEFAULT_STROKE_COLOR, useJerseyDrawing } from "@/composables/useJerseyDrawing";
 
 describe("clientToCanvasPoint", () => {
     it("maps 1:1 when the canvas is displayed at its native resolution", () => {
@@ -28,16 +28,20 @@ describe("useJerseyDrawing", () => {
         expect(canUndo.value).toBe(false);
     });
 
+    it("defaults to a literal hex color, not a token an <input type=\"color\"> can't parse", () => {
+        expect(DEFAULT_STROKE_COLOR).toMatch(/^#[0-9a-f]{6}$/);
+    });
+
     it("begins a stroke with the current color and width", () => {
         const { strokes, strokeColor, strokeWidth, beginStroke, isEmpty } = useJerseyDrawing();
-        strokeColor.value = "hsl(0 0% 0%)";
+        strokeColor.value = "#000000";
         strokeWidth.value = 8;
 
         beginStroke({ x: 1, y: 2 });
 
         expect(isEmpty.value).toBe(false);
         expect(strokes.value).toEqual([
-            { points: [{ x: 1, y: 2 }], color: "hsl(0 0% 0%)", width: 8 },
+            { points: [{ x: 1, y: 2 }], color: "#000000", width: 8 },
         ]);
     });
 


### PR DESCRIPTION
## Summary
Adds a native `<input type="color">` to the jersey drawing toolbar's stroke-color row so any color is reachable, alongside the existing five presets.

## Why
Closes #89. `JerseyDrawingCanvas.vue`'s stroke color picker (#87) was limited to 5 fixed swatches with no way to pick an arbitrary color.

## Changes
- `useJerseyDrawing.ts`: `DEFAULT_STROKE_COLOR` switched from `hsl(0 0% 100%)` to `#ffffff`.
- `JerseyDrawingCanvas.vue`: `STROKE_COLORS` presets switched to hex literals (computed from the same HSL values, not restyled); added a 6th round control — an `<input type="color">` styled to match the existing swatches — bound directly to `strokeColor`; `isCustomColor` computed drives its selection ring the same way the presets already work.

Presets moved to hex (not just the new control) because `<input type="color">` only accepts/emits `#rrggbb` — keeping one format means `strokeColor` never needs a conversion step, and both forms are equally canvas-safe (Canvas2D can't resolve `var()` either way, which is why these were literals to begin with — see #87/#89's note).

## Testing
- `pnpm --filter web type-check`, `check:styles`, `lint`, `test` (144 tests, incl. 3 new component tests + 1 new composable assertion), `test:visual` (24 passed, no baseline diff) — all pass.
- Manual pass in the dev server via Playwright MCP: opened Team Customization → Draw your own, confirmed the custom control renders at the default color with White ringed, clicking presets moves the ring and syncs the custom input, and — critically — setting the custom input to an off-palette color and drawing a stroke produced that exact pixel color on the canvas (read back via `getImageData`, matched exactly).

Closes #89

https://claude.ai/code/session_01K2zYwdJeAbjonncAH7BVab